### PR TITLE
feat: make RPC settings page for infra version

### DIFF
--- a/config/rpc.ts
+++ b/config/rpc.ts
@@ -25,7 +25,10 @@ export const useGetRpcUrlByChainId = () => {
         invariant(rpc, '[useGetRpcUrlByChainId] RPC is required!');
         return rpc;
       } else {
-        return getBackendRPCPath(chainId);
+        return (
+          clientConfig.savedClientConfig.rpcUrls[chainId] ||
+          getBackendRPCPath(chainId)
+        );
       }
     },
     [clientConfig],

--- a/features/settings/settings-form/settings-form.tsx
+++ b/features/settings/settings-form/settings-form.tsx
@@ -4,7 +4,6 @@ import { useForm } from 'react-hook-form';
 import { useSDK } from '@lido-sdk/react';
 import { Button, ToastSuccess, Block, Input } from '@lidofinance/lido-ui';
 
-import { dynamics } from 'config';
 import { useClientConfig } from 'providers/client-config';
 import { RPCErrorType, checkRpcUrl } from 'utils/check-rpc-url';
 import { CHAINS } from 'utils/chains';
@@ -90,7 +89,6 @@ export const SettingsForm = () => {
             fullwidth
             label="RPC URL"
             error={errors?.rpcUrl?.message}
-            disabled={!dynamics.ipfsMode}
             {...formMethods.register('rpcUrl', {
               required: true,
               validate: validateRpcUrl,
@@ -105,11 +103,7 @@ export const SettingsForm = () => {
               fullwidth
               color="primary"
               loading={formState.isValidating}
-              disabled={
-                !dynamics.ipfsMode ||
-                !formState.isValid ||
-                formState.isValidating
-              }
+              disabled={!formState.isValid || formState.isValidating}
             >
               Save
             </Button>

--- a/features/settings/settings-form/settings-form.tsx
+++ b/features/settings/settings-form/settings-form.tsx
@@ -4,6 +4,7 @@ import { useForm } from 'react-hook-form';
 import { useSDK } from '@lido-sdk/react';
 import { Button, ToastSuccess, Block, Input } from '@lidofinance/lido-ui';
 
+import { dynamics } from 'config';
 import { useClientConfig } from 'providers/client-config';
 import { RPCErrorType, checkRpcUrl } from 'utils/check-rpc-url';
 import { CHAINS } from 'utils/chains';
@@ -89,6 +90,7 @@ export const SettingsForm = () => {
             fullwidth
             label="RPC URL"
             error={errors?.rpcUrl?.message}
+            disabled={!dynamics.ipfsMode}
             {...formMethods.register('rpcUrl', {
               required: true,
               validate: validateRpcUrl,
@@ -103,7 +105,11 @@ export const SettingsForm = () => {
               fullwidth
               color="primary"
               loading={formState.isValidating}
-              disabled={!formState.isValid || formState.isValidating}
+              disabled={
+                !dynamics.ipfsMode ||
+                !formState.isValid ||
+                formState.isValidating
+              }
             >
               Save
             </Button>

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -1,4 +1,7 @@
 import { FC } from 'react';
+import { GetStaticProps } from 'next';
+
+import { dynamics } from 'config';
 import { Layout } from 'shared/components';
 import { SettingsForm } from 'features/settings/settings-form';
 
@@ -11,3 +14,9 @@ const Settings: FC = () => {
 };
 
 export default Settings;
+
+export const getStaticProps: GetStaticProps = async () => {
+  if (!dynamics.ipfsMode) return { notFound: true };
+
+  return { props: {} };
+};

--- a/shared/components/header/components/header-wallet.tsx
+++ b/shared/components/header/components/header-wallet.tsx
@@ -35,7 +35,7 @@ const HeaderWallet: FC = () => {
       ) : (
         <Connect size="sm" />
       )}
-      <HeaderSettingsButton />
+      {dynamics.ipfsMode && <HeaderSettingsButton />}
       <ThemeToggler />
       {dynamics.ipfsMode && (
         <IPFSInfoBoxWrap>


### PR DESCRIPTION
### Description

- made `RPC settings` page functionality, but disabled for infra version (return 404 page)
- made opportunity to use saved client RPC


### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
