### PR TITLE
feat(stats block): hide by line, if all of them NA - hide the stats block

### DIFF
--- a/features/home/lido-stats/lido-stats.tsx
+++ b/features/home/lido-stats/lido-stats.tsx
@@ -59,42 +59,56 @@ export const LidoStats: FC = memo(() => {
     >
       <Block>
         <DataTable>
-          <DataTableRow
-            title={
-              <FlexCenterVertical data-testid="aprTooltip">
-                Annual percentage rate
-                <Tooltip title={LIDO_APR_TOOLTIP_TEXT}>
-                  <Question />
-                </Tooltip>
-              </FlexCenterVertical>
-            }
-            loading={lidoApr.initialLoading}
-            data-testid="lidoAPR"
-            highlight
-          >
-            {lidoApr.apr ? `${lidoApr.apr}%` : DATA_UNAVAILABLE}
-          </DataTableRow>
-          <DataTableRow
-            title="Total staked with Lido"
-            data-testid="totalStaked"
-            loading={lidoStats.initialLoading}
-          >
-            {lidoStats.data.totalStaked}
-          </DataTableRow>
-          <DataTableRow
-            title="Stakers"
-            data-testid="stakers"
-            loading={lidoStats.initialLoading}
-          >
-            {lidoStats.data.stakers}
-          </DataTableRow>
-          <DataTableRow
-            title="stETH market cap"
-            data-testid="stEthMarketCap"
-            loading={lidoStats.initialLoading}
-          >
-            {lidoStats.data.marketCap}
-          </DataTableRow>
+          {dynamics.ipfsMode && !isStatItemNotAvailable(lidoApr.apr) && (
+            <DataTableRow
+              title={
+                <FlexCenterVertical data-testid="aprTooltip">
+                  Annual percentage rate
+                  <Tooltip title={LIDO_APR_TOOLTIP_TEXT}>
+                    <Question />
+                  </Tooltip>
+                </FlexCenterVertical>
+              }
+              loading={lidoApr.initialLoading}
+              data-testid="lidoAPR"
+              highlight
+            >
+              {lidoApr.apr ? `${lidoApr.apr}%` : DATA_UNAVAILABLE}
+            </DataTableRow>
+          )}
+
+          {dynamics.ipfsMode &&
+            !isStatItemNotAvailable(lidoStats.data.totalStaked) && (
+              <DataTableRow
+                title="Total staked with Lido"
+                data-testid="totalStaked"
+                loading={lidoStats.initialLoading}
+              >
+                {lidoStats.data.totalStaked}
+              </DataTableRow>
+            )}
+
+          {dynamics.ipfsMode &&
+            !isStatItemNotAvailable(lidoStats.data.stakers) && (
+              <DataTableRow
+                title="Stakers"
+                data-testid="stakers"
+                loading={lidoStats.initialLoading}
+              >
+                {lidoStats.data.stakers}
+              </DataTableRow>
+            )}
+
+          {dynamics.ipfsMode &&
+            !isStatItemNotAvailable(lidoStats.data.marketCap) && (
+              <DataTableRow
+                title="stETH market cap"
+                data-testid="stEthMarketCap"
+                loading={lidoStats.initialLoading}
+              >
+                {lidoStats.data.marketCap}
+              </DataTableRow>
+            )}
         </DataTable>
       </Block>
     </Section>

--- a/features/home/lido-stats/lido-stats.tsx
+++ b/features/home/lido-stats/lido-stats.tsx
@@ -31,16 +31,24 @@ export const LidoStats: FC = memo(() => {
       getTokenAddress(chainId, TOKENS.STETH),
     );
   }, [chainId]);
+
   const lidoApr = useLidoApr();
   const lidoStats = useLidoStats();
 
-  if (
-    dynamics.ipfsMode &&
-    isStatItemNotAvailable(lidoApr.apr) &&
-    isStatItemNotAvailable(lidoStats.data.totalStaked) &&
-    isStatItemNotAvailable(lidoStats.data.stakers) &&
-    isStatItemNotAvailable(lidoStats.data.marketCap)
-  ) {
+  const showApr =
+    !dynamics.ipfsMode ||
+    (dynamics.ipfsMode && !isStatItemNotAvailable(lidoApr.apr));
+  const showTotalStaked =
+    !dynamics.ipfsMode ||
+    (dynamics.ipfsMode && !isStatItemNotAvailable(lidoStats.data.totalStaked));
+  const showStakers =
+    !dynamics.ipfsMode ||
+    (dynamics.ipfsMode && !isStatItemNotAvailable(lidoStats.data.stakers));
+  const showMarketCap =
+    !dynamics.ipfsMode ||
+    (dynamics.ipfsMode && !isStatItemNotAvailable(lidoStats.data.marketCap));
+
+  if (!showApr && !showTotalStaked && !showStakers && !showMarketCap) {
     return null;
   }
 
@@ -59,7 +67,7 @@ export const LidoStats: FC = memo(() => {
     >
       <Block>
         <DataTable>
-          {dynamics.ipfsMode && !isStatItemNotAvailable(lidoApr.apr) && (
+          {showApr && (
             <DataTableRow
               title={
                 <FlexCenterVertical data-testid="aprTooltip">
@@ -77,38 +85,35 @@ export const LidoStats: FC = memo(() => {
             </DataTableRow>
           )}
 
-          {dynamics.ipfsMode &&
-            !isStatItemNotAvailable(lidoStats.data.totalStaked) && (
-              <DataTableRow
-                title="Total staked with Lido"
-                data-testid="totalStaked"
-                loading={lidoStats.initialLoading}
-              >
-                {lidoStats.data.totalStaked}
-              </DataTableRow>
-            )}
+          {showTotalStaked && (
+            <DataTableRow
+              title="Total staked with Lido"
+              data-testid="totalStaked"
+              loading={lidoStats.initialLoading}
+            >
+              {lidoStats.data.totalStaked}
+            </DataTableRow>
+          )}
 
-          {dynamics.ipfsMode &&
-            !isStatItemNotAvailable(lidoStats.data.stakers) && (
-              <DataTableRow
-                title="Stakers"
-                data-testid="stakers"
-                loading={lidoStats.initialLoading}
-              >
-                {lidoStats.data.stakers}
-              </DataTableRow>
-            )}
+          {showStakers && (
+            <DataTableRow
+              title="Stakers"
+              data-testid="stakers"
+              loading={lidoStats.initialLoading}
+            >
+              {lidoStats.data.stakers}
+            </DataTableRow>
+          )}
 
-          {dynamics.ipfsMode &&
-            !isStatItemNotAvailable(lidoStats.data.marketCap) && (
-              <DataTableRow
-                title="stETH market cap"
-                data-testid="stEthMarketCap"
-                loading={lidoStats.initialLoading}
-              >
-                {lidoStats.data.marketCap}
-              </DataTableRow>
-            )}
+          {showMarketCap && (
+            <DataTableRow
+              title="stETH market cap"
+              data-testid="stEthMarketCap"
+              loading={lidoStats.initialLoading}
+            >
+              {lidoStats.data.marketCap}
+            </DataTableRow>
+          )}
         </DataTable>
       </Block>
     </Section>


### PR DESCRIPTION
### Description

Hide stats block by line, if all of them NA - hide the stats block.

<img width="529" alt="image" src="https://github.com/lidofinance/ethereum-staking-widget/assets/9885789/86604604-b0b9-4ab2-b8f7-472e6f14e229">


### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
