### PR TITLE
Build id generation

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,6 @@
 import NextBundleAnalyzer from '@next/bundle-analyzer';
 import buildDynamics from './scripts/build-dynamics.mjs';
+import generateBuildId from './scripts/generate-build-id.mjs';
 
 buildDynamics();
 
@@ -55,6 +56,7 @@ const withBundleAnalyzer = NextBundleAnalyzer({
 
 export default withBundleAnalyzer({
   basePath,
+  generateBuildId,
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/scripts/generate-build-id.mjs
+++ b/scripts/generate-build-id.mjs
@@ -1,0 +1,10 @@
+import buildInfo from '../build-info.json' assert { type: 'json' };
+
+export default function generateBuildId() {
+  const commit = buildInfo.commit;
+  const buildId = commit === 'REPLACE_WITH_COMMIT' ? null : commit;
+  console.info(
+    buildId ? `Generated build id: ${buildId}` : 'Fallback to default build ID',
+  );
+  return buildId;
+}


### PR DESCRIPTION

### Description

- Added generation of build id from commit hash
- Checked that build files don't change between builds with custom id
- If build-info.json is not filled out, fallback to next default build id

### Demo

<img width="665" alt="image" src="https://github.com/lidofinance/ethereum-staking-widget/assets/3705803/6987d531-9792-4eb1-abf4-84431075d4d8">

### Testing notes

Should not affect in any way. Only health check required. 

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
