### PR TITLE
reef-knot 1.7.2 (Fix connection rejection logic during mobile browser autoconnect)

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "react-hook-form": "^7.45.2",
     "react-is": "^17.0.2",
     "react-transition-group": "^4.4.2",
-    "reef-knot": "^1.7.1",
+    "reef-knot": "^1.7.2",
     "remark": "^13.0.0",
     "remark-external-links": "^8.0.0",
     "remark-html": "^13.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2881,10 +2881,10 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.21.tgz#5de5a2385a35309427f6011992b544514d559aa1"
   integrity sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==
 
-"@reef-knot/connect-wallet-modal@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@reef-knot/connect-wallet-modal/-/connect-wallet-modal-1.6.1.tgz#20c237435d9428aa7998ee4cae7ea74ceb0a29d2"
-  integrity sha512-Gsiok+cqecuqDzuJC09qH+UkSs45QdDjOXNP1PZyrerd5eoPSq/fBPWAQ5z7Bj1rUv9lAImR7DCB3ryP+6Afog==
+"@reef-knot/connect-wallet-modal@1.6.2":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@reef-knot/connect-wallet-modal/-/connect-wallet-modal-1.6.2.tgz#de6f8c8eb344929b165cb150fdc22dfbf12fd78a"
+  integrity sha512-kDJEw85j6cikoh9i5yIfQQl5seQGyUiDJWUvLUT24FPn/gsUM/5cimx/mWP+1yzxhU2ru+/vUIQjMmt4UVpTaQ==
   dependencies:
     "@types/react" "17.0.53"
     "@types/react-dom" "17"
@@ -3003,10 +3003,10 @@
     "@reef-knot/wallet-adapter-zengo" "1.2.4"
     "@reef-knot/wallet-adapter-zerion" "1.2.4"
 
-"@reef-knot/web3-react@1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@reef-knot/web3-react/-/web3-react-1.4.1.tgz#a2c62a83e03196e643939ff9d755b3958aba4052"
-  integrity sha512-7wEP38yryxv7Y49beMmtHSo25piuRP75OKfRns6iiJCFxquIlK+qHF3OIlooHMKjvaeOP4YrYm0M22BHsjSvvw==
+"@reef-knot/web3-react@1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@reef-knot/web3-react/-/web3-react-1.4.2.tgz#1baac5af69e1139011d9fc0b3411d9b288f46d5f"
+  integrity sha512-707D5K3GxCts44ThhbpEExp0CMMD6h6bL2IFj2JX9SoDTPBZA/ixzbRggqTpZlqGEPsoo/72xGKl8nVsBB3JQg==
   dependencies:
     "@gnosis.pm/safe-apps-web3-react" "0.6.8"
     "@ledgerhq/iframe-provider" "0.4.2"
@@ -9348,12 +9348,12 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
-reef-knot@^1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/reef-knot/-/reef-knot-1.7.1.tgz#c11e0aa9aa196104254981edccc02fb3c1edff6c"
-  integrity sha512-sW6HdX+qxs/AqdTvLHxqh304CnfcU2Fku0/bzn7/cIIZdLZOV5VvOtJbRHRwtKPHielqk+WOjjz7V3SEbXnwkg==
+reef-knot@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/reef-knot/-/reef-knot-1.7.2.tgz#e6db358645c320956d5566e099c1a635471768ef"
+  integrity sha512-WgaBeN6Hw85nSXubw/UYULNk97ZnT66H/k2oDO5PflufWjUp3kRwL69Rhhbboeq9e6ZL7DlPWoC3LkLMceBUVw==
   dependencies:
-    "@reef-knot/connect-wallet-modal" "1.6.1"
+    "@reef-knot/connect-wallet-modal" "1.6.2"
     "@reef-knot/core-react" "1.5.1"
     "@reef-knot/ledger-connector" "1.0.1"
     "@reef-knot/types" "1.3.0"
@@ -9361,7 +9361,7 @@ reef-knot@^1.7.1:
     "@reef-knot/wallets-helpers" "1.1.5"
     "@reef-knot/wallets-icons" "1.0.0"
     "@reef-knot/wallets-list" "1.4.4"
-    "@reef-knot/web3-react" "1.4.1"
+    "@reef-knot/web3-react" "1.4.2"
 
 regenerate-unicode-properties@^10.1.0:
   version "10.1.0"


### PR DESCRIPTION
### Description
Related:
- https://github.com/lidofinance/ethereum-staking-widget/pull/8
- https://github.com/lidofinance/reef-knot/pull/72
- https://github.com/lidofinance/reef-knot/pull/83

The issue was found during QA session: if a user rejects the connection via wallet's UI, then the Terms modal window still closes. So the wallet is not connected, and it becomes possible to open the common Wallet Connection Modal with a list of all wallets, which is not expected behavior.
This PR fixes the issue.

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
