### PR TITLE
Hot fix: Remove 1inch withdrawals integration

### DIFF
--- a/features/withdrawals/hooks/useWithdrawalRates.ts
+++ b/features/withdrawals/hooks/useWithdrawalRates.ts
@@ -45,45 +45,6 @@ const calculateRateReceive = (
   return { rate, toReceive };
 };
 
-type OneInchQuotePartial = {
-  toAmount: string;
-};
-
-const getOneInchRate: getRate = async (amount, token) => {
-  let rateInfo: rateCalculationResult | null;
-  try {
-    if (amount.isZero() || amount.isNegative()) {
-      return {
-        name: '1inch',
-        rate: 0,
-        toReceive: BigNumber.from(0),
-      };
-    }
-    const capped_amount = amount;
-    const api = `https://api-lido.1inch.io/v5.2/1/quote`;
-    const query = new URLSearchParams({
-      src: getTokenAddress(CHAINS.Mainnet, token),
-      dst: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
-      amount: amount.toString(),
-    });
-    const url = `${api}?${query.toString()}`;
-    const data: OneInchQuotePartial =
-      await standardFetcher<OneInchQuotePartial>(url);
-    rateInfo = calculateRateReceive(
-      amount,
-      capped_amount,
-      BigNumber.from(data.toAmount),
-    );
-  } catch {
-    rateInfo = null;
-  }
-  return {
-    name: '1inch',
-    rate: rateInfo?.rate ?? null,
-    toReceive: rateInfo?.toReceive ?? null,
-  };
-};
-
 type ParaSwapPriceResponsePartial = {
   priceRoute: {
     srcAmount: string;
@@ -194,7 +155,6 @@ const getWithdrawalRates = async ({
   token,
 }: getWithdrawalRatesParams): Promise<getWithdrawalRatesResult> => {
   const rates = await Promise.all([
-    getOneInchRate(amount, token),
     getParaSwapRate(amount, token),
     getCowSwapRate(amount, token),
   ]);

--- a/features/withdrawals/request/form/options/dex-options.tsx
+++ b/features/withdrawals/request/form/options/dex-options.tsx
@@ -16,13 +16,12 @@ import {
   DexOptionsContainer,
   DexOptionAmount,
   InlineLoaderSmall,
-  OneInchIcon,
   ParaSwapIcon,
   CowSwapIcon,
   DexOptionLoader,
 } from './styles';
 
-const placeholder = Array.from<null>({ length: 3 }).fill(null);
+const placeholder = Array.from<null>({ length: 2 }).fill(null);
 
 const dexInfo: {
   [key: string]: {
@@ -32,17 +31,6 @@ const dexInfo: {
     link: (amount: BigNumber, token: TOKENS.STETH | TOKENS.WSTETH) => string;
   };
 } = {
-  '1inch': {
-    title: '1inch',
-    icon: <OneInchIcon />,
-    onClickGoTo: () => {
-      trackMatomoEvent(MATOMO_CLICK_EVENTS_TYPES.withdrawalGoTo1inch);
-    },
-    link: (amount, token) =>
-      `https://app.1inch.io/#/1/simple/swap/${
-        token == TOKENS.STETH ? 'stETH' : 'wstETH'
-      }/ETH?sourceTokenAmount=${formatEther(amount)}`,
-  },
   paraswap: {
     title: 'ParaSwap',
     icon: <ParaSwapIcon />,

--- a/features/withdrawals/request/form/options/options-picker.tsx
+++ b/features/withdrawals/request/form/options/options-picker.tsx
@@ -10,7 +10,6 @@ import {
   InlineLoaderSmall,
   LidoIcon,
   CowSwapIcon,
-  OneInchIcon,
   ParaSwapIcon,
   OptionsPickerButton,
   OptionsPickerContainer,
@@ -79,7 +78,6 @@ const DexButton: React.FC<OptionButtonProps> = ({ isActive, onClick }) => {
       <OptionsPickerRow>
         <OptionsPickerLabel>Use aggregators</OptionsPickerLabel>
         <OptionsPickerIcons>
-          <OneInchIcon />
           <CowSwapIcon />
           <ParaSwapIcon />
         </OptionsPickerIcons>


### PR DESCRIPTION
### Description

Removes 1inch dex from withdrawals list

### Demo
<img width="777" alt="image" src="https://github.com/lidofinance/ethereum-staking-widget/assets/3705803/83e4f3dc-4953-47ea-b68d-63e4df8ee253">


### Code review notes

Just code removal

### Testing notes

Only withdrawals page is affected.

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
