### PR TITLE
feat: added toast after add to wallet

### DIFF
--- a/shared/components/token-to-wallet/token-to-wallet.tsx
+++ b/shared/components/token-to-wallet/token-to-wallet.tsx
@@ -1,4 +1,4 @@
-import { Tooltip } from '@lidofinance/lido-ui';
+import { ToastInfo, Tooltip } from '@lidofinance/lido-ui';
 import { useTokenToWallet } from '@lido-sdk/react';
 import { TokenToWalletStyle } from './styles';
 
@@ -12,9 +12,16 @@ export const TokenToWallet: TokenToWalletComponent = (props) => {
 
   if (!addToken) return null;
 
+  const onClickHandler = async () => {
+    const result = await addToken();
+    if (!result) return;
+
+    ToastInfo('Tokens were successfully added to your wallet', {});
+  };
+
   return (
     <Tooltip placement="bottomLeft" title="Add tokens to wallet">
-      <TokenToWalletStyle tabIndex={-1} onClick={addToken} {...rest} />
+      <TokenToWalletStyle tabIndex={-1} onClick={onClickHandler} {...rest} />
     </Tooltip>
   );
 };


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

Added toast with success message after tokens were added into the wallet.

### Demo

<img width="727" alt="image" src="https://github.com/lidofinance/ethereum-staking-widget/assets/13162370/bfd9df08-e72e-4afc-b58d-40f77dfe1c4f">

### Testing notes

- click on Add to Wallet button
- then agree in Wallet
- then you see a new toast with a message

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
