### PR TITLE
refactor(SwitchItem): use transient props for `active`

### DIFF
--- a/shared/components/switch/styles.tsx
+++ b/shared/components/switch/styles.tsx
@@ -33,10 +33,10 @@ export const Handle = styled.div<{ $checked: boolean }>`
 // Not wrapping <a> inside <a> in IPFS mode
 // Also avoid problems with migrate to Next v13
 // see: https://nextjs.org/docs/app/building-your-application/upgrading/app-router-migration#link-component
-export const SwitchItemStyled = styled(LocalLink)<{ active: boolean }>`
+export const SwitchItemStyled = styled(LocalLink)<{ $active: boolean }>`
   z-index: 2;
   margin: 0;
-  opacity: ${({ active }) => (active ? 1 : 0.5)};
+  opacity: ${({ $active }) => ($active ? 1 : 0.5)};
   transition: opacity 0.3s ease;
   line-height: 1.6em;
   text-decoration: none;

--- a/shared/components/switch/switch-item.tsx
+++ b/shared/components/switch/switch-item.tsx
@@ -7,5 +7,5 @@ export const SwitchItem: SwitchItemComponent = (props) => {
   const { href, ...rest } = props;
   const active = useCompareWithRouterPath(href ?? '');
 
-  return <SwitchItemStyled href={href ?? ''} active={active} {...rest} />;
+  return <SwitchItemStyled href={href ?? ''} $active={active} {...rest} />;
 };


### PR DESCRIPTION
### Description

Fix warning 'Received  `true` for a non-boolean attribute `active` ...'.

### Code review notes

Check `WRAP` and `WITHDRAWALS` pages.

### Checklist:

- [x] Checked the changes locally.
- [x] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
