### PR TITLE
Update UI kit types on staking widget

### DIFF
--- a/features/rewards/components/rewardsTable/RewardsTable.tsx
+++ b/features/rewards/components/rewardsTable/RewardsTable.tsx
@@ -43,7 +43,7 @@ export const RewardsTable: FC<RewardsTableProps> = (props) => {
         pagesCount={pageCount}
         onItemClick={(currentPage: number) => setPage(currentPage - 1)}
         activePage={page + 1}
-        siblingCount={4}
+        siblingCount={0}
       />
     </>
   );

--- a/features/withdrawals/claim/form/requests-list/request-item.tsx
+++ b/features/withdrawals/claim/form/requests-list/request-item.tsx
@@ -2,7 +2,7 @@ import { forwardRef } from 'react';
 import { useWeb3 } from 'reef-knot/web3-react';
 import { useFormState, useWatch } from 'react-hook-form';
 
-import { Checkbox, External } from '@lidofinance/lido-ui';
+import { Checkbox, CheckboxProps, External } from '@lidofinance/lido-ui';
 import { FormatToken } from 'shared/formatters';
 
 import { RequestStatus } from './request-item-status';
@@ -15,7 +15,7 @@ type RequestItemProps = {
   token_id: string;
   name: `requests.${number}.checked`;
   index: number;
-} & React.ComponentProps<'input'>;
+} & CheckboxProps;
 
 export const RequestItem = forwardRef<HTMLInputElement, RequestItemProps>(
   ({ token_id, name, disabled, index, ...props }, ref) => {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@lidofinance/api-rpc": "^0.28.0",
     "@lidofinance/eth-api-providers": "^0.28.0",
     "@lidofinance/eth-providers": "^0.28.0",
-    "@lidofinance/lido-ui": "^3.8.1",
+    "@lidofinance/lido-ui": "^3.12.0",
     "@lidofinance/lido-ui-blocks": "2.10.2",
     "@lidofinance/next-api-wrapper": "^0.28.0",
     "@lidofinance/next-ip-rate-limit": "^0.28.0",

--- a/shared/hook-form/controls/token-select-hook-form.tsx
+++ b/shared/hook-form/controls/token-select-hook-form.tsx
@@ -52,7 +52,7 @@ export const TokenSelectHookForm = ({
       icon={iconsMap[field.value]}
       data-testid="drop-down"
       error={isValidationErrorTypeValidate(errors[errorField]?.type)}
-      onChange={(value: TOKENS) => {
+      onChange={(value) => {
         setValue(fieldName, value, {
           shouldDirty: false,
           shouldTouch: false,
@@ -64,7 +64,7 @@ export const TokenSelectHookForm = ({
           shouldValidate: false,
         });
         clearErrors(resetField);
-        onChange?.(value);
+        onChange?.(value as TOKENS);
       }}
     >
       {options.map(({ label, token }) => (

--- a/yarn.lock
+++ b/yarn.lock
@@ -2602,10 +2602,10 @@
   dependencies:
     "@lidofinance/blocks-connect-wallet-modal" "2.11.2"
 
-"@lidofinance/lido-ui@^3.8.1":
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/@lidofinance/lido-ui/-/lido-ui-3.8.1.tgz#21af8db3e27d12f08d032fcbedf00ea8904f9199"
-  integrity sha512-RalApHbilFGOePeRtRrcokMUQyH/YDcWu8njlZizNPxEDLJxMW8Y7i/rWtO05UESjEyvto2azTCDuPVuIhZHCw==
+"@lidofinance/lido-ui@^3.12.0":
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/@lidofinance/lido-ui/-/lido-ui-3.12.0.tgz#b53fcfc752adecd5fb3cf89d42ed17da085080de"
+  integrity sha512-COCnfqKpj0hrnY3BxCaZRbS7cRaUuI0lotrMC6jS5QVlsxcp1dJzDWzPzrFnO+7s+y7TFikMA5JRfQTVJowJHg==
   dependencies:
     "@styled-system/should-forward-prop" "5.1.5"
     "@swc/helpers" "^0.4.11"


### PR DESCRIPTION
### Description

- Updated UI kit, now it exports proper types
- Fixed bug with rewards table

Before:
<img width="1014" alt="image" src="https://github.com/lidofinance/ethereum-staking-widget/assets/19698566/5373bba4-d403-469c-afdd-22217e4a17b1">

After:
<img width="1076" alt="image" src="https://github.com/lidofinance/ethereum-staking-widget/assets/19698566/f46a84d1-c5d1-4c77-a985-d0545d9eddd6">


### Testing notes

No visual or functional changes are expected, the only difference is reward table padding

### Checklist:

- [x] Checked the changes locally.