### PR TITLE
Add widget remount on wallet change

### DIFF
--- a/features/wsteth/shared/form-controller/form-controller.tsx
+++ b/features/wsteth/shared/form-controller/form-controller.tsx
@@ -1,11 +1,11 @@
-import { FC, PropsWithChildren, useCallback, useEffect, useMemo } from 'react';
+import { FC, PropsWithChildren, useEffect, useMemo } from 'react';
 import { useWeb3 } from 'reef-knot/web3-react';
-import { useFormContext } from 'react-hook-form';
+import { UseFormReset, useFormContext } from 'react-hook-form';
 import { useTransactionModal } from 'shared/transaction-modal';
 import { useFormControllerContext } from './form-controller-context';
 
 type FormControllerProps = {
-  reset?: () => void;
+  reset?: UseFormReset<Record<string, any>>;
 };
 
 export const FormController: FC<PropsWithChildren<FormControllerProps>> = ({
@@ -17,13 +17,7 @@ export const FormController: FC<PropsWithChildren<FormControllerProps>> = ({
   const { onSubmit } = useFormControllerContext();
   const { dispatchModalState } = useTransactionModal();
 
-  const reset = useCallback(() => {
-    if (resetProp) {
-      resetProp();
-    } else {
-      resetDefault();
-    }
-  }, [resetDefault, resetProp]);
+  const reset = resetProp ?? resetDefault;
 
   // Bind submit action
   const doSubmit = useMemo(
@@ -43,7 +37,10 @@ export const FormController: FC<PropsWithChildren<FormControllerProps>> = ({
   // Reset form amount after disconnect wallet
   useEffect(() => {
     if (!active) reset();
-  }, [active, reset]);
+    // reset will be captured when active changes
+    // so we don't need it in deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active]);
 
   return (
     <form autoComplete="off" onSubmit={doSubmit}>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,9 +3,11 @@ import Head from 'next/head';
 import { Wallet, StakeForm, LidoStats, StakeFaq } from 'features/home';
 import { Layout } from 'shared/components';
 import NoSSRWrapper from '../shared/components/no-ssr-wrapper';
+import { useWeb3Key } from 'shared/hooks/useWeb3Key';
 
-const Home: FC = () => (
-  <>
+const Home: FC = () => {
+  const key = useWeb3Key();
+  return (
     <Layout
       title="Stake Ether"
       subtitle="Stake ETH and receive stETH while staking."
@@ -15,13 +17,13 @@ const Home: FC = () => (
       </Head>
 
       <NoSSRWrapper>
-        <Wallet />
-        <StakeForm />
+        <Wallet key={'wallet' + key} />
+        <StakeForm key={'form' + key} />
       </NoSSRWrapper>
       <LidoStats />
       <StakeFaq />
     </Layout>
-  </>
-);
+  );
+};
 
 export default Home;

--- a/pages/withdrawals/[mode].tsx
+++ b/pages/withdrawals/[mode].tsx
@@ -1,16 +1,16 @@
 import { FC } from 'react';
 import { GetStaticPaths, GetStaticProps } from 'next';
 import Head from 'next/head';
-import { useWeb3 } from 'reef-knot/web3-react';
 
 import { Layout } from 'shared/components';
 import NoSSRWrapper from 'shared/components/no-ssr-wrapper';
 
 import { WithdrawalsTabs } from 'features/withdrawals';
 import { WithdrawalsProvider } from 'features/withdrawals/contexts/withdrawals-context';
+import { useWeb3Key } from 'shared/hooks/useWeb3Key';
 
 const Withdrawals: FC<WithdrawalsModePageParams> = ({ mode }) => {
-  const { account, chainId } = useWeb3();
+  const key = useWeb3Key();
 
   return (
     <Layout
@@ -22,8 +22,7 @@ const Withdrawals: FC<WithdrawalsModePageParams> = ({ mode }) => {
       </Head>
       <WithdrawalsProvider mode={mode}>
         <NoSSRWrapper>
-          {/* In order to simplify side effects of switching wallets we remount the whole widget, resetting all internal state */}
-          <WithdrawalsTabs key={`${account ?? '_'}${chainId ?? '1'}`} />
+          <WithdrawalsTabs key={key} />
         </NoSSRWrapper>
       </WithdrawalsProvider>
     </Layout>

--- a/pages/wrap/[[...mode]].tsx
+++ b/pages/wrap/[[...mode]].tsx
@@ -3,8 +3,10 @@ import { GetStaticPaths, GetStaticProps } from 'next';
 import Head from 'next/head';
 import { Layout } from 'shared/components';
 import { WrapUnwrapTabs } from 'features/wsteth/wrap-unwrap-tabs';
+import { useWeb3Key } from 'shared/hooks/useWeb3Key';
 
 const WrapPage: FC<WrapModePageProps> = ({ mode }) => {
+  const key = useWeb3Key();
   return (
     <Layout
       title="Wrap & Unwrap"
@@ -13,8 +15,7 @@ const WrapPage: FC<WrapModePageProps> = ({ mode }) => {
       <Head>
         <title>Wrap | Lido</title>
       </Head>
-
-      <WrapUnwrapTabs mode={mode}></WrapUnwrapTabs>
+      <WrapUnwrapTabs mode={mode} key={key}></WrapUnwrapTabs>
     </Layout>
   );
 };

--- a/shared/components/footer/footer.tsx
+++ b/shared/components/footer/footer.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import { version, branch } from 'build-info.json';
+import buildInfo from 'build-info.json';
 
 import {
   FooterStyle,
@@ -11,6 +11,7 @@ import {
 } from './styles';
 
 const getVersionInfo = () => {
+  const { version, branch } = buildInfo;
   const repoBaseUrl = 'https://github.com/lidofinance/ethereum-staking-widget';
   if (version === 'REPLACE_WITH_VERSION')
     return {

--- a/shared/components/footer/footer.tsx
+++ b/shared/components/footer/footer.tsx
@@ -22,6 +22,12 @@ const getVersionInfo = () => {
       label: 'preview',
       link: `${repoBaseUrl}/tree/${branch}`,
     };
+  if (version === 'staging' || version === 'dev') {
+    return {
+      label: version,
+      link: `${repoBaseUrl}/tree/${branch}`,
+    };
+  }
   return {
     label: `v${version}`,
     link: `${repoBaseUrl}/releases/tag/${version}`,

--- a/shared/hooks/useWeb3Key.ts
+++ b/shared/hooks/useWeb3Key.ts
@@ -1,0 +1,9 @@
+import { dynamics } from 'config';
+import { useWeb3 } from 'reef-knot/web3-react';
+
+// In order to simplify side effects of switching wallets/chains
+// we can remount by this key, resetting all internal states
+export const useWeb3Key = () => {
+  const { account, chainId } = useWeb3();
+  return `${account ?? 'NO_ACCOUNT'}_${chainId ?? dynamics.defaultChain}`;
+};

--- a/utils/getErrorMessage.ts
+++ b/utils/getErrorMessage.ts
@@ -49,7 +49,6 @@ export const extractCodeFromError = (
     error.reason.includes('STAKE_LIMIT')
   ) {
     return 'LIMIT_REACHED';
-    // TODO: error.reason more cases
   }
 
   // sometimes we have error message but bad error code
@@ -61,7 +60,8 @@ export const extractCodeFromError = (
       normalizedMessage.includes('rejected the transaction') ||
       normalizedMessage.includes('rejected the request') ||
       normalizedMessage.includes('reject this request') ||
-      normalizedMessage.includes('rejected methods')
+      normalizedMessage.includes('rejected methods') ||
+      normalizedMessage.includes('transaction declined')
     )
       return 'ACTION_REJECTED';
   }


### PR DESCRIPTION
### Description

- now stake,wrap and withdrawal pages remount completely if chain or address changes, eliminating disconnect edge cases 
- added case for ledger live + wc transaction reject
- added footer version case for develop and staging environments 

### Checklist:

- [x] Checked the changes locally.

