### PR TITLE
fix: next.js HMR for IPFS dev

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -34,6 +34,8 @@ const rateLimitTimeFrame = process.env.RATE_LIMIT_TIME_FRAME || 60; // 1 minute;
 const rewardsBackendAPI = process.env.REWARDS_BACKEND;
 const defaultChain = process.env.DEFAULT_CHAIN;
 
+const ipfsDevMode = process.env?.npm_lifecycle_event === 'dev-ipfs';
+
 // cache control
 export const CACHE_CONTROL_HEADER = 'x-cache-control';
 export const CACHE_CONTROL_PAGES = [
@@ -175,5 +177,6 @@ export default withBundleAnalyzer({
     ethAPIBasePath,
     rewardsBackendAPI,
     defaultChain,
+    ipfsDevMode,
   },
 });

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -34,7 +34,7 @@ const rateLimitTimeFrame = process.env.RATE_LIMIT_TIME_FRAME || 60; // 1 minute;
 const rewardsBackendAPI = process.env.REWARDS_BACKEND;
 const defaultChain = process.env.DEFAULT_CHAIN;
 
-const ipfsDevMode = process.env?.npm_lifecycle_event === 'dev-ipfs';
+const developmentMode = process.env.NODE_ENV === 'development';
 
 // cache control
 export const CACHE_CONTROL_HEADER = 'x-cache-control';
@@ -177,6 +177,6 @@ export default withBundleAnalyzer({
     ethAPIBasePath,
     rewardsBackendAPI,
     defaultChain,
-    ipfsDevMode,
+    developmentMode,
   },
 });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "GPL-3.0-or-later",
   "scripts": {
-    "dev": "node server.mjs",
+    "dev": "node NODE_ENV=development server.mjs",
     "build": "next build",
     "build:analyze": "ANALYZE_BUNDLE=true next build",
     "start": "NODE_OPTIONS='-r next-logger' NODE_ENV=production node server.mjs",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "GPL-3.0-or-later",
   "scripts": {
-    "dev": "node NODE_ENV=development server.mjs",
+    "dev": "NODE_ENV=development node server.mjs",
     "build": "next build",
     "build:analyze": "ANALYZE_BUNDLE=true next build",
     "start": "NODE_OPTIONS='-r next-logger' NODE_ENV=production node server.mjs",

--- a/utilsApi/withCSP.ts
+++ b/utilsApi/withCSP.ts
@@ -6,7 +6,7 @@ import { dynamics } from 'config';
 import { AppWrapperType } from 'types';
 
 const { serverRuntimeConfig } = getConfig();
-const { cspTrustedHosts, cspReportOnly, cspReportUri, ipfsDevMode } =
+const { cspTrustedHosts, cspReportOnly, cspReportUri, developmentMode } =
   serverRuntimeConfig;
 
 const trustedHosts = cspTrustedHosts ? cspTrustedHosts.split(',') : [];
@@ -29,11 +29,12 @@ export const contentSecurityPolicy = {
     ...(dynamics.ipfsMode && {
       // connectSrc must be another for IPFS because of custom RPC
       connectSrc: [
+        "'self'",
         'https:',
         'wss:',
 
         // When we use `yarn dev-ipfs` we still use Next.js HMR, which works over `http` and `ws`
-        ...(ipfsDevMode ? ['http:', 'ws:'] : []),
+        ...(developmentMode ? ['ws:'] : []),
       ],
       // CSP directive 'frame-ancestors' is ignored when delivered via a <meta> element.
       // CSP directive 'report-uri' is ignored when delivered via a <meta> element.

--- a/utilsApi/withCSP.ts
+++ b/utilsApi/withCSP.ts
@@ -6,7 +6,8 @@ import { dynamics } from 'config';
 import { AppWrapperType } from 'types';
 
 const { serverRuntimeConfig } = getConfig();
-const { cspTrustedHosts, cspReportOnly, cspReportUri } = serverRuntimeConfig;
+const { cspTrustedHosts, cspReportOnly, cspReportUri, ipfsDevMode } =
+  serverRuntimeConfig;
 
 const trustedHosts = cspTrustedHosts ? cspTrustedHosts.split(',') : [];
 
@@ -27,7 +28,13 @@ export const contentSecurityPolicy = {
 
     ...(dynamics.ipfsMode && {
       // connectSrc must be another for IPFS because of custom RPC
-      connectSrc: ['https:', 'wss:'],
+      connectSrc: [
+        'https:',
+        'wss:',
+
+        // When we use `yarn dev-ipfs` we still use Next.js HMR, which works over `http` and `ws`
+        ...(ipfsDevMode ? ['http:', 'ws:'] : []),
+      ],
       // CSP directive 'frame-ancestors' is ignored when delivered via a <meta> element.
       // CSP directive 'report-uri' is ignored when delivered via a <meta> element.
     }),


### PR DESCRIPTION
### Description

When we use `yarn dev-ipfs` we still use Next.js HMR, which works over `http` and `ws`.

Without this fix a IPFS mode not works on http://localhost in Safari and Firefox (possible another browsers).

Not actual for Chrome (works any way).


### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
