### PR TITLE
Validation messages and edge-cases

### DIFF
--- a/config/tx.ts
+++ b/config/tx.ts
@@ -1,8 +1,8 @@
-export const STANDARD_GAS_LIMIT = 21000;
+import { BigNumber } from 'ethers';
 
-export const WSTETH_APPROVE_GAS_LIMIT = 78000;
+export const WSTETH_APPROVE_GAS_LIMIT = BigNumber.from(78000);
 
-export const WRAP_FROM_ETH_GAS_LIMIT = 100000;
-export const WRAP_GAS_LIMIT = 140000;
-export const WRAP_GAS_LIMIT_GOERLI = 120000;
-export const UNWRAP_GAS_LIMIT = 115000;
+export const WRAP_FROM_ETH_GAS_LIMIT = BigNumber.from(100000);
+export const WRAP_GAS_LIMIT = BigNumber.from(140000);
+export const WRAP_GAS_LIMIT_GOERLI = BigNumber.from(120000);
+export const UNWRAP_GAS_LIMIT = BigNumber.from(115000);

--- a/features/stake/stake-form/stake-form-context/types.ts
+++ b/features/stake/stake-form/stake-form-context/types.ts
@@ -22,7 +22,7 @@ export type StakeFormNetworkData = {
 };
 
 export type StakeFormValidationContext = {
-  active: boolean;
+  isWalletActive: boolean;
   stakingLimitLevel: LIMIT_LEVEL;
   currentStakeLimit: BigNumber;
   gasCost: BigNumber;

--- a/features/stake/stake-form/stake-form-context/validation.ts
+++ b/features/stake/stake-form/stake-form-context/validation.ts
@@ -31,7 +31,7 @@ export const stakeFormValidationResolver: Resolver<
     validateEtherAmount('amount', amount, 'ETH');
 
     const {
-      active,
+      isWalletActive,
       stakingLimitLevel,
       currentStakeLimit,
       etherBalance,
@@ -45,7 +45,7 @@ export const stakeFormValidationResolver: Resolver<
     validateStakeEth({
       formField: 'amount',
       amount,
-      active,
+      isWalletActive,
       stakingLimitLevel,
       currentStakeLimit,
       etherBalance,
@@ -53,7 +53,7 @@ export const stakeFormValidationResolver: Resolver<
       isMultisig,
     });
 
-    if (!active) {
+    if (!isWalletActive) {
       return {
         values,
         errors: { referral: 'wallet not connected' },
@@ -81,7 +81,7 @@ export const useStakeFormValidationContext = (
       (!active || (etherBalance && gasCost && isMultisig !== undefined))
     ) {
       return {
-        active,
+        isWalletActive: active,
         stakingLimitLevel: stakingLimitInfo.stakeLimitLevel,
         currentStakeLimit: stakingLimitInfo.currentStakeLimit,
         // condition above guaranties stubs will only be passed when active = false

--- a/features/stake/stake-form/stake-form-context/validation.ts
+++ b/features/stake/stake-form/stake-form-context/validation.ts
@@ -1,14 +1,11 @@
 import { useMemo } from 'react';
 import invariant from 'tiny-invariant';
-import { formatEther } from '@ethersproject/units';
 import { useWeb3 } from 'reef-knot/web3-react';
 import { Zero } from '@ethersproject/constants';
 
 import { validateEtherAmount } from 'shared/hook-form/validation/validate-ether-amount';
 import { VALIDATION_CONTEXT_TIMEOUT } from 'features/withdrawals/withdrawals-constants';
 import { handleResolverValidationError } from 'shared/hook-form/validation/validation-error';
-import { validateBignumberMax } from 'shared/hook-form/validation/validate-bignumber-max';
-import { validateStakeLimit } from 'shared/hook-form/validation/validate-stake-limit';
 import { awaitWithTimeout } from 'utils/await-with-timeout';
 import { useAwaiter } from 'shared/hooks/use-awaiter';
 
@@ -18,6 +15,7 @@ import type {
   StakeFormNetworkData,
   StakeFormValidationContext,
 } from './types';
+import { validateStakeEth } from 'shared/hook-form/validation/validate-stake-eth';
 
 export const stakeFormValidationResolver: Resolver<
   StakeFormInput,
@@ -44,49 +42,18 @@ export const stakeFormValidationResolver: Resolver<
       VALIDATION_CONTEXT_TIMEOUT,
     );
 
-    validateStakeLimit('amount', stakingLimitLevel);
+    validateStakeEth({
+      formField: 'amount',
+      amount,
+      active,
+      stakingLimitLevel,
+      currentStakeLimit,
+      etherBalance,
+      gasCost,
+      isMultisig,
+    });
 
-    if (active) {
-      validateBignumberMax(
-        'amount',
-        amount,
-        etherBalance,
-        `Entered ETH amount exceeds your available balance of ${formatEther(
-          etherBalance,
-        )}`,
-      );
-
-      validateBignumberMax(
-        'amount',
-        amount,
-        currentStakeLimit,
-        `Entered ETH amount exceeds current staking limit of ${formatEther(
-          currentStakeLimit,
-        )}`,
-      );
-
-      if (!isMultisig) {
-        const gasPaddedBalance = etherBalance.sub(gasCost);
-
-        validateBignumberMax(
-          'amount',
-          Zero,
-          gasPaddedBalance,
-          `Ensure you have sufficient ETH to cover the gas cost of ${formatEther(
-            gasCost,
-          )}`,
-        );
-
-        validateBignumberMax(
-          'amount',
-          amount,
-          gasPaddedBalance,
-          `Enter ETH amount less than ${formatEther(
-            gasPaddedBalance,
-          )} to ensure you leave enough ETH for gas fees`,
-        );
-      }
-    } else {
+    if (!active) {
       return {
         values,
         errors: { referral: 'wallet not connected' },

--- a/features/withdrawals/claim/claim-form-context/claim-form-context.tsx
+++ b/features/withdrawals/claim/claim-form-context/claim-form-context.tsx
@@ -22,6 +22,7 @@ import {
 import { ClaimFormHelperState, useHelperState } from './use-helper-state';
 import { useClaimData } from 'features/withdrawals/contexts/claim-data-context';
 import { useTransactionModal } from 'shared/transaction-modal';
+import { useWeb3 } from 'reef-knot/web3-react';
 
 type ClaimFormDataContextValueType = {
   onSubmit: FormEventHandler<HTMLFormElement>;
@@ -39,6 +40,7 @@ export const useClaimFormData = () => {
 
 export const ClaimFormProvider: FC<PropsWithChildren> = ({ children }) => {
   const { dispatchModalState } = useTransactionModal();
+  const { active } = useWeb3();
   const { data } = useClaimData();
 
   const [shouldReset, setShouldReset] = useState<boolean>(false);
@@ -49,7 +51,7 @@ export const ClaimFormProvider: FC<PropsWithChildren> = ({ children }) => {
   const formObject = useForm<ClaimFormInputType, ClaimFormValidationContext>({
     defaultValues: getDefaultValues,
     resolver: claimFormValidationResolver,
-    context: { maxSelectedRequestCount },
+    context: { maxSelectedRequestCount, active },
     mode: 'onChange',
     reValidateMode: 'onChange',
   });

--- a/features/withdrawals/claim/claim-form-context/claim-form-context.tsx
+++ b/features/withdrawals/claim/claim-form-context/claim-form-context.tsx
@@ -51,7 +51,7 @@ export const ClaimFormProvider: FC<PropsWithChildren> = ({ children }) => {
   const formObject = useForm<ClaimFormInputType, ClaimFormValidationContext>({
     defaultValues: getDefaultValues,
     resolver: claimFormValidationResolver,
-    context: { maxSelectedRequestCount, active },
+    context: { maxSelectedRequestCount, isWalletActive: active },
     mode: 'onChange',
     reValidateMode: 'onChange',
   });

--- a/features/withdrawals/claim/claim-form-context/types.ts
+++ b/features/withdrawals/claim/claim-form-context/types.ts
@@ -5,7 +5,7 @@ import {
 
 export type ClaimFormValidationContext = {
   maxSelectedRequestCount: number;
-  active: boolean;
+  isWalletActive: boolean;
 };
 
 export type ClaimFormInputType = {

--- a/features/withdrawals/claim/claim-form-context/types.ts
+++ b/features/withdrawals/claim/claim-form-context/types.ts
@@ -5,6 +5,7 @@ import {
 
 export type ClaimFormValidationContext = {
   maxSelectedRequestCount: number;
+  active: boolean;
 };
 
 export type ClaimFormInputType = {

--- a/features/withdrawals/claim/claim-form-context/validation.ts
+++ b/features/withdrawals/claim/claim-form-context/validation.ts
@@ -13,7 +13,7 @@ export const claimFormValidationResolver: Resolver<
 > = async ({ requests }, context) => {
   invariant(context);
   try {
-    const { maxSelectedRequestCount, active } = context;
+    const { maxSelectedRequestCount, isWalletActive } = context;
     const selectedTokens = requests
       .filter((r) => r.checked)
       .map((r) => r.status as RequestStatusClaimable);
@@ -27,7 +27,7 @@ export const claimFormValidationResolver: Resolver<
         `Cannot claim more than ${maxSelectedRequestCount} requests at once`,
       );
 
-    if (!active) {
+    if (!isWalletActive) {
       return {
         values: {
           requests,

--- a/features/withdrawals/claim/claim-form-context/validation.ts
+++ b/features/withdrawals/claim/claim-form-context/validation.ts
@@ -13,7 +13,7 @@ export const claimFormValidationResolver: Resolver<
 > = async ({ requests }, context) => {
   invariant(context);
   try {
-    const { maxSelectedRequestCount } = context;
+    const { maxSelectedRequestCount, active } = context;
     const selectedTokens = requests
       .filter((r) => r.checked)
       .map((r) => r.status as RequestStatusClaimable);
@@ -26,6 +26,16 @@ export const claimFormValidationResolver: Resolver<
         'requests',
         `Cannot claim more than ${maxSelectedRequestCount} requests at once`,
       );
+
+    if (!active) {
+      return {
+        values: {
+          requests,
+          selectedTokens,
+        },
+        errors: { selectedTokens: 'no wallet connected' },
+      };
+    }
 
     return {
       values: {

--- a/features/withdrawals/claim/form/requests-list/requests-empty.tsx
+++ b/features/withdrawals/claim/form/requests-list/requests-empty.tsx
@@ -1,11 +1,11 @@
-import { useWeb3 } from 'reef-knot/web3-react';
-
 import { EmptyText, WrapperEmpty } from './styles';
 
-export const RequestsEmpty = () => {
-  const { active } = useWeb3();
+type RequestsEmptyProps = {
+  isWalletConnected?: boolean;
+};
 
-  if (!active) {
+export const RequestsEmpty = ({ isWalletConnected }: RequestsEmptyProps) => {
+  if (!isWalletConnected) {
     return (
       <WrapperEmpty>
         <EmptyText>Connect wallet to see your withdrawal requests</EmptyText>

--- a/features/withdrawals/claim/form/requests-list/requests-list.tsx
+++ b/features/withdrawals/claim/form/requests-list/requests-list.tsx
@@ -4,8 +4,10 @@ import { Wrapper } from './styles';
 import { RequestsLoader } from './requests-loader';
 import { useFieldArray, useFormContext, useFormState } from 'react-hook-form';
 import { ClaimFormInputType } from '../../claim-form-context';
+import { useWeb3 } from 'reef-knot/web3-react';
 
 export const RequestsList: React.FC = () => {
+  const { active } = useWeb3();
   const { isLoading } = useFormState<ClaimFormInputType>();
   const { register } = useFormContext<ClaimFormInputType>();
   const { fields } = useFieldArray<ClaimFormInputType, 'requests'>({
@@ -16,8 +18,8 @@ export const RequestsList: React.FC = () => {
     return <RequestsLoader />;
   }
 
-  if (fields.length === 0) {
-    return <RequestsEmpty />;
+  if (!active || fields.length === 0) {
+    return <RequestsEmpty isWalletConnected={active} />;
   }
 
   return (

--- a/features/withdrawals/request/form/transaction-info.tsx
+++ b/features/withdrawals/request/form/transaction-info.tsx
@@ -4,18 +4,18 @@ import { useRequestTxPrice } from 'features/withdrawals/hooks/useWithdrawTxPrice
 import { useApproveGasLimit } from 'features/wsteth/wrap/hooks/use-approve-gas-limit';
 import { useWatch } from 'react-hook-form';
 import { DataTableRowStethByWsteth } from 'shared/components/data-table-row-steth-by-wsteth';
-import { FormatPrice, FormatToken } from 'shared/formatters';
+import { FormatPrice } from 'shared/formatters';
 import { useTxCostInUsd } from 'shared/hooks';
-import { getTokenDisplayName } from 'utils/getTokenDisplayName';
 import {
   RequestFormInputType,
   useRequestFormData,
   useValidationResults,
 } from '../request-form-context';
-import { MaxUint256 } from '@ethersproject/constants';
-import { useMemo } from 'react';
+import { useWeb3 } from 'reef-knot/web3-react';
+import { AllowanceDataTableRow } from 'shared/components/allowance-data-table-row';
 
 export const TransactionInfo = () => {
+  const { active } = useWeb3();
   const { isApprovalFlow, isApprovalFlowLoading, allowance } =
     useRequestFormData();
   const token = useWatch<RequestFormInputType, 'token'>({ name: 'token' });
@@ -34,10 +34,6 @@ export const TransactionInfo = () => {
     approveGasLimit && Number(approveGasLimit),
   );
 
-  const isInfiniteAllowance = useMemo(() => {
-    return allowance.eq(MaxUint256);
-  }, [allowance]);
-
   return (
     <>
       <DataTableRow
@@ -55,21 +51,13 @@ export const TransactionInfo = () => {
       >
         <FormatPrice amount={requestTxPriceInUsd} />
       </DataTableRow>
-      <DataTableRow
+      <AllowanceDataTableRow
         data-testid="allowance"
-        title="Allowance"
+        token={token}
+        allowance={allowance}
+        isBlank={!active}
         loading={isApprovalFlowLoading}
-      >
-        {isInfiniteAllowance ? (
-          'Infinite'
-        ) : (
-          <FormatToken
-            showAmountTip
-            amount={allowance}
-            symbol={getTokenDisplayName(token)}
-          />
-        )}
-      </DataTableRow>
+      />
       {token === TOKENS.STETH ? (
         <DataTableRow data-testid="exchangeRate" title="Exchange rate">
           1 stETH = 1 ETH

--- a/features/withdrawals/request/request-form-context/types.ts
+++ b/features/withdrawals/request/request-form-context/types.ts
@@ -14,7 +14,7 @@ export type RequestFormInputType = {
 } & ValidationResults;
 
 export type RequestFormValidationContextType = {
-  active: boolean;
+  isWalletActive: boolean;
   asyncContext: Promise<RequestFormValidationAsyncContextType>;
   setIntermediateValidationResults: Dispatch<SetStateAction<ValidationResults>>;
 };

--- a/features/withdrawals/request/request-form-context/use-validation-context.ts
+++ b/features/withdrawals/request/request-form-context/use-validation-context.ts
@@ -67,5 +67,9 @@ export const useValidationContext = (
   const asyncContext =
     useAwaiter<RequestFormValidationAsyncContextType>(context).awaiter;
 
-  return { active, asyncContext, setIntermediateValidationResults };
+  return {
+    isWalletActive: active,
+    asyncContext,
+    setIntermediateValidationResults,
+  };
 };

--- a/features/withdrawals/request/request-form-context/validators.ts
+++ b/features/withdrawals/request/request-form-context/validators.ts
@@ -159,7 +159,7 @@ export const RequestFormValidationResolver: Resolver<
     validateEtherAmount('amount', amount, token);
 
     // early return
-    if (!context.active) return { values, errors: {} };
+    if (!context.isWalletActive) return { values, errors: {} };
 
     // wait for context promise with timeout and extract relevant data
     // validation function only waits limited time for data and fails validation otherwise

--- a/features/withdrawals/request/request-form-context/validators.ts
+++ b/features/withdrawals/request/request-form-context/validators.ts
@@ -57,9 +57,9 @@ const messageMinUnstake = (min: BigNumber, token: TokensWithdrawable) =>
   )}`;
 
 const messageMaxAmount = (max: BigNumber, token: TokensWithdrawable) =>
-  `${getTokenDisplayName(token)} amount must not be greater than ${formatEther(
-    max,
-  )}`;
+  `Entered ${getTokenDisplayName(
+    token,
+  )} amount exceeds your available balance of ${formatEther(max)}`;
 
 const validateSplitRequests = (
   field: string,
@@ -154,8 +154,8 @@ export const RequestFormValidationResolver: Resolver<
     invariant(context, 'must have context promise');
     setResults = context.setIntermediateValidationResults;
 
-    // this check does not require context and can be placed first
-    // also limits context missing edge cases on page start
+    // this check does not require async context and can be placed first
+    // also limits async context missing edge cases on page start
     validateEtherAmount('amount', amount, token);
 
     // early return

--- a/features/wsteth/unwrap/hooks/use-unwra-form-validation-context.ts
+++ b/features/wsteth/unwrap/hooks/use-unwra-form-validation-context.ts
@@ -19,7 +19,7 @@ export const useUnwrapFormValidationContext = ({
       return undefined;
     }
     return {
-      active,
+      isWalletActive: active,
       maxAmount,
     };
   }, [active, maxAmount]);

--- a/features/wsteth/unwrap/hooks/use-unwrap-gas-limit.ts
+++ b/features/wsteth/unwrap/hooks/use-unwrap-gas-limit.ts
@@ -1,6 +1,5 @@
 import { useLidoSWR, useWSTETHContractRPC } from '@lido-sdk/react';
 import { ESTIMATE_ACCOUNT, ESTIMATE_AMOUNT, UNWRAP_GAS_LIMIT } from 'config';
-import { BigNumber } from 'ethers';
 
 import { useCurrentStaticRpcProvider } from 'shared/hooks/use-current-static-rpc-provider';
 import { STRATEGY_LAZY } from 'utils/swrStrategies';
@@ -20,7 +19,7 @@ export const useUnwrapGasLimit = () => {
         return gasLimit;
       } catch (error) {
         console.warn(error);
-        return BigNumber.from(UNWRAP_GAS_LIMIT);
+        return UNWRAP_GAS_LIMIT;
       }
     },
     STRATEGY_LAZY,

--- a/features/wsteth/unwrap/hooks/use-unwrap-tx-processing.ts
+++ b/features/wsteth/unwrap/hooks/use-unwrap-tx-processing.ts
@@ -8,7 +8,7 @@ import { getFeeData } from 'utils/getFeeData';
 
 import type { UnwrapFormInputType } from '../unwrap-form-context';
 
-type UnwrapTxProcessorArgs = UnwrapFormInputType & {
+type UnwrapTxProcessorArgs = Omit<UnwrapFormInputType, 'dummyErrorField'> & {
   isMultisig: boolean;
 };
 

--- a/features/wsteth/unwrap/unwrap-form-context/types.ts
+++ b/features/wsteth/unwrap/unwrap-form-context/types.ts
@@ -11,7 +11,7 @@ export type UnwrapFormInputType = {
 export type UnwrapFormNetworkData = ReturnType<typeof useUnwrapFormNetworkData>;
 
 export type UnwrapFormValidationContext = {
-  active: boolean;
+  isWalletActive: boolean;
   maxAmount?: BigNumber;
 };
 

--- a/features/wsteth/unwrap/unwrap-form-context/types.ts
+++ b/features/wsteth/unwrap/unwrap-form-context/types.ts
@@ -5,6 +5,7 @@ import type { FormControllerContextValueType } from 'shared/hook-form/form-contr
 
 export type UnwrapFormInputType = {
   amount: null | BigNumber;
+  dummyErrorField: null;
 };
 
 export type UnwrapFormNetworkData = ReturnType<typeof useUnwrapFormNetworkData>;

--- a/features/wsteth/unwrap/unwrap-form-context/unwrap-form-context.tsx
+++ b/features/wsteth/unwrap/unwrap-form-context/unwrap-form-context.tsx
@@ -50,6 +50,7 @@ export const UnwrapFormProvider: FC<PropsWithChildren> = ({ children }) => {
   >({
     defaultValues: {
       amount: null,
+      dummyErrorField: null,
     },
     context: validationContextPromise,
     criteriaMode: 'firstError',

--- a/features/wsteth/unwrap/unwrap-form-context/unwrap-form-validators.tsx
+++ b/features/wsteth/unwrap/unwrap-form-context/unwrap-form-validators.tsx
@@ -14,9 +14,9 @@ import { VALIDATION_CONTEXT_TIMEOUT } from 'features/withdrawals/withdrawals-con
 import type { UnwrapFormInputType, UnwrapFormValidationContext } from './types';
 
 const messageMaxAmount = (max: BigNumber) =>
-  `${getTokenDisplayName(
+  `Entered ${getTokenDisplayName(
     TOKENS.WSTETH,
-  )} amount must not be greater than ${formatEther(max)}`;
+  )} amount exceeds your available balance of ${formatEther(max)}`;
 
 export const UnwrapFormValidationResolver: Resolver<
   UnwrapFormInputType,
@@ -45,13 +45,21 @@ export const UnwrapFormValidationResolver: Resolver<
         maxAmount,
         messageMaxAmount(maxAmount),
       );
+    } else {
+      return {
+        values,
+        errors: { dummyErrorField: 'wallet is not connected' },
+      };
     }
-
     return {
       values,
       errors: {},
     };
   } catch (error) {
-    return handleResolverValidationError(error, 'UnwrapForm', 'amount');
+    return handleResolverValidationError(
+      error,
+      'UnwrapForm',
+      'dummyErrorField',
+    );
   }
 };

--- a/features/wsteth/unwrap/unwrap-form-context/unwrap-form-validators.tsx
+++ b/features/wsteth/unwrap/unwrap-form-context/unwrap-form-validators.tsx
@@ -31,7 +31,7 @@ export const UnwrapFormValidationResolver: Resolver<
 
     validateEtherAmount('amount', amount, TOKENS.WSTETH);
 
-    const { active, maxAmount } = await awaitWithTimeout(
+    const { isWalletActive: active, maxAmount } = await awaitWithTimeout(
       validationContextPromise,
       VALIDATION_CONTEXT_TIMEOUT,
     );

--- a/features/wsteth/wrap/hooks/use-wrap-form-network-data.ts
+++ b/features/wsteth/wrap/hooks/use-wrap-form-network-data.ts
@@ -9,7 +9,7 @@ import { useIsMultisig } from 'shared/hooks/useIsMultisig';
 import { useTokenMaxAmount } from 'shared/hooks/use-token-max-amount';
 
 import { STRATEGY_LAZY } from 'utils/swrStrategies';
-import { useStakingLimitInfo } from 'shared/hooks';
+import { useMaxGasPrice, useStakingLimitInfo } from 'shared/hooks';
 import { BALANCE_PADDING } from 'config';
 
 // Provides all data fetching for form to function
@@ -28,6 +28,7 @@ export const useWrapFormNetworkData = () => {
     useStakingLimitInfo();
 
   const { gasLimitETH, gasLimitStETH } = useWrapGasLimit();
+  const maxGasPrice = useMaxGasPrice();
 
   const maxAmountETH = useTokenMaxAmount({
     balance: ethBalance,
@@ -37,6 +38,10 @@ export const useWrapFormNetworkData = () => {
     padding: BALANCE_PADDING,
     isLoading: isMultisigLoading,
   });
+
+  const wrapEthGasCost = maxGasPrice
+    ? maxGasPrice.mul(gasLimitStETH)
+    : undefined;
 
   const revalidateWrapFormData = useCallback(async () => {
     await Promise.allSettled([
@@ -57,16 +62,17 @@ export const useWrapFormNetworkData = () => {
       isMultisig,
       ethBalance,
       stethBalance,
+      wrapEthGasCost,
       stakeLimitInfo,
       wstethBalance,
       revalidateWrapFormData,
       gasLimitETH,
       gasLimitStETH,
       maxAmountETH,
-      maxAmountStETH: stethBalance,
     }),
     [
       isMultisig,
+      wrapEthGasCost,
       ethBalance,
       stethBalance,
       stakeLimitInfo,

--- a/features/wsteth/wrap/hooks/use-wrap-form-validation-context.ts
+++ b/features/wsteth/wrap/hooks/use-wrap-form-validation-context.ts
@@ -24,25 +24,33 @@ export const useWrapFormValidationContext = ({
     wrapEthGasCost,
   } = networkData;
 
+  const isDataReady =
+    stethBalance &&
+    ethBalance &&
+    isMultisig !== undefined &&
+    wrapEthGasCost &&
+    stakeLimitInfo;
+
   const asyncContextValue: WrapFormAsyncValidationContext | undefined =
     useMemo(() => {
-      if (
-        stethBalance &&
-        ethBalance &&
-        isMultisig !== undefined &&
-        wrapEthGasCost &&
-        stakeLimitInfo
-      )
-        return {
-          stethBalance,
-          etherBalance: ethBalance,
-          isMultisig,
-          gasCost: wrapEthGasCost,
-          stakingLimitLevel: stakeLimitInfo.stakeLimitLevel,
-          currentStakeLimit: stakeLimitInfo.currentStakeLimit,
-        };
-      else return undefined;
-    }, [ethBalance, isMultisig, stakeLimitInfo, stethBalance, wrapEthGasCost]);
+      return isDataReady
+        ? {
+            stethBalance,
+            etherBalance: ethBalance,
+            isMultisig,
+            gasCost: wrapEthGasCost,
+            stakingLimitLevel: stakeLimitInfo.stakeLimitLevel,
+            currentStakeLimit: stakeLimitInfo.currentStakeLimit,
+          }
+        : undefined;
+    }, [
+      isDataReady,
+      ethBalance,
+      isMultisig,
+      stakeLimitInfo,
+      stethBalance,
+      wrapEthGasCost,
+    ]);
 
   const asyncContext = useAwaiter(asyncContextValue).awaiter;
   return {

--- a/features/wsteth/wrap/hooks/use-wrap-form-validation-context.ts
+++ b/features/wsteth/wrap/hooks/use-wrap-form-validation-context.ts
@@ -46,7 +46,7 @@ export const useWrapFormValidationContext = ({
 
   const asyncContext = useAwaiter(asyncContextValue).awaiter;
   return {
-    active,
+    isWalletActive: active,
     asyncContext,
   };
 };

--- a/features/wsteth/wrap/hooks/use-wrap-gas-limit.ts
+++ b/features/wsteth/wrap/hooks/use-wrap-gas-limit.ts
@@ -1,5 +1,4 @@
 import { useLidoSWR, useWSTETHContractRPC } from '@lido-sdk/react';
-import { BigNumber } from 'ethers';
 import { useWeb3 } from 'reef-knot/web3-react';
 import { CHAINS } from '@lido-sdk/constants';
 
@@ -32,7 +31,7 @@ export const useWrapGasLimit = () => {
           });
         } catch (error) {
           console.warn(`${_key}::[eth]`, error);
-          return applyGasLimitRatio(BigNumber.from(WRAP_FROM_ETH_GAS_LIMIT));
+          return applyGasLimitRatio(WRAP_FROM_ETH_GAS_LIMIT);
         }
       };
 
@@ -43,9 +42,9 @@ export const useWrapGasLimit = () => {
           });
         } catch (error) {
           console.warn(`${_key}::[steth]`, error);
-          return BigNumber.from(
-            chainId === CHAINS.Goerli ? WRAP_GAS_LIMIT_GOERLI : WRAP_GAS_LIMIT,
-          );
+          return chainId === CHAINS.Goerli
+            ? WRAP_GAS_LIMIT_GOERLI
+            : WRAP_GAS_LIMIT;
         }
       };
 
@@ -62,10 +61,10 @@ export const useWrapGasLimit = () => {
   );
 
   return {
-    gasLimitETH: data?.gasLimitETH || BigNumber.from(WRAP_FROM_ETH_GAS_LIMIT),
+    gasLimitETH: data?.gasLimitETH || WRAP_FROM_ETH_GAS_LIMIT,
     gasLimitStETH:
       data?.gasLimitStETH || chainId === CHAINS.Goerli
-        ? BigNumber.from(WRAP_GAS_LIMIT_GOERLI)
-        : BigNumber.from(WRAP_GAS_LIMIT),
+        ? WRAP_GAS_LIMIT_GOERLI
+        : WRAP_GAS_LIMIT,
   };
 };

--- a/features/wsteth/wrap/wrap-form-context/types.ts
+++ b/features/wsteth/wrap/wrap-form-context/types.ts
@@ -17,7 +17,7 @@ export type WrapFormNetworkData = ReturnType<typeof useWrapFormNetworkData>;
 export type WrapFormApprovalData = ReturnType<typeof useWrapTxApprove>;
 
 export type WrapFormValidationContext = {
-  active: boolean;
+  isWalletActive: boolean;
   asyncContext: Promise<WrapFormAsyncValidationContext>;
 };
 

--- a/features/wsteth/wrap/wrap-form-context/types.ts
+++ b/features/wsteth/wrap/wrap-form-context/types.ts
@@ -18,9 +18,16 @@ export type WrapFormApprovalData = ReturnType<typeof useWrapTxApprove>;
 
 export type WrapFormValidationContext = {
   active: boolean;
-  maxAmountETH?: BigNumber;
-  maxAmountStETH?: BigNumber;
-  stakeLimitLevel: LIMIT_LEVEL;
+  asyncContext: Promise<WrapFormAsyncValidationContext>;
+};
+
+export type WrapFormAsyncValidationContext = {
+  stethBalance: BigNumber;
+  etherBalance: BigNumber;
+  stakingLimitLevel: LIMIT_LEVEL;
+  currentStakeLimit: BigNumber;
+  gasCost: BigNumber;
+  isMultisig: boolean;
 };
 
 export type WrapFormDataContextValueType = WrapFormNetworkData &
@@ -28,7 +35,7 @@ export type WrapFormDataContextValueType = WrapFormNetworkData &
   FormControllerContextValueType<WrapFormInputType> & {
     isSteth: boolean;
     maxAmount?: BigNumber;
-    wrapGasLimit?: BigNumber;
+    wrapGasLimit: BigNumber;
     willReceiveWsteth?: BigNumber;
     stakeLimitInfo?: StakeLimitFullInfo;
   };

--- a/features/wsteth/wrap/wrap-form-context/wrap-form-context.tsx
+++ b/features/wsteth/wrap/wrap-form-context/wrap-form-context.tsx
@@ -47,10 +47,7 @@ export const WrapFormProvider: FC<PropsWithChildren> = ({ children }) => {
     networkData,
   });
 
-  const formObject = useForm<
-    WrapFormInputType,
-    Promise<WrapFormValidationContext>
-  >({
+  const formObject = useForm<WrapFormInputType, WrapFormValidationContext>({
     defaultValues: {
       amount: null,
       token: TOKENS_TO_WRAP.STETH,
@@ -82,9 +79,7 @@ export const WrapFormProvider: FC<PropsWithChildren> = ({ children }) => {
       ...approvalData,
       isSteth,
       stakeLimitInfo: networkData.stakeLimitInfo,
-      maxAmount: isSteth
-        ? networkData.maxAmountStETH
-        : networkData.maxAmountETH,
+      maxAmount: isSteth ? networkData.stethBalance : networkData.maxAmountETH,
       wrapGasLimit: isSteth
         ? networkData.gasLimitStETH
         : networkData.gasLimitETH,

--- a/features/wsteth/wrap/wrap-form-context/wrap-form-validators.ts
+++ b/features/wsteth/wrap/wrap-form-context/wrap-form-validators.ts
@@ -26,7 +26,7 @@ export const WrapFormValidationResolver: Resolver<
   const { amount, token } = values;
   try {
     invariant(validationContext, 'validation context must be present');
-    const { active, asyncContext } = validationContext;
+    const { isWalletActive, asyncContext } = validationContext;
 
     validateEtherAmount('amount', amount, token);
 
@@ -39,11 +39,11 @@ export const WrapFormValidationResolver: Resolver<
       // checks active internally after other wallet-less check
       validateStakeEth({
         formField: 'amount',
-        active,
+        isWalletActive,
         amount,
         ...awaitedContext,
       });
-    } else if (active) {
+    } else if (isWalletActive) {
       validateBignumberMax(
         'amount',
         amount,

--- a/features/wsteth/wrap/wrap-form-context/wrap-form-validators.ts
+++ b/features/wsteth/wrap/wrap-form-context/wrap-form-validators.ts
@@ -15,9 +15,9 @@ import { TokensWrappable, TOKENS_TO_WRAP } from 'features/wsteth/shared/types';
 import { validateStakeEth } from 'shared/hook-form/validation/validate-stake-eth';
 
 const messageMaxAmount = (max: BigNumber, token: TokensWrappable) =>
-  `${getTokenDisplayName(token)} amount must not be greater than ${formatEther(
-    max,
-  )}`;
+  `Entered ${getTokenDisplayName(
+    token,
+  )} amount exceeds your available balance of ${formatEther(max)}`;
 
 export const WrapFormValidationResolver: Resolver<
   WrapFormInputType,

--- a/features/wsteth/wrap/wrap-form/wrap-stats.tsx
+++ b/features/wsteth/wrap/wrap-form/wrap-stats.tsx
@@ -25,7 +25,7 @@ export const WrapFormStats = () => {
   const approveGasLimit = useApproveGasLimit();
   const approveTxCostInUsd = useTxCostInUsd(Number(approveGasLimit));
 
-  const wrapTxCostInUsd = useTxCostInUsd(wrapGasLimit && Number(wrapGasLimit));
+  const wrapTxCostInUsd = useTxCostInUsd(wrapGasLimit);
 
   return (
     <DataTable data-testid="wrapStats">

--- a/features/wsteth/wrap/wrap-form/wrap-stats.tsx
+++ b/features/wsteth/wrap/wrap-form/wrap-stats.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import { parseEther } from '@ethersproject/units';
 import { DataTable, DataTableRow } from '@lidofinance/lido-ui';
 import { useFormContext } from 'react-hook-form';
@@ -10,20 +9,26 @@ import { TOKENS_TO_WRAP } from 'features/wsteth/shared/types';
 
 import { useApproveGasLimit } from '../hooks/use-approve-gas-limit';
 import { useWrapFormData, WrapFormInputType } from '../wrap-form-context';
+import { useWeb3 } from 'reef-knot/web3-react';
+import { AllowanceDataTableRow } from 'shared/components/allowance-data-table-row';
+import { TOKENS } from '@lido-sdk/constants';
+
+const oneSteth = parseEther('1');
 
 export const WrapFormStats = () => {
+  const { active } = useWeb3();
   const { allowance, wrapGasLimit, willReceiveWsteth, isApprovalLoading } =
     useWrapFormData();
 
   const { watch } = useFormContext<WrapFormInputType>();
   const [token] = watch(['token']);
+
   const isSteth = token === TOKENS_TO_WRAP.STETH;
 
-  const oneSteth = useMemo(() => parseEther('1'), []);
   const oneWstethConverted = useWstethBySteth(oneSteth);
 
   const approveGasLimit = useApproveGasLimit();
-  const approveTxCostInUsd = useTxCostInUsd(Number(approveGasLimit));
+  const approveTxCostInUsd = useTxCostInUsd(approveGasLimit);
 
   const wrapTxCostInUsd = useTxCostInUsd(wrapGasLimit);
 
@@ -55,13 +60,14 @@ export const WrapFormStats = () => {
           symbol="wstETH"
         />
       </DataTableRow>
-      <DataTableRow
+      <AllowanceDataTableRow
         data-testid="allowance"
-        title="Allowance"
+        allowance={allowance}
+        isBlank={!(isSteth && active)}
         loading={isApprovalLoading}
-      >
-        {isSteth ? <FormatToken amount={allowance} symbol="stETH" /> : <>-</>}
-      </DataTableRow>
+        token={TOKENS.STETH}
+      />
+
       <DataTableRow title="You will receive">
         <FormatToken
           amount={willReceiveWsteth}

--- a/shared/components/allowance-data-table-row/allowance-data-table-row.tsx
+++ b/shared/components/allowance-data-table-row/allowance-data-table-row.tsx
@@ -1,0 +1,44 @@
+import { MaxUint256 } from '@ethersproject/constants';
+import { TOKENS } from '@lido-sdk/constants';
+import { DataTableRow } from '@lidofinance/lido-ui';
+import { BigNumber } from 'ethers';
+import { ReactNode, useMemo } from 'react';
+import { FormatToken } from 'shared/formatters';
+import { getTokenDisplayName } from 'utils/getTokenDisplayName';
+
+export type AllowanceDataTableRowProps = Omit<
+  React.ComponentProps<typeof DataTableRow>,
+  'title'
+> & {
+  title?: ReactNode;
+  token: TOKENS.WSTETH | TOKENS.STETH | 'ETH';
+  allowance?: BigNumber;
+  isBlank?: boolean;
+};
+
+export const AllowanceDataTableRow = ({
+  token,
+  allowance,
+  isBlank,
+  title = 'Allowance',
+  ...rest
+}: AllowanceDataTableRowProps) => {
+  const isInfiniteAllowance = useMemo(() => {
+    return allowance && allowance.eq(MaxUint256);
+  }, [allowance]);
+  return (
+    <DataTableRow title={title} {...rest}>
+      {isBlank ? (
+        '-'
+      ) : isInfiniteAllowance ? (
+        'Infinite'
+      ) : (
+        <FormatToken
+          showAmountTip
+          amount={allowance}
+          symbol={getTokenDisplayName(token)}
+        />
+      )}
+    </DataTableRow>
+  );
+};

--- a/shared/components/allowance-data-table-row/index.ts
+++ b/shared/components/allowance-data-table-row/index.ts
@@ -1,0 +1,2 @@
+export { AllowanceDataTableRow } from './allowance-data-table-row';
+export type { AllowanceDataTableRowProps } from './allowance-data-table-row';

--- a/shared/hook-form/validation/validate-stake-eth.ts
+++ b/shared/hook-form/validation/validate-stake-eth.ts
@@ -9,7 +9,7 @@ import type { BigNumber } from 'ethers';
 export type validateStakeEthParams = {
   formField: string;
   amount: BigNumber;
-  active: boolean;
+  isWalletActive: boolean;
   stakingLimitLevel: LIMIT_LEVEL;
   currentStakeLimit: BigNumber;
   gasCost: BigNumber;
@@ -19,7 +19,7 @@ export type validateStakeEthParams = {
 
 // Runs validation pipeline common between stake and wrapEth
 export const validateStakeEth = ({
-  active,
+  isWalletActive,
   amount,
   formField,
   currentStakeLimit,
@@ -30,7 +30,7 @@ export const validateStakeEth = ({
 }: validateStakeEthParams) => {
   validateStakeLimit('amount', stakingLimitLevel);
 
-  if (active) {
+  if (isWalletActive) {
     validateBignumberMax(
       formField,
       amount,

--- a/shared/hook-form/validation/validate-stake-eth.ts
+++ b/shared/hook-form/validation/validate-stake-eth.ts
@@ -1,0 +1,74 @@
+import { validateBignumberMax } from './validate-bignumber-max';
+import { validateStakeLimit } from './validate-stake-limit';
+import { formatEther } from '@ethersproject/units';
+import { Zero } from '@ethersproject/constants';
+
+import type { LIMIT_LEVEL } from 'types';
+import type { BigNumber } from 'ethers';
+
+export type validateStakeEthParams = {
+  formField: string;
+  amount: BigNumber;
+  active: boolean;
+  stakingLimitLevel: LIMIT_LEVEL;
+  currentStakeLimit: BigNumber;
+  gasCost: BigNumber;
+  etherBalance: BigNumber;
+  isMultisig: boolean;
+};
+
+// Runs validation pipeline common between stake and wrapEth
+export const validateStakeEth = ({
+  active,
+  amount,
+  formField,
+  currentStakeLimit,
+  etherBalance,
+  gasCost,
+  isMultisig,
+  stakingLimitLevel,
+}: validateStakeEthParams) => {
+  validateStakeLimit('amount', stakingLimitLevel);
+
+  if (active) {
+    validateBignumberMax(
+      formField,
+      amount,
+      etherBalance,
+      `Entered ETH amount exceeds your available balance of ${formatEther(
+        etherBalance,
+      )}`,
+    );
+
+    validateBignumberMax(
+      formField,
+      amount,
+      currentStakeLimit,
+      `Entered ETH amount exceeds current staking limit of ${formatEther(
+        currentStakeLimit,
+      )}`,
+    );
+
+    if (!isMultisig) {
+      const gasPaddedBalance = etherBalance.sub(gasCost);
+
+      validateBignumberMax(
+        formField,
+        Zero,
+        gasPaddedBalance,
+        `Ensure you have sufficient ETH to cover the gas cost of ${formatEther(
+          gasCost,
+        )}`,
+      );
+
+      validateBignumberMax(
+        formField,
+        amount,
+        gasPaddedBalance,
+        `Enter ETH amount less than ${formatEther(
+          gasPaddedBalance,
+        )} to ensure you leave enough ETH for gas fees`,
+      );
+    }
+  }
+};


### PR DESCRIPTION
### Description

For All forms:
- [x] Correct behavior for when wallet is not connected (cannot start error tx with pressing ENTER)
- [x] Correct non-validation error behavior(network error won't block submit button)
- [x] Same message when amount is more than balance
- [x] Allowance Data Row component with `-` and `Infinite` cases for Wrap/Request

For Wrap:
- [x]  Wrap ETH now has same validation flow(and messages) and max button behavior as Stake
 
For Claim:
- [x]  When wallet is not connected always show special no-wallet ux

### Demo

<img width="497" alt="image" src="https://github.com/lidofinance/ethereum-staking-widget/assets/3705803/b2789acb-4b3e-40de-940b-2f6ffcdd52e4">

### Code review notes

- With async validation contexts I moved out always available parts like `active`. This allows us to have only `active=true` things in asyncContext(e.g. balance) and in case of `active=false` run basic input validation AND error out silently into **dummy** field. 
What that gives us:  When wallet is not connected user still has basic validation, but even if validation passes - `active=false` sets errors for invisible field, so you cannot submit even with ENTER. Striking user with basic validation first, allows us to hide that we might not have yet loaded balances, stakeLimit and else

- Also moved around some stuff to avoid useless Number-> BigNumber conversion

### Testing notes
All forms are touched, but only as far as validation and errors. No need to test TXs full flow - it's not touched. Also please test input, pressing Enter and other when wallet is disconnected.

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
