### PR TITLE
fix: matomo event name of l2 banner link on unwrap page

### DIFF
--- a/features/wsteth/unwrap/unwrap-form/unwrap-form.tsx
+++ b/features/wsteth/unwrap/unwrap-form/unwrap-form.tsx
@@ -10,6 +10,7 @@ import { UnwrapFormProvider } from '../unwrap-form-context';
 import { FormController } from 'shared/hook-form/form-controller/form-controller';
 import { TokenAmountInputUnwrap } from '../unwrap-form-controls/amount-input-unwrap';
 import { SubmitButtonUnwrap } from '../unwrap-form-controls/submit-button-unwrap';
+import { MATOMO_CLICK_EVENTS } from 'config';
 
 export const UnwrapForm: FC = memo(() => {
   return (
@@ -22,7 +23,7 @@ export const UnwrapForm: FC = memo(() => {
             </InputWrap>
             <SubmitButtonUnwrap />
           </FormController>
-          <L2Wsteth />
+          <L2Wsteth matomoEventLink={MATOMO_CLICK_EVENTS.l2BannerUnwrap} />
           <UnwrapStats />
           <UnwrapFormTxModal />
         </WrapBlock>

--- a/features/wsteth/wrap/wrap-form/wrap-form.tsx
+++ b/features/wsteth/wrap/wrap-form/wrap-form.tsx
@@ -12,6 +12,7 @@ import { SubmitButtonWrap } from '../wrap-form-controls/submit-button-wrap';
 import { TransactionModalProvider } from 'shared/transaction-modal/transaction-modal-context';
 import { InputGroupHookForm } from 'shared/hook-form/controls/input-group-hook-form';
 import { L2Wsteth } from 'shared/banners/l2-wsteth';
+import { MATOMO_CLICK_EVENTS } from 'config';
 
 export const WrapForm: React.FC = memo(() => {
   return (
@@ -25,7 +26,7 @@ export const WrapForm: React.FC = memo(() => {
             </InputGroupHookForm>
             <SubmitButtonWrap />
           </FormControllerWrap>
-          <L2Wsteth />
+          <L2Wsteth matomoEventLink={MATOMO_CLICK_EVENTS.l2BannerWrap} />
           <WrapFormStats />
           <WrapFormTxModal />
         </WrapBlock>

--- a/shared/banners/l2-wsteth/l2-wsteth.tsx
+++ b/shared/banners/l2-wsteth/l2-wsteth.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import {
   Banner,
   L2Icons,
@@ -9,9 +10,17 @@ import { L2_DISCOVERY_LINK } from '../l2-banner';
 import { MATOMO_CLICK_EVENTS } from 'config';
 import { trackEvent } from '@lidofinance/analytics-matomo';
 
-const linkClickHandler = () => trackEvent(...MATOMO_CLICK_EVENTS.l2BannerWrap);
+type L2WstethProps = {
+  matomoEventLink:
+    | typeof MATOMO_CLICK_EVENTS.l2BannerWrap
+    | typeof MATOMO_CLICK_EVENTS.l2BannerUnwrap;
+};
 
-export const L2Wsteth = () => {
+export const L2Wsteth = ({ matomoEventLink }: L2WstethProps) => {
+  const linkClickHandler = useCallback(
+    () => trackEvent(...matomoEventLink),
+    [matomoEventLink],
+  );
   return (
     <Banner data-testid="L2wstETHbanner">
       <L2Icons />


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

"Learn more" link at the L2 banner on "Unwrap" page uses `eth_widget_banner_l2_unwrap`

### Checklist:

- [x] Checked the changes locally.
- [x] Created / updated analytics events.
