### PR TITLE
Feature/si 1095 revert 1inch to withdrawals page

### DIFF
--- a/features/withdrawals/request/form/options/dex-options.tsx
+++ b/features/withdrawals/request/form/options/dex-options.tsx
@@ -127,7 +127,7 @@ export const DexOptions: React.FC<
         ? placeholder.map((_, i) => <DexOptionLoader key={i} />)
         : data?.map(({ name, toReceive, rate }) => {
             const dex = dexInfo[name];
-            if (!dex || !rate) return null;
+            if (!dex || (amount.gt('0') && !rate)) return null;
             return (
               <DexOption
                 title={dex.title}

--- a/features/withdrawals/request/form/options/dex-options.tsx
+++ b/features/withdrawals/request/form/options/dex-options.tsx
@@ -127,7 +127,7 @@ export const DexOptions: React.FC<
         ? placeholder.map((_, i) => <DexOptionLoader key={i} />)
         : data?.map(({ name, toReceive, rate }) => {
             const dex = dexInfo[name];
-            if (!dex) return null;
+            if (!dex || !rate) return null;
             return (
               <DexOption
                 title={dex.title}


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

Hiding dex option on withdrawal request form if rate data is not fetchable.

### Demo

<img width="573" alt="image" src="https://github.com/lidofinance/ethereum-staking-widget/assets/7289992/6353a077-8421-41e6-a700-a4d4e2a08a9d">

### Checklist:

- [x] Checked the changes locally.
