### PR TITLE
refactor: public unsafe settings prefill RPC as array

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@ EL_RPC_URLS_1=
 EL_RPC_URLS_5=
 EL_RPC_URLS_17000=
 
+# IPFS prefill RPC URLs - list of URLs delimited by commas
+PREFILL_UNSAFE_EL_RPC_URLS=
+
 # supported networks for connecting wallet
 SUPPORTED_CHAINS=1,17000
 
@@ -11,7 +14,6 @@ DEFAULT_CHAIN=1
 
 # api key for ethplorer for token data
 ETHPLORER_API_KEY=freekey
-
 
 # comma-separated trusted hosts for Content Security Policy
 # e.g. http://localhost:PORT for local development
@@ -50,9 +52,6 @@ MATOMO_URL=
 
 # WalletConnect project ID
 WALLETCONNECT_PROJECT_ID=
-
-# Settings prefill
-PUBLIC_UNSAFE_SETTINGS_PREFILL_RPC=
 
 # Widget ETH API in IPFS mode (needs for `Lido statistics`)
 IPFS_WIDGET_ETH_API_BASE_PATH=

--- a/config/rpc.ts
+++ b/config/rpc.ts
@@ -20,8 +20,7 @@ export const useGetRpcUrlByChainId = () => {
       if (dynamics.ipfsMode) {
         const rpc =
           customConfig.savedCustomConfig.rpcUrls[chainId] ||
-          customConfig.settingsPrefillRpc ||
-          ''; // fallback must be set
+          customConfig.prefillUnsafeElRpcUrls?.[0];
 
         invariant(rpc, '[useGetRpcUrlByChainId] RPC is required!');
         return rpc;

--- a/config/types.ts
+++ b/config/types.ts
@@ -1,7 +1,7 @@
 export type EnvConfigRaw = {
   defaultChain: string | number;
   supportedChains: number[];
-  settingsPrefillRpc: string;
+  prefillUnsafeElRpcUrls: string[];
   ipfsMode: boolean;
   walletconnectProjectId: string;
 };
@@ -9,7 +9,7 @@ export type EnvConfigRaw = {
 export type EnvConfigParsed = {
   defaultChain: number;
   supportedChainIds: number[];
-  settingsPrefillRpc?: string;
+  prefillUnsafeElRpcUrls: string[];
   ipfsMode: boolean;
   walletconnectProjectId: string;
 };

--- a/env-dynamics.mjs
+++ b/env-dynamics.mjs
@@ -36,8 +36,8 @@ export const walletconnectProjectId = process.env.WALLETCONNECT_PROJECT_ID;
 /** @type boolean */
 export const ipfsMode = toBoolean(process.env.IPFS_MODE);
 
-/** @type string */
-export const settingsPrefillRpc = process.env.PUBLIC_UNSAFE_SETTINGS_PREFILL_RPC;
+/** @type string[] */
+export const prefillUnsafeElRpcUrls = process.env.PREFILL_UNSAFE_EL_RPC_URLS?.split(',') ?? [];
 
 /** @type string */
 export const ipfsWidgetEthApiBasePath = process.env.IPFS_WIDGET_ETH_API_BASE_PATH;

--- a/utils/parse-env-config.ts
+++ b/utils/parse-env-config.ts
@@ -4,7 +4,7 @@ export const parseEnvConfig = (envConfig: EnvConfigRaw): EnvConfigParsed => {
   return {
     defaultChain: Number(envConfig.defaultChain),
     supportedChainIds: envConfig.supportedChains,
-    settingsPrefillRpc: envConfig.settingsPrefillRpc,
+    prefillUnsafeElRpcUrls: envConfig.prefillUnsafeElRpcUrls,
     ipfsMode: envConfig.ipfsMode,
     walletconnectProjectId: envConfig.walletconnectProjectId,
   };


### PR DESCRIPTION
### Description

Refactor:
- The ENV `PUBLIC_UNSAFE_SETTINGS_PREFILL_RPC` to `PREFILL_UNSAFE_EL_RPC_URLS`
- The dynamic ENV `settingsPrefillRpc: string` to `prefillUnsafeElRpcUrls: string[]`

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
