### PR TITLE
fix(cors): correct a api urls in ETH widget IPFS mode

### DIFF
--- a/features/home/one-inch-info/one-inch-info.tsx
+++ b/features/home/one-inch-info/one-inch-info.tsx
@@ -24,7 +24,7 @@ const ONE_INCH_RATE_LIMIT = 1.004;
 export const OneInchInfo: FC = () => {
   const linkProps = use1inchLinkProps();
 
-  const apiOneInchRatePath = 'api/oneinch-rate?token=eth';
+  const apiOneInchRatePath = 'api/oneinch-rate/?token=eth';
   const { data, initialLoading } = useLidoSWR<{ rate: number }>(
     dynamics.ipfsMode
       ? `${dynamics.widgetApiBasePathForIpfs}/${apiOneInchRatePath}`

--- a/features/rewards/fetchers/requesters/json/backend.ts
+++ b/features/rewards/fetchers/requesters/json/backend.ts
@@ -1,3 +1,5 @@
+import { dynamics } from 'config';
+
 export type BackendQuery = {
   address: string;
   currency?: string;
@@ -12,7 +14,11 @@ export const backendRequest = async (query: BackendQuery) => {
 
   Object.entries(query).forEach(([k, v]) => params.append(k, v.toString()));
 
-  const requested = await fetch(`/api/rewards?${params.toString()}`);
+  const apiRewardsPath = `/api/rewards/?${params.toString()}`;
+  const apiRewardsUrl = dynamics.ipfsMode
+    ? `${dynamics.widgetApiBasePathForIpfs}${apiRewardsPath}`
+    : apiRewardsPath;
+  const requested = await fetch(apiRewardsUrl);
 
   if (!requested.ok) {
     const responded = await requested.json();

--- a/features/rewards/hooks/useRewardsDataLoad.ts
+++ b/features/rewards/hooks/useRewardsDataLoad.ts
@@ -1,5 +1,6 @@
-import { Backend } from 'features/rewards/types';
 import { useEffect, useRef } from 'react';
+import { Backend } from 'features/rewards/types';
+import { dynamics } from 'config';
 import { useLidoSWR } from 'shared/hooks';
 import { swrAbortableMiddleware } from 'utils';
 
@@ -43,8 +44,14 @@ export const useRewardsDataLoad: UseRewardsDataLoad = (props) => {
   Object.entries(requestOptions).forEach(([k, v]) =>
     params.append(k, v.toString()),
   );
+
+  const apiRewardsPath = `/api/rewards/?${params.toString()}`;
+  const apiRewardsUrl = dynamics.ipfsMode
+    ? `${dynamics.widgetApiBasePathForIpfs}${apiRewardsPath}`
+    : apiRewardsPath;
+
   const { data, ...rest } = useLidoSWR<Backend>(
-    address ? `/api/rewards?${params.toString()}` : null,
+    address ? apiRewardsUrl : null,
     {
       shouldRetryOnError: false,
       revalidateOnFocus: false,

--- a/features/withdrawals/hooks/useWithdrawalRates.ts
+++ b/features/withdrawals/hooks/useWithdrawalRates.ts
@@ -60,7 +60,7 @@ const getOneInchRate: GetRateType = async (amount, token) => {
       };
     }
 
-    const apiOneInchRatePath = `api/oneinch-rate?token=${token}`;
+    const apiOneInchRatePath = `api/oneinch-rate/?token=${token}`;
     const respData = await standardFetcher<{ rate: string }>(
       dynamics.ipfsMode
         ? `${dynamics.widgetApiBasePathForIpfs}/${apiOneInchRatePath}`

--- a/features/withdrawals/request/form/options/dex-options.tsx
+++ b/features/withdrawals/request/form/options/dex-options.tsx
@@ -99,7 +99,7 @@ const DexOption: React.FC<DexOptionProps> = ({
         Go to {title}
       </DexOptionBlockLink>
       <DexOptionAmount>
-        {loading && <InlineLoaderSmall />}
+        {loading && !toReceive && <InlineLoaderSmall />}
         {toReceive ? (
           <FormatToken
             approx

--- a/shared/hooks/useLidoStats.ts
+++ b/shared/hooks/useLidoStats.ts
@@ -21,7 +21,7 @@ export const useLidoStats = (): {
   initialLoading: boolean;
 } => {
   const { chainId } = useSDK();
-  const apiShortLidoStatsPath = `api/short-lido-stats?chainId=${chainId}`;
+  const apiShortLidoStatsPath = `api/short-lido-stats/?chainId=${chainId}`;
   const lidoStats = useLidoSWR<ResponseData>(
     dynamics.ipfsMode
       ? `${dynamics.widgetApiBasePathForIpfs}/${apiShortLidoStatsPath}`


### PR DESCRIPTION
### Description

Fix CORS ('cause it have been redirects to urls with `/` at end):
- correct a `api/oneinch-rate/` url in ETH widget IPFS mode
- correct a `api/short-lido-stats/` url in ETH widget IPFS mode
- correct a `api/reward/` url in ETH widget IPFS mode


### Checklist:

- [X] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
