### PR TITLE
fix: missing split request validation case

### DIFF
--- a/features/withdrawals/request/request-form-context/__tests__/validators.test.ts
+++ b/features/withdrawals/request/request-form-context/__tests__/validators.test.ts
@@ -38,14 +38,16 @@ describe('tvlJokeValidate', () => {
   });
 });
 
-const amountPerRequest = bn(100);
+const maxAmountPerRequest = bn(100);
+const minAmountPerRequest = bn(10);
 const maxRequestCount = 100;
 describe('validateSplitRequests', () => {
   it('should split into 1 request', () => {
     const requests = validateSplitRequests(
       field,
       bn(10),
-      amountPerRequest,
+      maxAmountPerRequest,
+      minAmountPerRequest,
       maxRequestCount,
     );
     expect(requests).toHaveLength(1);
@@ -56,24 +58,39 @@ describe('validateSplitRequests', () => {
     const requests = validateSplitRequests(
       field,
       bn(150),
-      amountPerRequest,
+      maxAmountPerRequest,
+      minAmountPerRequest,
       maxRequestCount,
     );
     expect(requests).toHaveLength(2);
-    expect(requests[0].eq(amountPerRequest)).toBe(true);
-    expect(requests[1].eq(bn(150).sub(amountPerRequest))).toBe(true);
+    expect(requests[0].eq(maxAmountPerRequest)).toBe(true);
+    expect(requests[1].eq(bn(150).sub(maxAmountPerRequest))).toBe(true);
+  });
+
+  it('should split into 2(max+min) requests', () => {
+    const requests = validateSplitRequests(
+      field,
+      maxAmountPerRequest.add(minAmountPerRequest),
+      maxAmountPerRequest,
+      minAmountPerRequest,
+      maxRequestCount,
+    );
+    expect(requests).toHaveLength(2);
+    expect(requests[0].eq(maxAmountPerRequest)).toBe(true);
+    expect(requests[1].eq(minAmountPerRequest)).toBe(true);
   });
 
   it('should split into max requests', () => {
     const requests = validateSplitRequests(
       field,
-      amountPerRequest.mul(maxRequestCount),
-      amountPerRequest,
+      maxAmountPerRequest.mul(maxRequestCount),
+      maxAmountPerRequest,
+      minAmountPerRequest,
       maxRequestCount,
     );
     expect(requests).toHaveLength(maxRequestCount);
     requests.forEach((r) => {
-      expect(r.eq(amountPerRequest)).toBe(true);
+      expect(r.eq(maxAmountPerRequest)).toBe(true);
     });
   });
 
@@ -81,8 +98,9 @@ describe('validateSplitRequests', () => {
     const fn = () =>
       validateSplitRequests(
         field,
-        amountPerRequest.mul(maxRequestCount).add(1),
-        amountPerRequest,
+        maxAmountPerRequest.mul(maxRequestCount).add(1),
+        maxAmountPerRequest,
+        minAmountPerRequest,
         maxRequestCount,
       );
     expect(fn).toThrow();
@@ -95,6 +113,26 @@ describe('validateSplitRequests', () => {
       });
       expect(e).toHaveProperty('payload.requestCount');
       expect((e as any).payload.requestCount).toBe(maxRequestCount + 1);
+    }
+  });
+
+  it('should throw right error when cannot split because of left over', () => {
+    const fn = () =>
+      validateSplitRequests(
+        field,
+        maxAmountPerRequest.add(minAmountPerRequest).sub(1),
+        maxAmountPerRequest,
+        minAmountPerRequest,
+        maxRequestCount,
+      );
+    expect(fn).toThrow();
+    try {
+      fn();
+    } catch (e) {
+      expect(e).toMatchObject({
+        field,
+        type: ValidationSplitRequest.type,
+      });
     }
   });
 });

--- a/features/withdrawals/request/request-form-context/validators.ts
+++ b/features/withdrawals/request/request-form-context/validators.ts
@@ -60,14 +60,15 @@ const messageMaxAmount = (max: BigNumber, token: TokensWithdrawable) =>
 const validateSplitRequests = (
   field: string,
   amount: BigNumber,
-  amountPerRequest: BigNumber,
+  maxAmountPerRequest: BigNumber,
+  minAmountPerRequest: BigNumber,
   maxRequestCount: number,
 ): BigNumber[] => {
-  const maxAmount = amountPerRequest.mul(maxRequestCount);
+  const maxAmount = maxAmountPerRequest.mul(maxRequestCount);
 
-  const lastRequestAmountEther = amount.mod(amountPerRequest);
+  const lastRequestAmountEther = amount.mod(maxAmountPerRequest);
   const restCount = lastRequestAmountEther.gt(0) ? 1 : 0;
-  const requestCount = amount.div(amountPerRequest).toNumber() + restCount;
+  const requestCount = amount.div(maxAmountPerRequest).toNumber() + restCount;
 
   const isMoreThanMax = amount.gt(maxAmount);
   if (isMoreThanMax) {
@@ -78,8 +79,19 @@ const validateSplitRequests = (
     );
   }
 
+  if (restCount && lastRequestAmountEther.lt(minAmountPerRequest)) {
+    const difference = minAmountPerRequest.sub(lastRequestAmountEther);
+    throw new ValidationSplitRequest(
+      field,
+      `Cannot split into valid requests as last request would be less than minimal withdrawal amount. Add ${formatEther(
+        difference,
+      )} to withdrawal amount.`,
+      { requestCount },
+    );
+  }
+
   const requests = Array.from<BigNumber>({ length: requestCount }).fill(
-    amountPerRequest,
+    maxAmountPerRequest,
   );
   if (restCount) {
     requests[requestCount - 1] = lastRequestAmountEther;
@@ -169,6 +181,7 @@ export const RequestFormValidationResolver: Resolver<
       'amount',
       amount,
       maxAmountPerRequest,
+      minAmountPerRequest,
       maxRequestCount,
     );
     validationResults.requests = requests;

--- a/utils/__tests__/getErrorMessage.test.ts
+++ b/utils/__tests__/getErrorMessage.test.ts
@@ -18,7 +18,7 @@ describe('getErrorMessage', () => {
   });
 
   it('should return LIMIT_REACHED error message when error reason includes STAKE_LIMIT', () => {
-    const error = { reason: ['STAKE_LIMIT'] };
+    const error = { reason: 'STAKE_LIMIT' };
     expect(getErrorMessage(error)).toBe(ErrorMessage.LIMIT_REACHED);
   });
 
@@ -47,7 +47,7 @@ describe('extractCodeFromError', () => {
   });
 
   test('extracts error code from reason array', () => {
-    const error = { reason: ['STAKE_LIMIT'] };
+    const error = { reason: 'STAKE_LIMIT' };
     expect(extractCodeFromError(error)).toBe('LIMIT_REACHED');
   });
 


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

Add missing split request validation case when last request could be less than minimal withdraw amount. Added tests for that case.


### Demo
<img width="764" alt="image" src="https://github.com/lidofinance/ethereum-staking-widget/assets/3705803/37edbdf6-6778-4b3e-8d37-a2bba04d4b65">
### Code review notes

<!--- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

<!--- List all possible edge cases and how to test them. -->

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
