### PR TITLE
feat: set cors (origin: *) for /api/short-lido-stats

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -145,8 +145,8 @@ export default withBundleAnalyzer({
         headers: [{ key: 'Access-Control-Allow-Origin', value: '*' }],
       },
       {
-        // oneinch-rate is public (firstly for IPFS version)
-        source: '/api/oneinch-rate',
+        // is public (firstly for IPFS version)
+        source: '/api/short-lido-stats',
         headers: [
           { key: 'Access-Control-Allow-Origin', value: '*' },
           { key: 'Access-Control-Allow-Methods', value: 'GET' }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -144,6 +144,14 @@ export default withBundleAnalyzer({
         source: '/manifest.json',
         headers: [{ key: 'Access-Control-Allow-Origin', value: '*' }],
       },
+      {
+        // oneinch-rate is public (firstly for IPFS version)
+        source: '/api/oneinch-rate',
+        headers: [
+          { key: 'Access-Control-Allow-Origin', value: '*' },
+          { key: 'Access-Control-Allow-Methods', value: 'GET' }
+        ],
+      },
       ...CACHE_CONTROL_PAGES.map((page) => ({
         source: page,
         headers: [{ key: CACHE_CONTROL_HEADER, value: CACHE_CONTROL_VALUE }],


### PR DESCRIPTION
### Description

API method `/api/oneinch-rate` allowed for all origins (only GET)

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
