### PR TITLE
Add hover on you will receive value

### DIFF
--- a/features/stake/stake-form/stake-form-info.tsx
+++ b/features/stake/stake-form/stake-form-info.tsx
@@ -25,7 +25,7 @@ export const StakeFormInfo = () => {
   return (
     <DataTable data-testid="stakeFormInfo">
       <DataTableRow title="You will receive" data-testid="youWillReceive">
-        <FormatToken amount={amount ?? Zero} symbol="stETH" />
+        <FormatToken amount={amount ?? Zero} symbol="stETH" showAmountTip />
       </DataTableRow>
       <DataTableRow title="Exchange rate" data-testid="exchangeRate">
         1 ETH = 1 stETH

--- a/features/stake/stake-form/stake-form-info.tsx
+++ b/features/stake/stake-form/stake-form-info.tsx
@@ -25,7 +25,12 @@ export const StakeFormInfo = () => {
   return (
     <DataTable data-testid="stakeFormInfo">
       <DataTableRow title="You will receive" data-testid="youWillReceive">
-        <FormatToken amount={amount ?? Zero} symbol="stETH" showAmountTip />
+        <FormatToken
+          amount={amount ?? Zero}
+          symbol="stETH"
+          showAmountTip
+          trimEllipsis
+        />
       </DataTableRow>
       <DataTableRow title="Exchange rate" data-testid="exchangeRate">
         1 ETH = 1 stETH

--- a/features/wsteth/unwrap/unwrap-form/unwrap-stats.tsx
+++ b/features/wsteth/unwrap/unwrap-form/unwrap-stats.tsx
@@ -27,6 +27,7 @@ export const UnwrapStats = () => {
           data-testid="youWillReceive"
           amount={willReceiveStETH}
           symbol="stETH"
+          showAmountTip
         />
       </DataTableRow>
     </DataTable>

--- a/features/wsteth/unwrap/unwrap-form/unwrap-stats.tsx
+++ b/features/wsteth/unwrap/unwrap-form/unwrap-stats.tsx
@@ -28,6 +28,7 @@ export const UnwrapStats = () => {
           amount={willReceiveStETH}
           symbol="stETH"
           showAmountTip
+          trimEllipsis
         />
       </DataTableRow>
     </DataTable>

--- a/features/wsteth/wrap/wrap-form/wrap-stats.tsx
+++ b/features/wsteth/wrap/wrap-form/wrap-stats.tsx
@@ -68,6 +68,7 @@ export const WrapFormStats = () => {
           data-testid="youWillReceive"
           symbol="wstETH"
           showAmountTip
+          trimEllipsis
         />
       </DataTableRow>
     </DataTable>

--- a/features/wsteth/wrap/wrap-form/wrap-stats.tsx
+++ b/features/wsteth/wrap/wrap-form/wrap-stats.tsx
@@ -67,6 +67,7 @@ export const WrapFormStats = () => {
           amount={willReceiveWsteth}
           data-testid="youWillReceive"
           symbol="wstETH"
+          showAmountTip
         />
       </DataTableRow>
     </DataTable>

--- a/shared/formatters/format-token.tsx
+++ b/shared/formatters/format-token.tsx
@@ -26,6 +26,7 @@ export const FormatToken: FormatTokenComponent = ({
     amount,
     maxDecimalDigits,
     maxTotalLength,
+    true,
   );
   const showTooltip = showAmountTip && isTrimmed;
 

--- a/shared/formatters/format-token.tsx
+++ b/shared/formatters/format-token.tsx
@@ -10,6 +10,7 @@ export type FormatTokenProps = {
   maxDecimalDigits?: number;
   maxTotalLength?: number;
   showAmountTip?: boolean;
+  trimEllipsis?: boolean;
 };
 export type FormatTokenComponent = Component<'span', FormatTokenProps>;
 
@@ -20,13 +21,14 @@ export const FormatToken: FormatTokenComponent = ({
   maxDecimalDigits = 4,
   maxTotalLength = 15,
   showAmountTip = false,
+  trimEllipsis,
   ...rest
 }) => {
   const { actual, isTrimmed, trimmed } = useFormattedBalance(
     amount,
     maxDecimalDigits,
     maxTotalLength,
-    true,
+    trimEllipsis,
   );
   const showTooltip = showAmountTip && isTrimmed;
 

--- a/utils/formatBalance.ts
+++ b/utils/formatBalance.ts
@@ -42,6 +42,7 @@ export const formatBalanceWithTrimmed = (
   balance = Zero,
   maxDecimalDigits = 4,
   maxTotalLength = 30,
+  trimEllipsis?: boolean,
 ) => {
   const balanceString = formatEther(balance);
   let trimmed = balanceString;
@@ -64,6 +65,10 @@ export const formatBalanceWithTrimmed = (
     }
   }
 
+  if (isTrimmed && trimEllipsis && !trimmed.includes('...')) {
+    trimmed += '...';
+  }
+
   return {
     actual: balanceString,
     trimmed,
@@ -75,9 +80,16 @@ export const useFormattedBalance = (
   balance = Zero,
   maxDecimalDigits = 4,
   maxTotalLength = 30,
+  trimEllipsis?: boolean,
 ) => {
   return useMemo(
-    () => formatBalanceWithTrimmed(balance, maxDecimalDigits, maxTotalLength),
-    [balance, maxDecimalDigits, maxTotalLength],
+    () =>
+      formatBalanceWithTrimmed(
+        balance,
+        maxDecimalDigits,
+        maxTotalLength,
+        trimEllipsis,
+      ),
+    [balance, maxDecimalDigits, maxTotalLength, trimEllipsis],
   );
 };


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

> Need to add hovers on Stake page, Wrap page, Unwrap page, Request page to "You will receive" value

### Demo

<img width="523" alt="image" src="https://github.com/lidofinance/ethereum-staking-widget/assets/7289992/0b7a2034-e4b2-4065-9f2c-c7ba15ad2ccb">

### Checklist:

- [x] Checked the changes locally.
