### PR TITLE
feat: add wallet metrics for Phantom, BitKeep

### DIFF
--- a/config/matomoWalletsEvents.ts
+++ b/config/matomoWalletsEvents.ts
@@ -240,25 +240,25 @@ export const MATOMO_WALLETS_EVENTS: Record<
     'Connect OKX wallet',
     'eth_widget_connect_okx',
   ],
+  [MATOMO_WALLETS_EVENTS_TYPES.onClickPhantom]: [
+    'Ethereum_Staking_Widget',
+    'Click Phantom wallet',
+    'eth_widget_click_phantom',
+  ],
   [MATOMO_WALLETS_EVENTS_TYPES.onConnectPhantom]: [
     'Ethereum_Staking_Widget',
     'Connect Phantom wallet',
     'eth_widget_connect_phantom',
   ],
-  [MATOMO_WALLETS_EVENTS_TYPES.onClickPhantom]: [
+  [MATOMO_WALLETS_EVENTS_TYPES.onClickBitkeep]: [
     'Ethereum_Staking_Widget',
-    'Connect Phantom wallet',
-    'eth_widget_click_phantom',
+    'Click BitKeep wallet',
+    'eth_widget_click_bitkeep',
   ],
   [MATOMO_WALLETS_EVENTS_TYPES.onConnectBitkeep]: [
     'Ethereum_Staking_Widget',
     'Connect BitKeep wallet',
     'eth_widget_connect_bitkeep',
-  ],
-  [MATOMO_WALLETS_EVENTS_TYPES.onClickBitkeep]: [
-    'Ethereum_Staking_Widget',
-    'Connect BitKeep wallet',
-    'eth_widget_click_bitkeep',
   ],
 };
 


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

Adds matomo metric events for Phantom and BitKeep wallets.

### Testing notes

Event codes are:
- eth_widget_click_phantom
- eth_widget_connect_phantom
- eth_widget_click_bitkeep
- eth_widget_connect_bitkeep

### Checklist:

- [ ] Checked the changes locally.
- [x] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [x] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
