### PR TITLE
Remove some wallets

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react-hook-form": "^7.45.2",
     "react-is": "^18.2.0",
     "react-transition-group": "^4.4.2",
-    "reef-knot": "^1.10.6",
+    "reef-knot": "^1.11.0",
     "remark": "^13.0.0",
     "remark-external-links": "^8.0.0",
     "remark-html": "^13.0.1",
@@ -124,10 +124,6 @@
     "typescript": "^4.9.4",
     "url-loader": "^4.1.1",
     "webpack-preprocessor-loader": "^1.3.0"
-  },
-  "resolutions": {
-    "postcss": "^8.4.31",
-    "crypto-js": "^4.2.0"
   },
   "resolutions": {
     "postcss": "^8.4.31",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2600,10 +2600,10 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.23.tgz#498e41218ab3b6a1419c735e5c6ae2c5ed609b6c"
   integrity sha512-C16M+IYz0rgRhWZdCmK+h58JMv8vijAA61gmz2rspCSwKwzBebpdcsiUmwrtJRdphuY30i6BSLEOP8ppbNLyLg==
 
-"@reef-knot/connect-wallet-modal@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@reef-knot/connect-wallet-modal/-/connect-wallet-modal-1.10.0.tgz#f8948265716408296191c4ba51394c09478a6938"
-  integrity sha512-lfKvTz8OS41a+YvX9Xy9ky22LAvIkjz1o6PvAVRG6QJmxal7akhgdx9ZZJU9+gNDV4Aigfj12NYVQ2TQVY9vRQ==
+"@reef-knot/connect-wallet-modal@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@reef-knot/connect-wallet-modal/-/connect-wallet-modal-1.11.0.tgz#8975c68277eedadc6ec9137f3cf20dff6f8011a3"
+  integrity sha512-Bhxhxz5Vu3oJDgmzeLo5QuIl3TrqO8AVV4qg+ise1epoB+F4GTH+a8t1zTUn3a8QlxTS6aWDGSPPimYF9BeaUA==
   dependencies:
     "@ledgerhq/hw-app-eth" "^6.34.3"
     "@ledgerhq/hw-transport" "^6.28.8"
@@ -2716,15 +2716,15 @@
   resolved "https://registry.yarnpkg.com/@reef-knot/wallets-helpers/-/wallets-helpers-1.1.5.tgz#bceb7d91a6f7748ec093fbdf7422772bd71708b6"
   integrity sha512-OFWR6zsUy04Waujl1VlNNs91P/kyHeGLC49QLWs3vrHvVipEk7ydUhKU/dHrbuhjQBS7quKg4vrodyCUUl4zyQ==
 
-"@reef-knot/wallets-icons@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@reef-knot/wallets-icons/-/wallets-icons-1.2.0.tgz#96d20b1805a926b47ce41238d945b10620bb49f6"
-  integrity sha512-UpZ4641R4roLwQw//AHEuz4OfElhqpNB2kRsR1p0kD4BOiPqkr8t3u4I+U0tBC4trhBu+j4MMgGNaXN5MUn4dg==
+"@reef-knot/wallets-icons@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@reef-knot/wallets-icons/-/wallets-icons-1.3.0.tgz#c2b3438f352080da1a9918e49b73d718b8f8dbd0"
+  integrity sha512-YudzhP/avx3jgbBdCw1QhInG1CGW08jweUw+eipLzHxPdfWpKSIQkeLw1GXOSflL6gI+dc7qmfi6wjfyB4Gpdg==
 
-"@reef-knot/wallets-list@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@reef-knot/wallets-list/-/wallets-list-1.6.0.tgz#3cce895d2aee56b122784db5354b79a1734ab608"
-  integrity sha512-+mWn0Mr7hAqH3k1J8WO9WJfug5RaIYEmXLi8hv+Twc1atgUqwqcSxhKzklRhM+Yjbfgi42PiCJ/YQMIoARATvQ==
+"@reef-knot/wallets-list@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@reef-knot/wallets-list/-/wallets-list-1.7.0.tgz#93fe0accaa86383961ef07b6bb2aa371174346dc"
+  integrity sha512-6f3I2Z9Nch4df55xiJZMAkCTXuy8coZBZoMZkmfFIVdV5Gvh5MOjQ82+p4kgngKk3gNXxeQ9MFM1Ldj2mxrR3Q==
   dependencies:
     "@reef-knot/wallet-adapter-ambire" "1.2.4"
     "@reef-knot/wallet-adapter-bitkeep" "1.1.0"
@@ -2739,10 +2739,10 @@
     "@reef-knot/wallet-adapter-zengo" "1.2.4"
     "@reef-knot/wallet-adapter-zerion" "1.2.4"
 
-"@reef-knot/web3-react@1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@reef-knot/web3-react/-/web3-react-1.8.0.tgz#4023eaab935c3b15efb6f441e3b6e413f5de24ae"
-  integrity sha512-2NPvqEP18rsd+xMvT8yJw6I3YG5rQgryeAA2MGrCoqV6Mt4WDiHuj7R/sMaqXbc3goSjcVWbFM+O+nos8o2lLA==
+"@reef-knot/web3-react@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@reef-knot/web3-react/-/web3-react-1.9.0.tgz#c9fa2a4f88a439f9360cb82dfda42dfa77537f38"
+  integrity sha512-Rk3ZvOtjxIDSMOtPGOn8hD73csU58lPda4I8LDPNWhgwmV8RPSCVj1kiOrANK6dRuRUFQYlLPunaKEgWmYHXpQ==
   dependencies:
     "@gnosis.pm/safe-apps-web3-react" "0.6.8"
     "@ledgerhq/iframe-provider" "0.4.2"
@@ -9185,20 +9185,20 @@ redis-parser@^3.0.0:
   dependencies:
     redis-errors "^1.0.0"
 
-reef-knot@^1.10.6:
-  version "1.10.6"
-  resolved "https://registry.yarnpkg.com/reef-knot/-/reef-knot-1.10.6.tgz#4bf2cd7c9595dcc48ab1692d2025f1cb8b7ff825"
-  integrity sha512-sSBmZhU/wOl/c9ovvjm+q6raUlTWDH2sUrckIQ629N6KO238K9v7F86eKHisqAcwWm8JbqhczUCOHUtuYrq6VQ==
+reef-knot@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/reef-knot/-/reef-knot-1.11.0.tgz#35002347c78f2e73c6be82214807ffcd12108309"
+  integrity sha512-O5rirJIMjAognoD84UPVQBcYc3Y/Eawh2SMWYEneXuDVRme0VIz8BQQKEuWIKaSeORW6JxDoVOgv9k5eYh8WmA==
   dependencies:
-    "@reef-knot/connect-wallet-modal" "1.10.0"
+    "@reef-knot/connect-wallet-modal" "1.11.0"
     "@reef-knot/core-react" "1.7.0"
     "@reef-knot/ledger-connector" "1.1.1"
     "@reef-knot/types" "1.3.0"
     "@reef-knot/ui-react" "1.0.7"
     "@reef-knot/wallets-helpers" "1.1.5"
-    "@reef-knot/wallets-icons" "1.2.0"
-    "@reef-knot/wallets-list" "1.6.0"
-    "@reef-knot/web3-react" "1.8.0"
+    "@reef-knot/wallets-icons" "1.3.0"
+    "@reef-knot/wallets-list" "1.7.0"
+    "@reef-knot/web3-react" "1.9.0"
 
 reflect.getprototypeof@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
### Description

Resolves SI-1081
Remove wallets: matwallet, zerion, blockchain.com, phantom, taho, zengo.
Remove duplicated `yarn resolutions` field because of https://github.com/lidofinance/ethereum-staking-widget/commit/7317b38b5d3f7a365ce3b1162ee43ef804c6947e

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
