### PR TITLE
feat: set a CORS and HttpMethodGuard for /api/oneinch-rate and /api/short-lido-stats

### DIFF
--- a/pages/api/oneinch-rate.ts
+++ b/pages/api/oneinch-rate.ts
@@ -1,6 +1,9 @@
+import { BigNumber } from 'ethers';
 import { Cache } from 'memory-cache';
+
 import { wrapRequest as wrapNextRequest } from '@lidofinance/next-api-wrapper';
 import { CHAINS, TOKENS, getTokenAddress } from '@lido-sdk/constants';
+
 import {
   CACHE_ONE_INCH_RATE_KEY,
   CACHE_ONE_INCH_RATE_TTL,
@@ -11,10 +14,12 @@ import {
   responseTimeMetric,
   errorAndCacheDefaultWrappers,
   rateLimit,
+  httpMethodGuard,
+  HttpMethod,
+  cors,
 } from 'utilsApi';
 import Metrics from 'utilsApi/metrics';
 import { API } from 'types';
-import { BigNumber } from 'ethers';
 
 const cache = new Cache<typeof CACHE_ONE_INCH_RATE_KEY, unknown>();
 
@@ -44,6 +49,8 @@ const oneInchRate: API = async (req, res) => {
 };
 
 export default wrapNextRequest([
+  httpMethodGuard([HttpMethod.GET]),
+  cors({ origin: ['*'], methods: [HttpMethod.GET] }),
   rateLimit,
   responseTimeMetric(Metrics.request.apiTimings, API_ROUTES.ONEINCH_RATE),
   ...errorAndCacheDefaultWrappers,

--- a/pages/api/short-lido-stats.ts
+++ b/pages/api/short-lido-stats.ts
@@ -1,21 +1,25 @@
 import getConfig from 'next/config';
 import { Cache } from 'memory-cache';
 import { wrapRequest as wrapNextRequest } from '@lidofinance/next-api-wrapper';
+
 import {
+  API_ROUTES,
   CACHE_LIDO_SHORT_STATS_KEY,
   CACHE_LIDO_SHORT_STATS_TTL,
-  API_ROUTES,
 } from 'config';
+import { API, SubgraphChains } from 'types';
 import {
-  getTotalStaked,
+  cors,
+  errorAndCacheDefaultWrappers,
   getLidoHoldersViaSubgraphs,
   getStEthPrice,
-  errorAndCacheDefaultWrappers,
-  responseTimeMetric,
+  getTotalStaked,
+  HttpMethod,
+  httpMethodGuard,
   rateLimit,
+  responseTimeMetric,
 } from 'utilsApi';
 import Metrics from 'utilsApi/metrics';
-import { API, SubgraphChains } from 'types';
 import { parallelizePromises } from 'utils';
 
 const { serverRuntimeConfig } = getConfig();
@@ -57,6 +61,8 @@ const shortLidoStats: API = async (req, res) => {
 };
 
 export default wrapNextRequest([
+  httpMethodGuard([HttpMethod.GET]),
+  cors({ origin: ['*'], methods: [HttpMethod.GET] }),
   rateLimit,
   responseTimeMetric(Metrics.request.apiTimings, API_ROUTES.SHORT_LIDO_STATS),
   ...errorAndCacheDefaultWrappers,

--- a/utilsApi/nextApiWrappers.ts
+++ b/utilsApi/nextApiWrappers.ts
@@ -1,4 +1,4 @@
-import { Histogram } from 'prom-client';
+import type { Histogram } from 'prom-client';
 import { getStatusLabel } from '@lidofinance/api-metrics';
 import {
   RequestWrapper,

--- a/utilsApi/nextApiWrappers.ts
+++ b/utilsApi/nextApiWrappers.ts
@@ -1,3 +1,4 @@
+import { Histogram } from 'prom-client';
 import { getStatusLabel } from '@lidofinance/api-metrics';
 import {
   RequestWrapper,
@@ -7,12 +8,23 @@ import {
   DEFAULT_API_ERROR_MESSAGE,
 } from '@lidofinance/next-api-wrapper';
 import { rateLimitWrapper } from '@lidofinance/next-ip-rate-limit';
-import { Histogram } from 'prom-client';
 import {
   CACHE_DEFAULT_HEADERS,
   RATE_LIMIT,
   RATE_LIMIT_TIME_FRAME,
 } from 'config';
+
+export enum HttpMethod {
+  GET = 'GET',
+  HEAD = 'HEAD',
+  POST = 'POST',
+  PUT = 'PUT',
+  DELETE = 'DELETE',
+  CONNECT = 'CONNECT',
+  OPTIONS = 'OPTIONS',
+  TRACE = 'TRACE',
+  PATCH = 'PATCH',
+}
 
 export const extractErrorMessage = (
   error: unknown,
@@ -22,6 +34,55 @@ export const extractErrorMessage = (
   if (error instanceof Error) return error.message;
   return defaultMessage ?? DEFAULT_API_ERROR_MESSAGE;
 };
+
+export type CorsWrapperType = {
+  origin?: string[];
+  methods?: HttpMethod[];
+  allowedHeaders?: string[];
+  credentials?: boolean;
+};
+
+export const cors =
+  ({
+    origin = ['*'],
+    methods = [HttpMethod.GET],
+    allowedHeaders = ['*'],
+    credentials = false,
+  }: CorsWrapperType): RequestWrapper =>
+  async (req, res, next) => {
+    if (!req || !req.method) {
+      res.status(405);
+      throw new Error('Not HTTP method provided');
+    }
+
+    res.setHeader('Access-Control-Allow-Credentials', String(credentials));
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Access-Control-Allow-Methods', methods.toString());
+    res.setHeader('Access-Control-Allow-Headers', allowedHeaders.toString());
+
+    if (req.method === HttpMethod.OPTIONS) {
+      // In preflight just need return a CORS headers
+      res.status(200).end();
+      return;
+    }
+
+    await next?.(req, res, next);
+  };
+
+export const httpMethodGuard =
+  (methodWhitelist: HttpMethod[]): RequestWrapper =>
+  async (req, res, next) => {
+    if (
+      !req ||
+      !req.method ||
+      !Object.values(methodWhitelist).includes(req.method as HttpMethod)
+    ) {
+      res.status(405);
+      throw new Error(`You can use only: ${methodWhitelist.toString()}`);
+    }
+
+    await next?.(req, res, next);
+  };
 
 export const responseTimeMetric =
   (metrics: Histogram<string>, route: string): RequestWrapper =>


### PR DESCRIPTION
### Description

Set a CORS origin '*' and HttpMethodGuard 'GET' for:
- /api/oneinch-rate
- /api/short-lido-stats

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
