### PR TITLE
Added permit signature error

### DIFF
--- a/utils/getErrorMessage.ts
+++ b/utils/getErrorMessage.ts
@@ -5,7 +5,7 @@ export enum ErrorMessage {
   ENABLE_BLIND_SIGNING = 'Please enable blind signing on your Ledger hardware wallet.',
   LIMIT_REACHED = 'Transaction could not be completed because stake limit is exhausted. Please wait until the stake limit restores and try again. Otherwise, you can swap your Ethereum on 1inch platform instantly.',
   DEVICE_LOCKED = 'Please unlock your Ledger hardware wallet',
-  INVALID_SIGNATURE = 'Invalid Permit signature. Perhaps it has expired. Try signing again.',
+  INVALID_SIGNATURE = 'Invalid Permit signature. Perhaps it has expired or already been used. Try submitting a withdrawal request again.',
 }
 
 export const getErrorMessage = (error: unknown): ErrorMessage => {

--- a/utils/getErrorMessage.ts
+++ b/utils/getErrorMessage.ts
@@ -5,6 +5,7 @@ export enum ErrorMessage {
   ENABLE_BLIND_SIGNING = 'Please enable blind signing on your Ledger hardware wallet.',
   LIMIT_REACHED = 'Transaction could not be completed because stake limit is exhausted. Please wait until the stake limit restores and try again. Otherwise, you can swap your Ethereum on 1inch platform instantly.',
   DEVICE_LOCKED = 'Please unlock your Ledger hardware wallet',
+  INVALID_SIGNATURE = 'Invalid Permit signature. Perhaps it has expired. Try signing again.',
 }
 
 export const getErrorMessage = (error: unknown): ErrorMessage => {
@@ -21,6 +22,8 @@ export const getErrorMessage = (error: unknown): ErrorMessage => {
     case 'UNPREDICTABLE_GAS_LIMIT':
     case 'INSUFFICIENT_FUNDS':
       return ErrorMessage.NOT_ENOUGH_ETHER;
+    case 'INVALID_SIGNATURE':
+      return ErrorMessage.INVALID_SIGNATURE;
     case 'ACTION_REJECTED':
     case 4001:
       return ErrorMessage.DENIED_SIG;
@@ -43,12 +46,9 @@ export const extractCodeFromError = (
   // early exit on non object error
   if (!error || typeof error != 'object') return 0;
 
-  if (
-    'reason' in error &&
-    typeof error.reason == 'string' &&
-    error.reason.includes('STAKE_LIMIT')
-  ) {
-    return 'LIMIT_REACHED';
+  if ('reason' in error && typeof error.reason == 'string') {
+    if (error.reason.includes('STAKE_LIMIT')) return 'LIMIT_REACHED';
+    if (error.reason.includes('INVALID_SIGNATURE')) return 'INVALID_SIGNATURE';
   }
 
   // sometimes we have error message but bad error code


### PR DESCRIPTION
### Description

Added error message when permit signature is invalid. 

### Demo

<img width="532" alt="image" src="https://github.com/lidofinance/ethereum-staking-widget/assets/3705803/b290baf6-77af-4ff4-bd6a-0d88cd17fd16">

### Testing notes

How to reproduce:

1. start withdrawing
2. sign permit but don't sign tx yet
3. open another window
4. go trough full withdrawal flow (but don't sign tx from step 2)
5. sign tx from step 2

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
