### PR TITLE
fix: navlink active for home page

### DIFF
--- a/shared/components/layout/header/components/navigation/navigation.tsx
+++ b/shared/components/layout/header/components/navigation/navigation.tsx
@@ -7,6 +7,7 @@ import {
   WITHDRAWALS_REQUEST_PATH,
   WITHDRAWALS_CLAIM_PATH,
   REWARDS_PATH,
+  getPathWithoutFirstSlash,
 } from 'config/urls';
 import { LocalLink } from 'shared/components/local-link';
 import { useRouterPath } from 'shared/hooks/use-router-path';
@@ -50,7 +51,7 @@ export const Navigation: FC = memo(() => {
     <Nav>
       {routes.map(({ name, path, subPaths, icon }) => {
         const isActive =
-          pathnameWithoutQuery === path ||
+          pathnameWithoutQuery === getPathWithoutFirstSlash(path) ||
           (path.length > 1 && pathnameWithoutQuery.startsWith(path)) ||
           (Array.isArray(subPaths) &&
             subPaths?.indexOf(pathnameWithoutQuery) > -1);


### PR DESCRIPTION
### Description
Fixed active navlink

<img width="1008" alt="image" src="https://github.com/lidofinance/ethereum-staking-widget/assets/3705803/23eece44-1458-4970-97f2-d3120fc75168">

### Testing notes
Needs recheck for infra/ipfs

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
