### PR TITLE
[fix] disable oneinch endpoint

### DIFF
--- a/pages/api/oneinch-rate.ts
+++ b/pages/api/oneinch-rate.ts
@@ -54,6 +54,9 @@ const validateAndGetQueryToken = async (
 // * (optional) token: see TOKEN_ALLOWED_LIST above. Default see TOKEN_ETH above.
 // Returns 1inch rate
 const oneInchRate: API = async (req, res) => {
+  res.status(403);
+  return;
+
   const token = await validateAndGetQueryToken(req, res);
   const cacheKey = `${CACHE_ONE_INCH_RATE_KEY}-${token}`;
   const cachedOneInchRate = cache.get(cacheKey);

--- a/pages/api/oneinch-rate.ts
+++ b/pages/api/oneinch-rate.ts
@@ -56,7 +56,7 @@ const validateAndGetQueryToken = async (
 const oneInchRate: API = async (req, res) => {
   res.status(403);
   return;
-
+  // TODO: enable test in test/consts.ts
   const token = await validateAndGetQueryToken(req, res);
   const cacheKey = `${CACHE_ONE_INCH_RATE_KEY}-${token}`;
   const cachedOneInchRate = cache.get(cacheKey);

--- a/test/consts.ts
+++ b/test/consts.ts
@@ -160,17 +160,17 @@ const LIDO_STATS_SCHEMA = {
 };
 
 export const GET_REQUESTS: GetRequest[] = [
-  {
-    uri: '/api/oneinch-rate',
-    schema: {
-      type: 'object',
-      properties: {
-        rate: { type: 'number', min: 0 },
-      },
-      required: ['rate'],
-      additionalProperties: false,
-    },
-  },
+  // {
+  //   uri: '/api/oneinch-rate',
+  //   schema: {
+  //     type: 'object',
+  //     properties: {
+  //       rate: { type: 'number', min: 0 },
+  //     },
+  //     required: ['rate'],
+  //     additionalProperties: false,
+  //   },
+  // },
   {
     uri: `/api/short-lido-stats?chainId=${CONFIG.STAND_CONFIG.chainId}`,
     schema: {

--- a/test/consts.ts
+++ b/test/consts.ts
@@ -160,6 +160,7 @@ const LIDO_STATS_SCHEMA = {
 };
 
 export const GET_REQUESTS: GetRequest[] = [
+  // TODO: enabled when bringing back 1inch endpoint
   // {
   //   uri: '/api/oneinch-rate',
   //   schema: {


### PR DESCRIPTION

### Description

- [x] currently unused `api/oneinch-rate` endpoint returns `403`
- [x] endpoint test commented out   

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
