### PR TITLE
Fix stake modal balance token

### DIFF
--- a/features/stake/stake-form/stake-form-context/stake-form-context.tsx
+++ b/features/stake/stake-form/stake-form-context/stake-form-context.tsx
@@ -54,7 +54,7 @@ export const useStakeFormData = () => {
 };
 
 const useStakeFormNetworkData = (): StakeFormNetworkData => {
-  const { update: updateStethBalance } = useSTETHBalance();
+  const { data: stethBalance, update: updateStethBalance } = useSTETHBalance();
   const { isMultisig, isLoading: isMultisigLoading } = useIsMultisig();
   const gasLimit = useStethSubmitGasLimit();
   const maxGasFee = useMaxGasPrice();
@@ -106,7 +106,7 @@ const useStakeFormNetworkData = (): StakeFormNetworkData => {
   ]);
 
   return {
-    etherBalance,
+    stethBalance,
     stakeableEther,
     stakingLimitInfo,
     gasCost,

--- a/features/stake/stake-form/stake-form-context/types.ts
+++ b/features/stake/stake-form/stake-form-context/types.ts
@@ -10,7 +10,7 @@ export type StakeFormInput = {
 };
 
 export type StakeFormNetworkData = {
-  etherBalance?: BigNumber;
+  stethBalance?: BigNumber;
   stakeableEther?: BigNumber;
   stakingLimitInfo?: StakeLimitFullInfo;
   gasLimit?: BigNumber;

--- a/features/stake/stake-form/stake-form-modal.tsx
+++ b/features/stake/stake-form/stake-form-modal.tsx
@@ -6,7 +6,7 @@ import { TX_OPERATION as TX_OPERATION_LEGACY } from 'shared/components/tx-stage-
 import { useStakeFormData } from './stake-form-context';
 
 export const StakeFormModal = () => {
-  const { etherBalance } = useStakeFormData();
+  const { stethBalance } = useStakeFormData();
   const {
     dispatchModalState,
     onRetry,
@@ -28,7 +28,7 @@ export const StakeFormModal = () => {
       amountToken="ETH"
       willReceiveAmount={amount ? formatBalance(amount) : undefined}
       willReceiveAmountToken="stETH"
-      balance={etherBalance}
+      balance={stethBalance}
       balanceToken="stETH"
       failedText={errorText}
       onRetry={() => onRetry?.()}


### PR DESCRIPTION
### Description

Fixed incorrect balance passthrough for stake success modal. ETH balance was passed instead of stETH.


### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
