### PR TITLE
feat: support href query string in link IPFS

### DIFF
--- a/pages/_home/home-page-ipfs.tsx
+++ b/pages/_home/home-page-ipfs.tsx
@@ -54,13 +54,16 @@ const HomePageIpfs: FC = () => {
       parsedPath[0] === getPathWithoutFirstSlash(WITHDRAWALS_PATH) &&
       !parsedPath[1]
     ) {
-      void replace(WITHDRAWALS_REQUEST_PATH);
+      void replace(
+        WITHDRAWALS_REQUEST_PATH,
+        router.query as Record<string, string>,
+      );
     }
 
     if (parsedPath[0] && !IPFS_ROUTABLE_PAGES.includes(parsedPath[0])) {
-      void replace(HOME_PATH);
+      void replace(HOME_PATH, router.query as Record<string, string>);
     }
-  }, [replace, parsedPath]);
+  }, [replace, parsedPath, router.query]);
 
   /**
    * TODO:

--- a/shared/components/link-ipfs.tsx
+++ b/shared/components/link-ipfs.tsx
@@ -4,21 +4,22 @@ import { usePrefixedPush } from 'shared/hooks/use-prefixed-history';
 
 type Props = {
   href: string;
+  query?: Record<string, string>;
   onClick?: MouseEventHandler<HTMLAnchorElement>;
   children?: ReactNode;
 };
 
-export const LinkIpfs = ({ onClick, ...props }: Props) => {
+export const LinkIpfs = ({ onClick, query, ...props }: Props) => {
   const push = usePrefixedPush();
   const { href } = props;
 
   const handleClick: MouseEventHandler<HTMLAnchorElement> = useCallback(
     (event) => {
       event.preventDefault();
-      void push(href);
+      void push(href, query);
       onClick?.(event);
     },
-    [onClick, push, href],
+    [onClick, push, href, query],
   );
 
   // TODO:

--- a/shared/components/local-link/index.tsx
+++ b/shared/components/local-link/index.tsx
@@ -10,15 +10,15 @@ export const LocalLink: FC<PropsWithChildren<LinkProps>> = (props) => {
   const { ref, embed, app } = router.query;
   const { href, ...restProps } = props;
 
-  const extraQuery = {} as { [key: string]: string | string[] };
-  if (ref) extraQuery.ref = ref;
-  if (embed) extraQuery.embed = embed;
-  if (app) extraQuery.app = app;
+  const extraQuery = {} as Record<string, string>;
+  // Not support case: ?ref=01234&ref=56789
+  if (ref) extraQuery.ref = String(ref);
+  if (embed) extraQuery.embed = String(embed);
+  if (app) extraQuery.app = String(app);
 
   if (typeof href === 'string') {
     if (dynamics.ipfsMode) {
-      // TODO: href + extraQuery?
-      return <LinkIpfs {...restProps} href={href} />;
+      return <LinkIpfs {...restProps} href={href} query={extraQuery} />;
     }
 
     return (

--- a/shared/hooks/use-prefixed-history.ts
+++ b/shared/hooks/use-prefixed-history.ts
@@ -7,8 +7,13 @@ export const usePrefixedPush = () => {
   const router = useRouter();
   type Args = Parameters<typeof router.push>;
   return useCallback(
-    (url: string, a1?: Args[1], a2?: Args[2]) => {
-      return router.push(prefixUrl(url), a1, a2);
+    (
+      url: string,
+      query?: Record<string, string>,
+      a1?: Args[1],
+      a2?: Args[2],
+    ) => {
+      return router.push(prefixUrl(url, query), a1, a2);
     },
     [router],
   );
@@ -18,8 +23,13 @@ export const usePrefixedReplace = () => {
   const router = useRouter();
   type Args = Parameters<typeof router.replace>;
   return useCallback(
-    (url: string, a1?: Args[1], a2?: Args[2]) => {
-      return router.replace(prefixUrl(url), a1, a2);
+    (
+      url: string,
+      query?: Record<string, string>,
+      a1?: Args[1],
+      a2?: Args[2],
+    ) => {
+      return router.replace(prefixUrl(url, query), a1, a2);
     },
     [router],
   );

--- a/utils/get-ipfs-base-path.ts
+++ b/utils/get-ipfs-base-path.ts
@@ -7,7 +7,12 @@ export const getIpfsBasePath = memoize(() => {
   return basePath;
 });
 
-export const prefixUrl = (url: string) => {
-  if (dynamics.ipfsMode) return `${getIpfsBasePath()}#${url}`;
+export const prefixUrl = (url: string, query?: Record<string, string>) => {
+  let queryString = '';
+  if (query && Object.keys(query).length > 0) {
+    queryString = `?${new URLSearchParams(query).toString()}`;
+  }
+
+  if (dynamics.ipfsMode) return `${getIpfsBasePath()}${queryString}#${url}`;
   return url;
 };


### PR DESCRIPTION
### Description

Added support passing a query string through "IPFS links" components.

Because ETH stake widget uses hash routing in IPFS mode URL structure is:

`<host>?<query_string>#/<hash_path>`

Example: https://localhost:3000/?ref=11&embed=222#/wrap

**NOT https://localhost:3000/#/wrap?ref=11&embed=222 !!!**

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
