### PR TITLE
Device locked error

### DIFF
--- a/utils/getErrorMessage.ts
+++ b/utils/getErrorMessage.ts
@@ -4,6 +4,7 @@ export enum ErrorMessage {
   SOMETHING_WRONG = 'Something went wrong.',
   ENABLE_BLIND_SIGNING = 'Please enable blind signing on your Ledger hardware wallet.',
   LIMIT_REACHED = 'Transaction could not be completed because stake limit is exhausted. Please wait until the stake limit restores and try again. Otherwise, you can swap your Ethereum on 1inch platform instantly.',
+  DEVICE_LOCKED = 'Please unlock your Ledger hardware wallet',
 }
 
 export const getErrorMessage = (error: unknown): ErrorMessage => {
@@ -27,6 +28,8 @@ export const getErrorMessage = (error: unknown): ErrorMessage => {
       return ErrorMessage.LIMIT_REACHED;
     case 'ENABLE_BLIND_SIGNING':
       return ErrorMessage.ENABLE_BLIND_SIGNING;
+    case 'DEVICE_LOCKED':
+      return ErrorMessage.DEVICE_LOCKED;
     default:
       return ErrorMessage.SOMETHING_WRONG;
   }
@@ -73,8 +76,12 @@ export const extractCodeFromError = (
   }
 
   if ('name' in error && typeof error.name == 'string') {
-    if (error.name.toLocaleLowerCase() === 'ethapppleaseenablecontractdata')
+    const error_name = error.name.toLowerCase();
+    if (error_name === 'EthAppPleaseEnableContractData'.toLowerCase())
       return 'ENABLE_BLIND_SIGNING';
+    if (error_name === 'LockedDeviceError'.toLowerCase()) {
+      return 'DEVICE_LOCKED';
+    }
   }
   if ('code' in error) {
     if (typeof error.code === 'string') return error.code.toUpperCase();


### PR DESCRIPTION
### Description

Added error for locked ledger.

### Demo
![telegram-cloud-photo-size-2-5371082901636106902-y](https://github.com/lidofinance/staking-widget-ts/assets/3705803/6c056ede-a3f6-43b8-a127-64699822bdeb)

### Code review notes

Improved code a bit for ledger cases.

### Testing notes

For ledger live error is displayed by them. Also for ledger you can hold two buttons to go control center and lock device manually.

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
