### PR TITLE
refactor: move home pages to features

### DIFF
--- a/features/home/home-page-regular.tsx
+++ b/features/home/home-page-regular.tsx
@@ -1,9 +1,14 @@
 import { FC } from 'react';
 import Head from 'next/head';
-import { Wallet, StakeForm, LidoStats, StakeFaq } from 'features/home';
+
 import { Layout } from 'shared/components';
 import NoSSRWrapper from 'shared/components/no-ssr-wrapper';
 import { useWeb3Key } from 'shared/hooks/useWeb3Key';
+
+import { Wallet } from './wallet/wallet';
+import { StakeForm } from './stake-form/stake-form';
+import { StakeFaq } from './stake-faq/stake-faq';
+import { LidoStats } from './lido-stats/lido-stats';
 
 const HomePageRegular: FC = () => {
   const key = useWeb3Key();

--- a/features/ipfs/home-page-ipfs.tsx
+++ b/features/ipfs/home-page-ipfs.tsx
@@ -14,12 +14,12 @@ import {
 import NoSSRWrapper from 'shared/components/no-ssr-wrapper';
 import { usePrefixedReplace } from 'shared/hooks/use-prefixed-history';
 
-import HomePageRegular from './home-page-regular';
-import WrapPage from '../wrap/[[...mode]]';
-import WithdrawalsPage from '../withdrawals/[mode]';
-import ReferralPage from '../referral';
-import RewardsPage from '../rewards';
-import SettingsPage from '../settings';
+import HomePageRegular from 'features/home/home-page-regular';
+import WrapPage from 'pages/wrap/[[...mode]]';
+import WithdrawalsPage from 'pages/withdrawals/[mode]';
+import ReferralPage from 'pages/referral';
+import RewardsPage from 'pages/rewards';
+import SettingsPage from 'pages/settings';
 
 /**
  * We are using single index.html endpoint

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,6 @@
 import { dynamics } from 'config';
 
-import HomePageRegular from './_home/home-page-regular';
-import HomePageIpfs from './_home/home-page-ipfs';
+import HomePageRegular from 'features/home/home-page-regular';
+import HomePageIpfs from 'features/ipfs/home-page-ipfs';
 
 export default dynamics.ipfsMode ? HomePageIpfs : HomePageRegular;


### PR DESCRIPTION
### Description

- `HomePageIpfs` moved to `features/ipfs`
- `HomePageRegular` moved to `features/home`

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
