### PR TITLE
fix: token number format in stage modal

### DIFF
--- a/features/stake/stake-form/stake-form-modal.tsx
+++ b/features/stake/stake-form/stake-form-modal.tsx
@@ -24,9 +24,9 @@ export const StakeFormModal = () => {
       txStage={convertTxStageToLegacy(txStage)}
       txOperation={TX_OPERATION_LEGACY.STAKING}
       txHash={txHash}
-      amount={amount ? formatBalance(amount) : ''}
+      amount={amount ? formatBalance(amount, 18) : ''}
       amountToken="ETH"
-      willReceiveAmount={amount ? formatBalance(amount) : undefined}
+      willReceiveAmount={amount ? formatBalance(amount, 18) : undefined}
       willReceiveAmountToken="stETH"
       balance={stethBalance}
       balanceToken="stETH"

--- a/features/stake/stake-form/stake-form-modal.tsx
+++ b/features/stake/stake-form/stake-form-modal.tsx
@@ -1,7 +1,6 @@
 import { useTransactionModal } from 'shared/transaction-modal';
 import { convertTxStageToLegacy } from 'features/wsteth/shared/utils/convertTxModalStageToLegacy';
 import { TxStageModal } from 'shared/components';
-import { formatBalance } from 'utils';
 import { TX_OPERATION as TX_OPERATION_LEGACY } from 'shared/components/tx-stage-modal';
 import { useStakeFormData } from './stake-form-context';
 
@@ -24,9 +23,9 @@ export const StakeFormModal = () => {
       txStage={convertTxStageToLegacy(txStage)}
       txOperation={TX_OPERATION_LEGACY.STAKING}
       txHash={txHash}
-      amount={amount ? formatBalance(amount, 18) : ''}
+      amount={amount}
       amountToken="ETH"
-      willReceiveAmount={amount ? formatBalance(amount, 18) : undefined}
+      willReceiveAmount={amount}
       willReceiveAmountToken="stETH"
       balance={stethBalance}
       balanceToken="stETH"

--- a/features/withdrawals/claim/tx-modal/tx-claim-modal.tsx
+++ b/features/withdrawals/claim/tx-modal/tx-claim-modal.tsx
@@ -14,6 +14,7 @@ import {
   trackMatomoEvent,
   MATOMO_CLICK_EVENTS_TYPES,
 } from 'config/trackMatomoEvent';
+import { withOptionaTooltip } from 'shared/components/tx-stage-modal/text-utils';
 
 export const TxClaimModal = () => {
   const {
@@ -26,21 +27,26 @@ export const TxClaimModal = () => {
     dispatchModalState,
   } = useTransactionModal();
 
-  const amountAsString = useMemo(
-    () => (amount ? formatBalance(amount, 4) : ''),
-    [amount],
-  );
-
-  const successDescription = 'Claiming operation was successful';
-  const successTitle = `${amountAsString} ETH has been claimed`;
-
-  const pendingDescription = 'Awaiting block confirmation';
-  const pendingTitle = `You are now claiming ${amountAsString} ETH`;
-
-  const signDescription = 'Processing your request';
-  const signTitle = `You are now claiming ${amountAsString} ETH`;
-
   const content = useMemo(() => {
+    const amountDisplay = amount
+      ? formatBalance(amount, 4, { adaptive: true, elipsis: true })
+      : '';
+    const amountFull = amount ? formatBalance(amount, 18) : '';
+    const amountEl = withOptionaTooltip(
+      amountDisplay,
+      amountFull,
+      <span data-testid="sendAmount">{amountDisplay}</span>,
+    );
+
+    const successDescription = 'Claiming operation was successful';
+    const successTitle = <>{amountEl} ETH has been claimed</>;
+
+    const pendingDescription = 'Awaiting block confirmation';
+    const pendingTitle = <>You are now claiming {amountEl} ETH</>;
+
+    const signDescription = 'Processing your request';
+    const signTitle = <>You are now claiming {amountEl} ETH</>;
+
     switch (txStage) {
       case TX_STAGE.SIGN:
         return <TxStageSign description={signDescription} title={signTitle} />;
@@ -74,15 +80,7 @@ export const TxClaimModal = () => {
       default:
         return null;
     }
-  }, [
-    errorText,
-    pendingTitle,
-    signTitle,
-    onRetry,
-    successTitle,
-    txHash,
-    txStage,
-  ]);
+  }, [amount, txStage, txHash, errorText, onRetry]);
 
   return (
     <TxStageModal

--- a/features/withdrawals/request/tx-modal/tx-request-modal.tsx
+++ b/features/withdrawals/request/tx-modal/tx-request-modal.tsx
@@ -18,6 +18,7 @@ import {
 
 import { getTokenDisplayName } from 'utils/getTokenDisplayName';
 import { TxRequestStageSuccess } from './tx-request-stage-success';
+import { withOptionaTooltip } from 'shared/components/tx-stage-modal/text-utils';
 
 export const TxRequestModal = () => {
   const modalState = useTransactionModal();
@@ -35,7 +36,16 @@ export const TxRequestModal = () => {
     } = modalState;
 
     const tokenName = token ? getTokenDisplayName(token) : '';
-    const amountAsString = requestAmount ? formatBalance(requestAmount, 4) : '';
+
+    const amountDisplay = requestAmount
+      ? formatBalance(requestAmount, 4, { adaptive: true, elipsis: true })
+      : '';
+    const amountFull = requestAmount ? formatBalance(requestAmount, 18) : '';
+    const amountEl = withOptionaTooltip(
+      amountDisplay,
+      amountFull,
+      <span data-testid="sendAmount">{amountDisplay}</span>,
+    );
 
     // if more dialogs are added convert to switch on dialog type
     if (dialog)
@@ -53,11 +63,27 @@ export const TxRequestModal = () => {
         />
       );
 
-    const approvingTitle = `You are now approving ${amountAsString} ${tokenName}`;
-    const approvingSingDescription = `Approving for ${amountAsString} ${tokenName}`;
+    const approvingTitle = (
+      <>
+        You are now approving {amountEl} {tokenName}
+      </>
+    );
+    const approvingSingDescription = (
+      <>
+        Approving for {amountEl} {tokenName}
+      </>
+    );
 
-    const withdrawalTitle = `You are requesting withdrawal for ${amountAsString} ${tokenName}`;
-    const withdrawalSingDescription = `Requesting withdrawal for ${amountAsString} ${tokenName}`;
+    const withdrawalTitle = (
+      <>
+        You are requesting withdrawal for {amountEl} {tokenName}
+      </>
+    );
+    const withdrawalSingDescription = (
+      <>
+        Requesting withdrawal for {amountEl} {tokenName}
+      </>
+    );
 
     const renderSign = () => {
       switch (txOperation) {
@@ -116,7 +142,7 @@ export const TxRequestModal = () => {
           <TxRequestStageSuccess
             txHash={txHash}
             tokenName={tokenName}
-            amountAsString={amountAsString}
+            amount={amountEl}
           />
         );
       case TX_STAGE.SUCCESS_MULTISIG:

--- a/features/withdrawals/request/tx-modal/tx-request-stage-success.tsx
+++ b/features/withdrawals/request/tx-modal/tx-request-stage-success.tsx
@@ -26,13 +26,13 @@ const LINK_ADD_NFT_GUIDE =
 type TxRequestStageSuccessProps = {
   txHash: string | null;
   tokenName: string;
-  amountAsString: string;
+  amount: React.ReactNode;
 };
 
 export const TxRequestStageSuccess = ({
   txHash,
   tokenName,
-  amountAsString,
+  amount,
 }: TxRequestStageSuccessProps) => {
   const { providerWeb3 } = useSDK();
   const { data: nftData, initialLoading: nftLoading } =
@@ -43,7 +43,7 @@ export const TxRequestStageSuccess = ({
 
   const successDescription = (
     <span>
-      Withdrawal request for {amountAsString} {tokenName} has been sent.
+      Withdrawal request for {amount} {tokenName} has been sent.
       <br />
       Check <LocalLink href={WITHDRAWALS_CLAIM_PATH}>Claim tab</LocalLink> to
       view your withdrawal requests or view your transaction on{' '}

--- a/features/withdrawals/shared/tx-stage-modal/stages/tx-stage-pending.tsx
+++ b/features/withdrawals/shared/tx-stage-modal/stages/tx-stage-pending.tsx
@@ -7,8 +7,8 @@ import { getStageIcon } from './icons';
 import { TX_STAGE } from 'shared/transaction-modal';
 
 type TxStagePendingProps = {
-  description: string;
-  title: string;
+  description: React.ReactNode;
+  title: React.ReactNode;
   txHash: string | null;
 };
 

--- a/features/withdrawals/shared/tx-stage-modal/stages/tx-stage-sign.tsx
+++ b/features/withdrawals/shared/tx-stage-modal/stages/tx-stage-sign.tsx
@@ -6,8 +6,8 @@ import { getStageIcon } from './icons';
 import { TX_STAGE } from 'shared/transaction-modal';
 
 type TxStageSignProps = {
-  description: string;
-  title: string;
+  description: React.ReactNode;
+  title: React.ReactNode;
 };
 
 export const TxStageSign: FC<TxStageSignProps> = (props) => {

--- a/features/withdrawals/shared/tx-stage-modal/stages/tx-stage-success.tsx
+++ b/features/withdrawals/shared/tx-stage-modal/stages/tx-stage-success.tsx
@@ -9,7 +9,7 @@ import { TX_STAGE } from 'shared/transaction-modal';
 type TxStageSuccessProps = {
   txHash: string | null;
   description: React.ReactNode;
-  title: string;
+  title: React.ReactNode;
   showEtherscan?: boolean;
   onClickEtherscan?: React.MouseEventHandler<HTMLAnchorElement>;
 };

--- a/features/wsteth/unwrap/unwrap-form/unwrap-form-tx-modal.tsx
+++ b/features/wsteth/unwrap/unwrap-form/unwrap-form-tx-modal.tsx
@@ -1,7 +1,6 @@
 import { useTransactionModal } from 'shared/transaction-modal';
 import { convertTxStageToLegacy } from 'features/wsteth/shared/utils/convertTxModalStageToLegacy';
 import { TxStageModal } from 'shared/components';
-import { formatBalance } from 'utils';
 import { useUnwrapFormData } from '../unwrap-form-context';
 import { TX_OPERATION as TX_OPERATION_LEGACY } from 'shared/components/tx-stage-modal';
 
@@ -16,9 +15,9 @@ export const UnwrapFormTxModal = () => {
       txStage={convertTxStageToLegacy(modalState.txStage)}
       txOperation={TX_OPERATION_LEGACY.UNWRAPPING}
       txHash={modalState.txHash}
-      amount={modalState.amount ? formatBalance(modalState.amount, 18) : ''}
+      amount={modalState.amount}
       amountToken="wstETH"
-      willReceiveAmount={formatBalance(willReceiveStETH, 18)}
+      willReceiveAmount={willReceiveStETH}
       willReceiveAmountToken="stETH"
       balance={stethBalance}
       balanceToken="stETH"

--- a/features/wsteth/unwrap/unwrap-form/unwrap-form-tx-modal.tsx
+++ b/features/wsteth/unwrap/unwrap-form/unwrap-form-tx-modal.tsx
@@ -16,9 +16,9 @@ export const UnwrapFormTxModal = () => {
       txStage={convertTxStageToLegacy(modalState.txStage)}
       txOperation={TX_OPERATION_LEGACY.UNWRAPPING}
       txHash={modalState.txHash}
-      amount={modalState.amount ? formatBalance(modalState.amount) : ''}
+      amount={modalState.amount ? formatBalance(modalState.amount, 18) : ''}
       amountToken="wstETH"
-      willReceiveAmount={formatBalance(willReceiveStETH)}
+      willReceiveAmount={formatBalance(willReceiveStETH, 18)}
       willReceiveAmountToken="stETH"
       balance={stethBalance}
       balanceToken="stETH"

--- a/features/wsteth/wrap/wrap-form/wrap-form-tx-modal.tsx
+++ b/features/wsteth/wrap/wrap-form/wrap-form-tx-modal.tsx
@@ -2,7 +2,6 @@ import { useTransactionModal } from 'shared/transaction-modal/transaction-modal-
 import { useFormContext } from 'react-hook-form';
 import { useWrapFormData, WrapFormInputType } from '../wrap-form-context';
 
-import { formatBalance } from 'utils';
 import { TxStageModal } from 'shared/components';
 
 import { getTokenDisplayName } from 'utils/getTokenDisplayName';
@@ -33,9 +32,9 @@ export const WrapFormTxModal = () => {
       txStage={convertTxStageToLegacy(txStage)}
       txOperation={convertTxStageToLegacyTxOperationWrap(txOperation)}
       txHash={txHash}
-      amount={amount ? formatBalance(amount, 18) : ''}
+      amount={amount}
       amountToken={getTokenDisplayName(token)}
-      willReceiveAmount={formatBalance(willReceiveWsteth, 18)}
+      willReceiveAmount={willReceiveWsteth}
       willReceiveAmountToken="wstETH"
       balance={wstethBalance}
       balanceToken={'wstETH'}

--- a/features/wsteth/wrap/wrap-form/wrap-form-tx-modal.tsx
+++ b/features/wsteth/wrap/wrap-form/wrap-form-tx-modal.tsx
@@ -33,9 +33,9 @@ export const WrapFormTxModal = () => {
       txStage={convertTxStageToLegacy(txStage)}
       txOperation={convertTxStageToLegacyTxOperationWrap(txOperation)}
       txHash={txHash}
-      amount={amount ? formatBalance(amount) : ''}
+      amount={amount ? formatBalance(amount, 18) : ''}
       amountToken={getTokenDisplayName(token)}
-      willReceiveAmount={formatBalance(willReceiveWsteth)}
+      willReceiveAmount={formatBalance(willReceiveWsteth, 18)}
       willReceiveAmountToken="wstETH"
       balance={wstethBalance}
       balanceToken={'wstETH'}

--- a/shared/components/tx-stage-modal/text-utils.tsx
+++ b/shared/components/tx-stage-modal/text-utils.tsx
@@ -15,12 +15,16 @@ export const withOptionaLineBreak = (text: string, el?: React.ReactNode) => {
 };
 
 // Wraps element with tooltip if it differs
-export const withOptionaTooltip = (text: string, tooltip?: string) => {
+export const withOptionaTooltip = (
+  text: string,
+  tooltip?: string,
+  el?: React.ReactNode,
+) => {
   return text === tooltip ? (
-    <>{text}</>
+    <>{el || text}</>
   ) : (
     <Tooltip placement="top" title={tooltip}>
-      <span>{text}</span>
+      <span>{el || text}</span>
     </Tooltip>
   );
 };

--- a/shared/components/tx-stage-modal/text-utils.tsx
+++ b/shared/components/tx-stage-modal/text-utils.tsx
@@ -1,15 +1,27 @@
 import { TX_OPERATION } from './types';
 import { TxLinkEtherscan } from '../tx-link-etherscan';
+import { Tooltip } from '@lidofinance/lido-ui';
 
 // Inserts new lines in front of long numbers so that the currency symbol remains on the same line
-export const withOptionaLineBreak = (text: string) => {
+export const withOptionaLineBreak = (text: string, el?: React.ReactNode) => {
   return text.length < 8 ? (
-    text
+    el || text
   ) : (
     <>
       <br />
-      {text}
+      {el || text}
     </>
+  );
+};
+
+// Wraps element with tooltip if it differs
+export const withOptionaTooltip = (text: string, tooltip?: string) => {
+  return text === tooltip ? (
+    <>{text}</>
+  ) : (
+    <Tooltip placement="top" title={tooltip}>
+      <span>{text}</span>
+    </Tooltip>
   );
 };
 

--- a/shared/components/tx-stage-modal/tx-stage-modal.tsx
+++ b/shared/components/tx-stage-modal/tx-stage-modal.tsx
@@ -5,7 +5,7 @@ import { use1inchLinkProps } from 'features/stake/hooks';
 import { TxLinkEtherscan } from 'shared/components/tx-link-etherscan';
 import { L2LowFee } from 'shared/banners';
 import { TxStageModalShape } from './tx-stage-modal-shape';
-import { ErrorMessage, formatBalance, formatBalanceString } from 'utils';
+import { ErrorMessage, formatBalance } from 'utils';
 import { ModalProps } from '@lidofinance/lido-ui';
 import {
   StylableLink,
@@ -76,8 +76,7 @@ export const TxStageModal = memo((props: TxStageModalProps) => {
   };
 
   const operationText = getOperationProcessingDisplayText(txOperation);
-  const amountString = formatBalanceString(amount, 4);
-  const amountWithBreak = withOptionaLineBreak(amountString);
+  const amountWithBreak = withOptionaLineBreak(amount);
 
   const [isRetryLoading, setRetryLoading] = useState(false);
   const retryResetTimerRef = useRef<NodeJS.Timeout | 0>(0);
@@ -110,11 +109,10 @@ export const TxStageModal = memo((props: TxStageModalProps) => {
         }
         description={
           <>
-            {operationText} {amountString} {amountToken}.{' '}
+            {operationText} {amount} {amountToken}.{' '}
             {txOperation !== TX_OPERATION.APPROVING && (
               <>
-                You will receive {formatBalanceString(willReceiveAmount, 4)}{' '}
-                {willReceiveAmountToken}
+                You will receive {willReceiveAmount} {willReceiveAmountToken}
               </>
             )}
           </>

--- a/shared/components/tx-stage-modal/tx-stage-modal.tsx
+++ b/shared/components/tx-stage-modal/tx-stage-modal.tsx
@@ -80,7 +80,11 @@ export const TxStageModal = memo((props: TxStageModalProps) => {
     ? formatBalance(amount, 4, { adaptive: true, elipsis: true })
     : '';
   const amountFull = amount ? formatBalance(amount, 18) : '';
-  const amountEl = withOptionaTooltip(amountDisplay, amountFull);
+  const amountEl = withOptionaTooltip(
+    amountDisplay,
+    amountFull,
+    <span data-testid="sendAmount">{amountDisplay}</span>,
+  );
 
   const willReceiveDisplay = willReceiveAmount
     ? formatBalance(willReceiveAmount, 4, { adaptive: true, elipsis: true })
@@ -91,6 +95,7 @@ export const TxStageModal = memo((props: TxStageModalProps) => {
   const willReceiveAmountEl = withOptionaTooltip(
     willReceiveDisplay,
     willReceiveFull,
+    <span data-testid="receiveAmount">{willReceiveDisplay}</span>,
   );
 
   const operationText = getOperationProcessingDisplayText(txOperation);

--- a/shared/components/tx-stage-modal/tx-stage-modal.tsx
+++ b/shared/components/tx-stage-modal/tx-stage-modal.tsx
@@ -21,6 +21,7 @@ import {
   withOptionaLineBreak,
   getOperationProcessingDisplayText,
   getSuccessText,
+  withOptionaTooltip,
 } from './text-utils';
 import { TX_STAGE, TX_OPERATION } from './types';
 import { TX_STAGE_MODAL_ICONS } from '../tx-stage-modal-content/icons';
@@ -28,9 +29,9 @@ import { TX_STAGE_MODAL_ICONS } from '../tx-stage-modal-content/icons';
 interface TxStageModalProps extends ModalProps {
   txStage: TX_STAGE;
   txOperation: TX_OPERATION;
-  amount: string;
+  amount: BigNumber | null;
   amountToken: string;
-  willReceiveAmount?: string;
+  willReceiveAmount?: BigNumber | null;
   willReceiveAmountToken?: string;
   txHash?: string | null;
   balance?: BigNumber;
@@ -47,7 +48,7 @@ export const TxStageModal = memo((props: TxStageModalProps) => {
     txHash,
     amount,
     amountToken,
-    willReceiveAmount,
+    willReceiveAmount = '',
     willReceiveAmountToken,
     balance,
     balanceToken,
@@ -75,8 +76,25 @@ export const TxStageModal = memo((props: TxStageModalProps) => {
     onClose: isCloseButtonHidden ? undefined : onClose,
   };
 
+  const amountDisplay = amount
+    ? formatBalance(amount, 4, { adaptive: true, elipsis: true })
+    : '';
+  const amountFull = amount ? formatBalance(amount, 18) : '';
+  const amountEl = withOptionaTooltip(amountDisplay, amountFull);
+
+  const willReceiveDisplay = willReceiveAmount
+    ? formatBalance(willReceiveAmount, 4, { adaptive: true, elipsis: true })
+    : '';
+  const willReceiveFull = willReceiveAmount
+    ? formatBalance(willReceiveAmount, 18)
+    : '';
+  const willReceiveAmountEl = withOptionaTooltip(
+    willReceiveDisplay,
+    willReceiveFull,
+  );
+
   const operationText = getOperationProcessingDisplayText(txOperation);
-  const amountWithBreak = withOptionaLineBreak(amount);
+  const amountWithBreak = withOptionaLineBreak(amountDisplay, amountEl);
 
   const [isRetryLoading, setRetryLoading] = useState(false);
   const retryResetTimerRef = useRef<NodeJS.Timeout | 0>(0);
@@ -109,10 +127,10 @@ export const TxStageModal = memo((props: TxStageModalProps) => {
         }
         description={
           <>
-            {operationText} {amount} {amountToken}.{' '}
+            {operationText} {amountEl} {amountToken}.{' '}
             {txOperation !== TX_OPERATION.APPROVING && (
               <>
-                You will receive {willReceiveAmount} {willReceiveAmountToken}
+                You will receive {willReceiveAmountEl} {willReceiveAmountToken}
               </>
             )}
           </>

--- a/utils/formatBalance.ts
+++ b/utils/formatBalance.ts
@@ -3,18 +3,36 @@ import { formatEther } from '@ethersproject/units';
 import { Zero } from '@ethersproject/constants';
 import { useMemo } from 'react';
 
-type FormatBalance = (balance?: BigNumber, maxDecimalDigits?: number) => string;
+type FormatBalance = (
+  balance?: BigNumber,
+  maxDecimalDigits?: number,
+  params?: {
+    adaptive?: boolean;
+    elipsis?: boolean;
+  },
+) => string;
 
 export const formatBalance: FormatBalance = (
   balance = Zero,
   maxDecimalDigits = 4,
+  { adaptive, elipsis } = {},
 ) => {
   const balanceString = formatEther(balance);
 
   if (balanceString.includes('.')) {
     const parts = balanceString.split('.');
     if (maxDecimalDigits === 0) return parts[0];
-    return parts[0] + '.' + parts[1].slice(0, maxDecimalDigits);
+    let decimal = parts[1];
+    if (adaptive) {
+      const nonZeroIdx = decimal.split('').findIndex((v) => v !== '0');
+      const sliceAt = Math.max(maxDecimalDigits, nonZeroIdx + 1);
+      decimal = decimal.slice(0, sliceAt);
+    } else {
+      decimal = decimal.slice(0, maxDecimalDigits);
+    }
+    const elipsisText =
+      elipsis && decimal.length < parts[1].length ? '...' : '';
+    return `${parts[0]}.${decimal}${elipsisText}`;
   }
 
   return balanceString;


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

> If after the comma the user texts bigger than 4 zero [0.000001], need display all the number after comma or bring solution to display it more friendly

### Demo

![image](https://github.com/lidofinance/ethereum-staking-widget/assets/7289992/278d532b-36d0-4cfc-8317-97d3f24392ad)

### Checklist:

- [x] Checked the changes locally.
