### PR TITLE
feat: switch to our own getFeeData

### DIFF
--- a/features/home/stake-form/hooks.ts
+++ b/features/home/stake-form/hooks.ts
@@ -1,15 +1,11 @@
 import { AddressZero } from '@ethersproject/constants';
 import { useLidoSWR, useSTETHContractRPC } from '@lido-sdk/react';
-import {
-  ESTIMATE_ACCOUNT,
-  getBackendRPCPath,
-  STETH_SUBMIT_GAS_LIMIT_DEFAULT,
-} from 'config';
+import { ESTIMATE_ACCOUNT, STETH_SUBMIT_GAS_LIMIT_DEFAULT } from 'config';
 import { parseEther } from '@ethersproject/units';
 import { useWeb3 } from 'reef-knot/web3-react';
-import { getStaticRpcBatchProvider } from 'utils/rpcProviders';
 import { BigNumber } from 'ethers';
-import { CHAINS } from 'utils/chains';
+import { getFeeData } from 'utils/getFeeData';
+import { CHAINS } from '@lido-sdk/constants';
 
 type UseStethSubmitGasLimit = () => number | undefined;
 
@@ -24,13 +20,7 @@ export const useStethSubmitGasLimit: UseStethSubmitGasLimit = () => {
         return;
       }
 
-      const provider = getStaticRpcBatchProvider(
-        chainId as string,
-        // TODO: add a way to type useWeb3 hook
-        getBackendRPCPath(chainId as CHAINS),
-      );
-
-      const feeData = await provider.getFeeData();
+      const feeData = await getFeeData(chainId as CHAINS);
       const maxPriorityFeePerGas = feeData.maxPriorityFeePerGas ?? undefined;
       const maxFeePerGas = feeData.maxFeePerGas ?? undefined;
 

--- a/features/withdrawals/hooks/contract/useRequest.ts
+++ b/features/withdrawals/hooks/contract/useRequest.ts
@@ -23,6 +23,7 @@ import { useWithdrawals } from 'features/withdrawals/contexts/withdrawals-contex
 
 import { useWithdrawalsContract } from './useWithdrawalsContract';
 import { useApprove } from 'shared/hooks/useApprove';
+import { getFeeData } from 'utils/getFeeData';
 import { Zero } from '@ethersproject/constants';
 import { TokensWithdrawable } from 'features/withdrawals/types/tokens-withdrawable';
 
@@ -58,7 +59,7 @@ const useWithdrawalRequestMethods = () => {
         },
       ] as const;
 
-      const feeData = await contractWeb3.provider.getFeeData();
+      const feeData = await getFeeData(chainId);
       const maxFeePerGas = feeData.maxFeePerGas ?? undefined;
       const maxPriorityFeePerGas = feeData.maxPriorityFeePerGas ?? undefined;
       const gasLimit =
@@ -114,7 +115,7 @@ const useWithdrawalRequestMethods = () => {
         },
       ] as const;
 
-      const feeData = await contractWeb3.provider.getFeeData();
+      const feeData = await getFeeData(chainId);
       const maxFeePerGas = feeData.maxFeePerGas ?? undefined;
       const maxPriorityFeePerGas = feeData.maxPriorityFeePerGas ?? undefined;
       const gasLimit =
@@ -169,7 +170,7 @@ const useWithdrawalRequestMethods = () => {
           );
           return providerWeb3?.getSigner().sendUncheckedTransaction(tx);
         } else {
-          const feeData = await contractWeb3.provider.getFeeData();
+          const feeData = await getFeeData(chainId);
           const maxFeePerGas = feeData.maxFeePerGas ?? undefined;
           const maxPriorityFeePerGas =
             feeData.maxPriorityFeePerGas ?? undefined;
@@ -224,7 +225,7 @@ const useWithdrawalRequestMethods = () => {
             );
           return providerWeb3?.getSigner().sendUncheckedTransaction(tx);
         } else {
-          const feeData = await contractWeb3.provider.getFeeData();
+          const feeData = await getFeeData(chainId);
           const maxFeePerGas = feeData.maxFeePerGas ?? undefined;
           const maxPriorityFeePerGas =
             feeData.maxPriorityFeePerGas ?? undefined;

--- a/features/wrap/features/unwrap-form/hooks.ts
+++ b/features/wrap/features/unwrap-form/hooks.ts
@@ -1,9 +1,10 @@
 import { parseEther } from '@ethersproject/units';
-import { getStaticRpcBatchProvider } from 'utils/rpcProviders';
 import { useLidoSWR, useWSTETHContractRPC } from '@lido-sdk/react';
 import { useWeb3 } from 'reef-knot/web3-react';
-import { ESTIMATE_ACCOUNT, getBackendRPCPath, UNWRAP_GAS_LIMIT } from 'config';
+import { ESTIMATE_ACCOUNT, UNWRAP_GAS_LIMIT } from 'config';
 import { BigNumber } from 'ethers';
+import { getFeeData } from 'utils/getFeeData';
+import { CHAINS } from '@lido-sdk/constants';
 
 export const useUnwrapGasLimit = () => {
   const wsteth = useWSTETHContractRPC();
@@ -16,13 +17,7 @@ export const useUnwrapGasLimit = () => {
         return;
       }
 
-      const provider = getStaticRpcBatchProvider(
-        // TODO: add a way to type useWeb3 hook
-        chainId as number,
-        getBackendRPCPath(chainId as number),
-      );
-
-      const feeData = await provider.getFeeData();
+      const feeData = await getFeeData(chainId as CHAINS);
       const maxPriorityFeePerGas = feeData.maxPriorityFeePerGas ?? undefined;
       const maxFeePerGas = feeData.maxFeePerGas ?? undefined;
 

--- a/features/wrap/features/wrap-form/hooks.tsx
+++ b/features/wrap/features/wrap-form/hooks.tsx
@@ -1,5 +1,5 @@
 import { parseEther } from '@ethersproject/units';
-import { CHAINS } from '@lido-sdk/constants';
+
 import { getStaticRpcBatchProvider } from '@lido-sdk/providers';
 import {
   useLidoSWR,
@@ -17,6 +17,7 @@ import {
 } from 'config';
 import { BigNumber } from 'ethers';
 import { STRATEGY_IMMUTABLE } from 'utils/swrStrategies';
+import { CHAINS } from '@lido-sdk/constants';
 
 export const useApproveGasLimit = () => {
   const steth = useSTETHContractRPC();
@@ -63,18 +64,12 @@ export const useWrapGasLimit = (fromEther: boolean) => {
         getBackendRPCPath(chainId as CHAINS),
       );
 
-      const feeData = await provider.getFeeData();
-      const maxPriorityFeePerGas = feeData.maxPriorityFeePerGas ?? undefined;
-      const maxFeePerGas = feeData.maxFeePerGas ?? undefined;
-
       if (fromEther) {
         const gasLimit = await provider
           .estimateGas({
             from: ESTIMATE_ACCOUNT,
             to: wsteth.address,
             value: parseEther('0.001'),
-            maxPriorityFeePerGas,
-            maxFeePerGas,
           })
           .catch((error) => {
             console.warn(error);
@@ -86,8 +81,6 @@ export const useWrapGasLimit = (fromEther: boolean) => {
         const gasLimit = await wsteth.estimateGas
           .wrap(parseEther('0.0001'), {
             from: ESTIMATE_ACCOUNT,
-            maxPriorityFeePerGas,
-            maxFeePerGas,
           })
           .catch((error) => {
             console.warn(error);

--- a/pages/api/rpc.ts
+++ b/pages/api/rpc.ts
@@ -24,6 +24,7 @@ const rpc = rpcFactory({
     'eth_getCode',
     'eth_estimateGas',
     'eth_getBlockByNumber',
+    'eth_feeHistory',
     'eth_getBalance',
     'eth_blockNumber',
     'eth_getTransactionByHash',

--- a/shared/components/token-to-wallet/token-to-wallet.tsx
+++ b/shared/components/token-to-wallet/token-to-wallet.tsx
@@ -1,4 +1,4 @@
-import { ToastInfo, Tooltip } from '@lidofinance/lido-ui';
+import { Tooltip } from '@lidofinance/lido-ui';
 import { useTokenToWallet } from '@lido-sdk/react';
 import { TokenToWalletStyle } from './styles';
 
@@ -12,16 +12,9 @@ export const TokenToWallet: TokenToWalletComponent = (props) => {
 
   if (!addToken) return null;
 
-  const onClickHandler = async () => {
-    const result = await addToken();
-    if (!result) return;
-
-    ToastInfo('Tokens were successfully added to your wallet', {});
-  };
-
   return (
     <Tooltip placement="bottomLeft" title="Add tokens to wallet">
-      <TokenToWalletStyle tabIndex={-1} onClick={onClickHandler} {...rest} />
+      <TokenToWalletStyle tabIndex={-1} onClick={addToken} {...rest} />
     </Tooltip>
   );
 };

--- a/shared/hooks/useApprove.ts
+++ b/shared/hooks/useApprove.ts
@@ -6,6 +6,8 @@ import { getERC20Contract } from '@lido-sdk/contracts';
 import { Zero } from '@ethersproject/constants';
 import { useAllowance, useMountedState, useSDK } from '@lido-sdk/react';
 import { isContract } from 'utils/isContract';
+import { getFeeData } from 'utils/getFeeData';
+import { CHAINS } from '@lido-sdk/constants';
 
 type TransactionCallback = () => Promise<ContractTransaction | string>;
 
@@ -37,7 +39,7 @@ export const useApprove = (
   owner?: string,
   wrapper: UseApproveWrapper = defaultWrapper,
 ): UseApproveResponse => {
-  const { providerWeb3, account } = useSDK();
+  const { providerWeb3, account, chainId } = useSDK();
   const mergedOwner = owner ?? account;
 
   invariant(token != null, 'Token is required');
@@ -58,6 +60,7 @@ export const useApprove = (
     try {
       setApproving(true);
       invariant(providerWeb3 != null, 'Web3 provider is required');
+      invariant(chainId, 'chain id is required');
       invariant(account, 'account is required');
       const contractWeb3 = getERC20Contract(token, providerWeb3.getSigner());
       const isMultisig = await isContract(account, providerWeb3);
@@ -72,9 +75,9 @@ export const useApprove = (
             .sendUncheckedTransaction(tx);
           return hash;
         } else {
-          const feeData = await providerWeb3
-            .getFeeData()
-            .catch((error) => console.warn(error));
+          const feeData = await getFeeData(chainId as CHAINS).catch((error) =>
+            console.warn(error),
+          );
           const maxPriorityFeePerGas =
             feeData?.maxPriorityFeePerGas ?? undefined;
           const maxFeePerGas = feeData?.maxFeePerGas ?? undefined;
@@ -90,10 +93,11 @@ export const useApprove = (
       setApproving(false);
     }
   }, [
-    providerWeb3,
-    token,
     setApproving,
+    providerWeb3,
+    chainId,
     account,
+    token,
     wrapper,
     updateAllowance,
     spender,

--- a/shared/hooks/useMaxGasPrice.ts
+++ b/shared/hooks/useMaxGasPrice.ts
@@ -1,30 +1,25 @@
-import { CHAINS } from '@lido-sdk/constants';
-import { getStaticRpcBatchProvider } from '@lido-sdk/providers';
 import { useLidoSWR, useSDK } from '@lido-sdk/react';
-import { getBackendRPCPath, ONE_GWEI } from 'config';
+import { ONE_GWEI } from 'config';
 
 import { BigNumber } from 'ethers';
+import invariant from 'tiny-invariant';
+import { getFeeData } from 'utils/getFeeData';
 
-// TODO: rewrite to use our own getFeeData
-// provider.getFeeData() has very cranky placeholder implementation in ethers.js
-// that has bad defaults and overprices txs
-// source:
-// https://github.com/ethers-io/ethers.js/blob/9373864742c179ba69c08c4f0c0661fdf78f8f63/src.ts/providers/abstract-provider.ts#L704
-//
 export const useMaxGasPrice = (): BigNumber | undefined => {
   const { chainId } = useSDK();
   const { data: maxGasPrice } = useLidoSWR(
     ['swr:max-gas-price', chainId],
     async () => {
       try {
-        const provider = getStaticRpcBatchProvider(
-          chainId as CHAINS,
-          getBackendRPCPath(chainId as CHAINS),
-        );
-        const feeData = await provider.getFeeData();
-        const maxGasPrice = feeData.maxFeePerGas;
-        if (maxGasPrice) return maxGasPrice;
-        return await provider.getGasPrice();
+        const feeData = await getFeeData(chainId);
+
+        if (feeData.maxFeePerGas) {
+          return feeData.maxFeePerGas;
+        }
+        if (feeData.gasPrice) {
+          return feeData.gasPrice;
+        }
+        invariant(false, 'must have some gas data');
       } catch (e) {
         console.error(e);
       }

--- a/types/subgraph.ts
+++ b/types/subgraph.ts
@@ -1,3 +1,3 @@
 import { CHAINS } from 'utils/chains';
 
-export type SubgraphChains = Extract<CHAINS, CHAINS.Mainnet | CHAINS.Goerli>;
+export type SubgraphChains = CHAINS;

--- a/utils/getFeeData.ts
+++ b/utils/getFeeData.ts
@@ -1,0 +1,59 @@
+import { BigNumber } from 'ethers';
+import { CHAINS } from '@lido-sdk/constants';
+import { getStaticRpcBatchProvider } from '@lido-sdk/providers';
+import { getBackendRPCPath } from 'config';
+import { StaticJsonRpcBatchProvider } from '@lidofinance/eth-providers';
+
+type FeeData = {
+  lastBaseFeePerGas: null | BigNumber;
+  maxFeePerGas: null | BigNumber;
+  maxPriorityFeePerGas: null | BigNumber;
+  gasPrice: null | BigNumber;
+};
+
+const getFeeHistory = (
+  provider: StaticJsonRpcBatchProvider,
+  blockCount: number,
+  latestBlock: string,
+  percentile: number[],
+) => {
+  return provider.send('eth_feeHistory', [
+    blockCount.toString(16),
+    latestBlock,
+    percentile,
+  ]) as Promise<{
+    baseFeePerGas: string[];
+    gasUsedRatio: number[];
+    oldestBlock: string;
+    reward: string[][];
+  }>;
+};
+
+export const getFeeData = async (chainId: CHAINS): Promise<FeeData> => {
+  const provider = getStaticRpcBatchProvider(
+    chainId,
+    getBackendRPCPath(chainId),
+  );
+
+  // we look back 5 blocks at fees of botton 25% txs
+  // if you want to increase maxPriorityFee output increase percentile
+  const feeHistory = await getFeeHistory(provider, 5, 'pending', [25]);
+
+  // get average priority fee
+  const maxPriorityFeePerGas = feeHistory.reward
+    .map((fees) => BigNumber.from(fees[0]))
+    .reduce((sum, fee) => sum.add(fee))
+    .div(feeHistory.reward.length);
+
+  const lastBaseFeePerGas = BigNumber.from(feeHistory.baseFeePerGas[0]);
+
+  // we have to multiply by 2 until we find a reliable way to predict baseFee change
+  const maxFeePerGas = lastBaseFeePerGas.mul(2).add(maxPriorityFeePerGas);
+
+  return {
+    lastBaseFeePerGas,
+    maxPriorityFeePerGas,
+    maxFeePerGas,
+    gasPrice: maxFeePerGas, // fallback
+  };
+};


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

Rewrote `getFeeData` to have same interface but with alternative implementation. Updated all use cases.


### Testing notes

- This should fix gross overestimation for gas price. It's slightly bigger than MM `aggressive` gas price. 
- This changes gasFee estimation for all txs in the widget. Unfortunately this affects a lot of functionality, but at least per-wallet recheck is not needed apart from single sanity check for MM/ledger/gnosis on 1 sample tx. 
- What should not happen: MM receives TX but says it will fail/will stall/not enough gas price/etc.
- What i'd like to be noted and crosschecked between this stand and develop is the difference between tx cost estimation in both widget UI(`max tx cost`) and MM UI(`site suggested gas price`) and MM's aggressive fees. This will provide us a helpful insight into how we should calculate fees.       

### Checklist:

- [x] Checked the changes locally.

