### PR TITLE
refactor: faq text (What is wsteth?) on wrap page

### DIFF
--- a/features/wsteth/shared/wrap-faq/list/what-is-wsteth.tsx
+++ b/features/wsteth/shared/wrap-faq/list/what-is-wsteth.tsx
@@ -5,10 +5,12 @@ export const WhatIsWsteth: FC = () => {
   return (
     <Accordion defaultExpanded summary="What is wstETH?">
       <p>
-        wstETH (wrapped stETH) is a non-rebasing version of stETH. Unlike the
-        stETH balance, which updates every day and communicates your share of
-        rewards, the wstETH balance stays the same while the stETH balance
-        updates inside the wrapper daily.
+        wstETH (wrapped stETH) is a non-rebasing version of stETH, wstETH&apos;s
+        price denominated in stETH changes instead. The wstETH balance can only
+        be changed upon transfers, minting, and burning. At any given time,
+        anyone holding wstETH can convert any amount of it to stETH at a fixed
+        rate, and vice versa. Normally, the rate gets updated once a day, when
+        stETH undergoes a rebase.
       </p>
     </Accordion>
   );


### PR DESCRIPTION
### Description

Changed text in FAQ section `What is wstETH?` on `wrap` page.

### Testing notes

Check just text in FAQ section `What is wstETH?` on `wrap` page.

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
