### PR TITLE
style: mobile mode for reward history filters

### DIFF
--- a/features/rewards/components/rewardsListContent/RewardsListContent.tsx
+++ b/features/rewards/components/rewardsListContent/RewardsListContent.tsx
@@ -5,7 +5,11 @@ import { ErrorBlockNoSteth } from 'features/rewards/components/errorBlocks/Error
 
 import { RewardsListsEmpty } from './RewardsListsEmpty';
 import { RewardsListErrorMessage } from './RewardsListErrorMessage';
-import { LoaderWrapper, TableWrapperStyle } from './RewardsListContentStyles';
+import {
+  LoaderWrapper,
+  TableWrapperStyle,
+  ErrorWrapper,
+} from './RewardsListContentStyles';
 import { RewardsTable } from 'features/rewards/components/rewardsTable';
 
 export const RewardsListContent: FC = () => {
@@ -31,7 +35,13 @@ export const RewardsListContent: FC = () => {
       </>
     );
   }
-  if (error) return <RewardsListErrorMessage error={error} />;
+  if (error) {
+    return (
+      <ErrorWrapper>
+        <RewardsListErrorMessage error={error} />
+      </ErrorWrapper>
+    );
+  }
   if (data && data.events.length === 0) return <ErrorBlockNoSteth />;
 
   return (

--- a/features/rewards/components/rewardsListContent/RewardsListContentStyles.ts
+++ b/features/rewards/components/rewardsListContent/RewardsListContentStyles.ts
@@ -8,3 +8,7 @@ export const LoaderWrapper = styled.div`
 export const TableWrapperStyle = styled.div`
   margin-top: 20px;
 `;
+
+export const ErrorWrapper = styled.div`
+  word-wrap: break-word;
+`;

--- a/features/rewards/components/rewardsListHeader/styles.ts
+++ b/features/rewards/components/rewardsListHeader/styles.ts
@@ -10,7 +10,7 @@ export const RewardsListHeaderStyle = styled.div`
 
   color: ${({ theme }) => theme.colors.secondary};
 
-  ${({ theme }) => theme.mediaQueries.md} {
+  ${({ theme }) => theme.mediaQueries.lg} {
     flex-direction: column;
     height: auto;
     align-items: initial;
@@ -28,6 +28,7 @@ export const LeftOptionsWrapper = styled.div`
   flex-wrap: wrap;
   margin-right: auto;
   gap: 16px;
+
   ${({ theme }) => theme.mediaQueries.lg} {
     order: 3;
     margin-right: 0;
@@ -35,6 +36,10 @@ export const LeftOptionsWrapper = styled.div`
     & > * {
       flex: 1 0;
     }
+  }
+
+  ${({ theme }) => theme.mediaQueries.md} {
+    flex-direction: column;
   }
 `;
 


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

Reward history filters fixed on mobile layout

### Demo

<img width="367" alt="image" src="https://github.com/lidofinance/ethereum-staking-widget/assets/7289992/5fbce81b-eac5-4b34-b1f6-1ec72d014805">

### Checklist:

- [x] Checked the changes locally.
