### PR TITLE
refactor(LidoStats): separate to small components

### DIFF
--- a/features/home/lido-stats/lido-stats-item.tsx
+++ b/features/home/lido-stats/lido-stats-item.tsx
@@ -1,0 +1,32 @@
+import { FC, memo, PropsWithChildren, ReactNode } from 'react';
+import { DataTableRow } from '@lidofinance/lido-ui';
+import { DATA_UNAVAILABLE } from 'config';
+
+type LidoStatsItemProps = {
+  show: boolean;
+  loading: boolean;
+  dataTestId: string;
+  title: ReactNode;
+  highlight?: boolean | undefined;
+};
+
+export const LidoStatsItem: FC<PropsWithChildren<LidoStatsItemProps>> = memo(
+  (props) => {
+    const { show, loading, dataTestId, title, children, highlight } = props;
+
+    if (!show) {
+      return null;
+    }
+
+    return (
+      <DataTableRow
+        title={title}
+        loading={loading}
+        data-testid={dataTestId}
+        highlight={highlight}
+      >
+        {children || DATA_UNAVAILABLE}
+      </DataTableRow>
+    );
+  },
+);

--- a/features/home/lido-stats/lido-stats.tsx
+++ b/features/home/lido-stats/lido-stats.tsx
@@ -1,60 +1,24 @@
-// import { FC, memo, useMemo, PropsWithChildren } from 'react';
 import { FC, memo, useMemo } from 'react';
+
 import { getEtherscanTokenLink } from '@lido-sdk/helpers';
 import { useSDK } from '@lido-sdk/react';
 import { getTokenAddress, TOKENS } from '@lido-sdk/constants';
-import {
-  Block,
-  DataTable,
-  DataTableRow,
-  Question,
-  Tooltip,
-} from '@lidofinance/lido-ui';
+import { Block, DataTable, Question, Tooltip } from '@lidofinance/lido-ui';
+
 import { Section, MatomoLink } from 'shared/components';
+import { useLidoApr, useLidoStats } from 'shared/hooks';
 import {
   LIDO_APR_TOOLTIP_TEXT,
-  DATA_UNAVAILABLE,
   MATOMO_CLICK_EVENTS_TYPES,
   dynamics,
 } from 'config';
-import { useLidoApr, useLidoStats } from 'shared/hooks';
+
 import { FlexCenterVertical } from './styles';
+import { LidoStatsItem } from './lido-stats-item';
 
 const isStatItemAvailable = (val: any): boolean => {
   return val && val !== 'N/A';
 };
-
-// type LidoStatsItemProps = {
-//   show: boolean;
-//   loading: boolean;
-//   dataTestId: string;
-// }
-
-// export const LidoStatsItem: FC<PropsWithChildren<LidoStatsItemProps>> = memo((props) => {
-//   const { show, loading, dataTestId, children } = props;
-//
-//   if (!show) {
-//     return null;
-//   }
-//
-//   return (
-//     <DataTableRow
-//       title={
-//         <FlexCenterVertical data-testid="aprTooltip">
-//           Annual percentage rate
-//           <Tooltip title={LIDO_APR_TOOLTIP_TEXT}>
-//             <Question />
-//           </Tooltip>
-//         </FlexCenterVertical>
-//       }
-//       loading={loading}
-//       data-testid={dataTestId}
-//       highlight
-//     >
-//       {children || DATA_UNAVAILABLE}
-//     </DataTableRow>
-//   );
-// });
 
 export const LidoStats: FC = memo(() => {
   const { chainId } = useSDK();
@@ -96,53 +60,49 @@ export const LidoStats: FC = memo(() => {
       <Block>
         <DataTable>
           <>
-            {showApr && (
-              <DataTableRow
-                title={
-                  <FlexCenterVertical data-testid="aprTooltip">
-                    Annual percentage rate
-                    <Tooltip title={LIDO_APR_TOOLTIP_TEXT}>
-                      <Question />
-                    </Tooltip>
-                  </FlexCenterVertical>
-                }
-                loading={lidoApr.initialLoading}
-                data-testid="lidoAPR"
-                highlight
-              >
-                {lidoApr.apr ? `${lidoApr.apr}%` : DATA_UNAVAILABLE}
-              </DataTableRow>
-            )}
+            <LidoStatsItem
+              title={
+                <FlexCenterVertical data-testid="aprTooltip">
+                  Annual percentage rate
+                  <Tooltip title={LIDO_APR_TOOLTIP_TEXT}>
+                    <Question />
+                  </Tooltip>
+                </FlexCenterVertical>
+              }
+              show={showApr}
+              loading={lidoApr.initialLoading}
+              dataTestId="lidoAPR"
+              highlight
+            >
+              {lidoApr.apr ?? `${lidoApr.apr}%`}
+            </LidoStatsItem>
 
-            {showTotalStaked && (
-              <DataTableRow
-                title="Total staked with Lido"
-                data-testid="totalStaked"
-                loading={lidoStats.initialLoading}
-              >
-                {lidoStats.data.totalStaked}
-              </DataTableRow>
-            )}
+            <LidoStatsItem
+              title="Total staked with Lido"
+              show={showTotalStaked}
+              loading={lidoStats.initialLoading}
+              dataTestId="totalStaked"
+            >
+              {lidoStats.data.totalStaked}
+            </LidoStatsItem>
 
-            {showStakers && (
-              <DataTableRow
-                title="Stakers"
-                data-testid="stakers"
-                loading={lidoStats.initialLoading}
-              >
-                {lidoStats.data.stakers}
-              </DataTableRow>
-            )}
+            <LidoStatsItem
+              title="Stakers"
+              show={showStakers}
+              loading={lidoStats.initialLoading}
+              dataTestId="stakers"
+            >
+              {lidoStats.data.stakers}
+            </LidoStatsItem>
 
-            {showMarketCap && (
-              <DataTableRow
-                title="stETH market cap"
-                data-testid="stEthMarketCap"
-                loading={lidoStats.initialLoading}
-              >
-                {lidoStats.data.marketCap}
-              </DataTableRow>
-            )}
+            <LidoStatsItem
+              title="stETH market cap"
+              show={showMarketCap}
+              loading={lidoStats.initialLoading}
+              dataTestId="stEthMarketCap"
+            >
+              {lidoStats.data.marketCap}
+            </LidoStatsItem>
           </>
         </DataTable>
       </Block>

--- a/features/home/lido-stats/lido-stats.tsx
+++ b/features/home/lido-stats/lido-stats.tsx
@@ -1,3 +1,4 @@
+// import { FC, memo, useMemo, PropsWithChildren } from 'react';
 import { FC, memo, useMemo } from 'react';
 import { getEtherscanTokenLink } from '@lido-sdk/helpers';
 import { useSDK } from '@lido-sdk/react';
@@ -22,6 +23,38 @@ import { FlexCenterVertical } from './styles';
 const isStatItemAvailable = (val: any): boolean => {
   return val && val !== 'N/A';
 };
+
+// type LidoStatsItemProps = {
+//   show: boolean;
+//   loading: boolean;
+//   dataTestId: string;
+// }
+
+// export const LidoStatsItem: FC<PropsWithChildren<LidoStatsItemProps>> = memo((props) => {
+//   const { show, loading, dataTestId, children } = props;
+//
+//   if (!show) {
+//     return null;
+//   }
+//
+//   return (
+//     <DataTableRow
+//       title={
+//         <FlexCenterVertical data-testid="aprTooltip">
+//           Annual percentage rate
+//           <Tooltip title={LIDO_APR_TOOLTIP_TEXT}>
+//             <Question />
+//           </Tooltip>
+//         </FlexCenterVertical>
+//       }
+//       loading={loading}
+//       data-testid={dataTestId}
+//       highlight
+//     >
+//       {children || DATA_UNAVAILABLE}
+//     </DataTableRow>
+//   );
+// });
 
 export const LidoStats: FC = memo(() => {
   const { chainId } = useSDK();


### PR DESCRIPTION
### Description

LidoStats has been separated to small components:
- LidoStats
- LidoStatsItem

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
