### PR TITLE
reef-knot 1.7.4 (add holesky wagmi chain, bitkeep wallet => bitget)

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "react-hook-form": "^7.45.2",
     "react-is": "^17.0.2",
     "react-transition-group": "^4.4.2",
-    "reef-knot": "^1.7.2",
+    "reef-knot": "^1.7.4",
     "remark": "^13.0.0",
     "remark-external-links": "^8.0.0",
     "remark-html": "^13.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2884,10 +2884,10 @@
     "@types/react" "17.0.53"
     "@types/react-dom" "17"
 
-"@reef-knot/core-react@1.5.1":
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/@reef-knot/core-react/-/core-react-1.5.1.tgz#2715b4da8525ed5adecc37b50f8ed2367e3f14a4"
-  integrity sha512-c+dVmw8pBPYdjpD7NU54XwQalwyOkR7csT/ke9dAIEKfbbIw4J6O3FIj1w+kKM+npI9Ji0SbmAmQuFs8VqvRJA==
+"@reef-knot/core-react@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@reef-knot/core-react/-/core-react-1.6.0.tgz#92ea1794b80a2b57c713e6f88b184acb82ad6718"
+  integrity sha512-Mi50svDMpRqoAcOqSQ9z71WufKJkDaos814n3aiVlNBBqkYS+F7J28/Ks8R0FYqEtcp/4cp2+3CRzX0bkEqPLQ==
 
 "@reef-knot/ledger-connector@1.0.1":
   version "1.0.1"
@@ -2927,10 +2927,10 @@
   resolved "https://registry.yarnpkg.com/@reef-knot/wallet-adapter-ambire/-/wallet-adapter-ambire-1.2.4.tgz#8a436a575b1f7cf5eebe5a9a0311e1cccdcfd4b3"
   integrity sha512-ZnVEYbQbsMFlyLIOAC8wGFdFlux0p7y3sdSgvBWbhoupDZaxUGNLXNHHauJ9mt1C1nLNhM9RpY8q4BBVKOD24g==
 
-"@reef-knot/wallet-adapter-bitkeep@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@reef-knot/wallet-adapter-bitkeep/-/wallet-adapter-bitkeep-1.0.1.tgz#5ef77196d269c73ebe08dcaabfee68cb2834ab76"
-  integrity sha512-xulFR1lLgWkz0svyP8gXTctYP7+SgmG3FuuB1VSrgmKwFS7+j12EwceUDeMOwgbz7LC1vzqgdN3WMj3mwjPLcw==
+"@reef-knot/wallet-adapter-bitkeep@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@reef-knot/wallet-adapter-bitkeep/-/wallet-adapter-bitkeep-1.1.0.tgz#fe430c838b76b9304527ae62a19dd7a126afb72b"
+  integrity sha512-GjVt1rGXVXCh5vUIAg0vxf9IpNJTiVC6jJxAbu8g1C4mWrLhi0eRkeQzNmO8Zk220b+OoiEIpNJDrF6+ycTRpw==
 
 "@reef-knot/wallet-adapter-blockchaincom@1.2.4":
   version "1.2.4"
@@ -2982,13 +2982,13 @@
   resolved "https://registry.yarnpkg.com/@reef-knot/wallets-icons/-/wallets-icons-1.0.0.tgz#14db791e78309f8a53d4a8a08e561d67a6757d93"
   integrity sha512-x3Numm/rRHbHLrMzZpD6dGb+b5F+ZdBdYe+0xZyqw3qPmS/K4M0Hh9sGWgw66iVhHOyiYWdmtVWpyg2mbg52Zg==
 
-"@reef-knot/wallets-list@1.4.4":
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/@reef-knot/wallets-list/-/wallets-list-1.4.4.tgz#2373ce815204d7ec3e7acd4e8d6bdef16c71cf4d"
-  integrity sha512-w9D9e9cd4NqhjyfaXHJ6wNWTxgBt72xwUbfrx9RjwDNU1r5NL5jIBCQsTlGh20u1LxZScWoMQ3T5Fy8CjFlvXg==
+"@reef-knot/wallets-list@1.4.5":
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/@reef-knot/wallets-list/-/wallets-list-1.4.5.tgz#65fb447cf950583d444b6abc7e6ac1c412a59a88"
+  integrity sha512-PdZHN5XfDImhBO6/crWxLu3bVu3sf5Mh44x4WPUDw9bC9lbBPgXsawyg6l9LdP3Zm6GW8O6x3xcLcVWR1LEUsA==
   dependencies:
     "@reef-knot/wallet-adapter-ambire" "1.2.4"
-    "@reef-knot/wallet-adapter-bitkeep" "1.0.1"
+    "@reef-knot/wallet-adapter-bitkeep" "1.1.0"
     "@reef-knot/wallet-adapter-blockchaincom" "1.2.4"
     "@reef-knot/wallet-adapter-exodus" "1.2.3"
     "@reef-knot/wallet-adapter-okx" "1.3.0"
@@ -9338,19 +9338,19 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
-reef-knot@^1.7.2:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/reef-knot/-/reef-knot-1.7.2.tgz#e6db358645c320956d5566e099c1a635471768ef"
-  integrity sha512-WgaBeN6Hw85nSXubw/UYULNk97ZnT66H/k2oDO5PflufWjUp3kRwL69Rhhbboeq9e6ZL7DlPWoC3LkLMceBUVw==
+reef-knot@^1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/reef-knot/-/reef-knot-1.7.4.tgz#94cad3e7e6c2a633df7a32f92e306dcca14b8834"
+  integrity sha512-tsmOtB3y04GzT/qNLQSvh/yXEQeEMyjQyfDLiMz1BvRJUYh3clBpo6kK64XS3ZSPOlT1I6aLpw3dGyp5dTtzaw==
   dependencies:
     "@reef-knot/connect-wallet-modal" "1.6.2"
-    "@reef-knot/core-react" "1.5.1"
+    "@reef-knot/core-react" "1.6.0"
     "@reef-knot/ledger-connector" "1.0.1"
     "@reef-knot/types" "1.3.0"
     "@reef-knot/ui-react" "1.0.7"
     "@reef-knot/wallets-helpers" "1.1.5"
     "@reef-knot/wallets-icons" "1.0.0"
-    "@reef-knot/wallets-list" "1.4.4"
+    "@reef-knot/wallets-list" "1.4.5"
     "@reef-knot/web3-react" "1.4.2"
 
 regenerate-unicode-properties@^10.1.0:


### PR DESCRIPTION
### Description
Adds:
1. Ability to import Holesky chain definition for wagmi setup. https://github.com/lidofinance/reef-knot/pull/86
The definition is taken from here: https://github.com/wagmi-dev/viem/blob/main/src/chains/definitions/holesky.ts Additional setup will be done in a separate PR.
2. Update for BitKeep wallet: it was renamed to Bitget and changed their logo. https://github.com/lidofinance/reef-knot/pull/87
We want to reflect this changes in the nearest release.

### Testing notes

Only BitKeep => Bitget renaming and a new logo should be checked. Holesky will be tested later and separately.

### Checklist:

- [ ] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
