### PR TITLE
feat: add withdrawalMaxInput matomo event, removed calculateRewards matomo event

### DIFF
--- a/config/matomoClickEvents.ts
+++ b/config/matomoClickEvents.ts
@@ -40,8 +40,6 @@ export const enum MATOMO_CLICK_EVENTS_TYPES {
   wrapTokenSelectETH = 'wrapTokenSelectEth',
   // Unwrap tab
   l2BannerUnwrap = 'l2BannerUnwrap',
-  // /rewards page
-  calculateRewards = 'calculateRewards',
 
   // /withdrawal page
   withdrawalUseLido = 'withdrawalUseLido',
@@ -241,12 +239,6 @@ export const MATOMO_CLICK_EVENTS: Record<
     'Ethereum_Staking_Widget',
     'Push "Learn more" at the L2 banner on "Unwrap" tab',
     'eth_widget_banner_l2_unwrap',
-  ],
-  // /rewards page
-  [MATOMO_CLICK_EVENTS_TYPES.calculateRewards]: [
-    'Ethereum_Staking_Widget',
-    'Push calculate reward button" ',
-    'eth_widget_calculate_reward',
   ],
 
   // /withdrawal page

--- a/features/withdrawals/request/form/controls/token-amount-input-request.tsx
+++ b/features/withdrawals/request/form/controls/token-amount-input-request.tsx
@@ -1,12 +1,16 @@
-import { InputDecoratorTvlStake } from 'features/withdrawals/shared/input-decorator-tvl-stake';
 import { useController, useWatch } from 'react-hook-form';
 
+import {
+  MATOMO_CLICK_EVENTS_TYPES,
+  trackMatomoEvent,
+} from 'config/trackMatomoEvent';
+import { TokenAmountInputHookForm } from 'shared/hook-form/controls/token-amount-input-hook-form';
+import { InputDecoratorTvlStake } from 'features/withdrawals/shared/input-decorator-tvl-stake';
 import {
   RequestFormInputType,
   useRequestFormData,
 } from 'features/withdrawals/request/request-form-context';
 import { useTvlMessage } from 'features/withdrawals/hooks/useTvlMessage';
-import { TokenAmountInputHookForm } from 'shared/hook-form/controls/token-amount-input-hook-form';
 
 export const TokenAmountInputRequest = () => {
   const token = useWatch<RequestFormInputType, 'token'>({ name: 'token' });
@@ -26,6 +30,9 @@ export const TokenAmountInputRequest = () => {
       token={token}
       isLocked={isTokenLocked}
       maxValue={maxAmount}
+      onMaxClick={() => {
+        trackMatomoEvent(MATOMO_CLICK_EVENTS_TYPES.withdrawalMaxInput);
+      }}
       rightDecorator={
         balanceDiff && <InputDecoratorTvlStake tvlDiff={balanceDiff} />
       }

--- a/shared/forms/components/input-amount/input-amount.tsx
+++ b/shared/forms/components/input-amount/input-amount.tsx
@@ -1,18 +1,32 @@
-import { forwardRef, useCallback, useEffect, useState } from 'react';
+import {
+  ChangeEvent,
+  ComponentProps,
+  forwardRef,
+  MouseEvent,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
 import { BigNumber } from 'ethers';
+
 import { formatEther, parseEther } from '@ethersproject/units';
+import { MaxUint256 } from '@ethersproject/constants';
+import { Input } from '@lidofinance/lido-ui';
+
 import { InputNumber } from '../input-number';
 import { InputDecoratorMaxButton } from '../input-decorator-max-button';
 import { InputDecoratorLocked } from '../input-decorator-locked';
-import { MaxUint256 } from '@ethersproject/constants';
-import { Input } from '@lidofinance/lido-ui';
 
 type InputAmountProps = {
   onChange?: (value: BigNumber | null) => void;
   value?: BigNumber | null;
+  onMaxClick?: (
+    event: MouseEvent<HTMLButtonElement>,
+    maxValue: BigNumber,
+  ) => void;
   maxValue?: BigNumber;
   isLocked?: boolean;
-} & Omit<React.ComponentProps<typeof InputNumber>, 'onChange' | 'value'>;
+} & Omit<ComponentProps<typeof InputNumber>, 'onChange' | 'value'>;
 
 const parseEtherSafe = (value: string) => {
   try {
@@ -27,6 +41,7 @@ export const InputAmount = forwardRef<HTMLInputElement, InputAmountProps>(
     {
       onChange,
       value,
+      onMaxClick,
       rightDecorator,
       isLocked,
       maxValue,
@@ -40,7 +55,7 @@ export const InputAmount = forwardRef<HTMLInputElement, InputAmountProps>(
     );
 
     const handleChange = useCallback(
-      (e: React.ChangeEvent<HTMLInputElement>) => {
+      (e: ChangeEvent<HTMLInputElement>) => {
         // Support for devices where inputMode="decimal" showing keyboard with comma as decimal delimiter
         if (e.currentTarget.value.includes(',')) {
           e.currentTarget.value = e.currentTarget.value.replaceAll(',', '.');
@@ -86,7 +101,12 @@ export const InputAmount = forwardRef<HTMLInputElement, InputAmountProps>(
     }, [stringValue, value]);
 
     const handleClickMax =
-      onChange && maxValue?.gt(0) ? () => onChange(maxValue) : undefined;
+      onChange && maxValue?.gt(0)
+        ? (event: MouseEvent<HTMLButtonElement>) => {
+            onChange(maxValue);
+            onMaxClick?.(event, maxValue);
+          }
+        : undefined;
 
     return (
       <Input

--- a/shared/forms/components/input-decorator-max-button/input-decorator-max-button.tsx
+++ b/shared/forms/components/input-decorator-max-button/input-decorator-max-button.tsx
@@ -1,8 +1,9 @@
+import { MouseEventHandler } from 'react';
 import { MaxButton } from './styled';
 
 type InputDecoratorMaxButtonProps = {
   disabled?: boolean;
-  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
 };
 
 export const InputDecoratorMaxButton = ({


### PR DESCRIPTION
### Description

Max button in withdrawals request form

<img width="874" alt="Снимок экрана 2023-10-06 в 17 17 00" src="https://github.com/lidofinance/ethereum-staking-widget/assets/9885789/042c2b53-2a4d-4020-afba-cbdc87c6d697">

### Checklist:

- [x] Checked the changes locally.
- [x] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
