### PR TITLE
Change the hiding rule of withdrawal aggregators

### DIFF
--- a/features/withdrawals/request/form/options/dex-options.tsx
+++ b/features/withdrawals/request/form/options/dex-options.tsx
@@ -116,9 +116,9 @@ export const DexOptions: React.FC<
     useWithdrawalRates();
 
   const dexesFiltered = useMemo(() => {
-    return data?.filter(({ rate, name }) => {
+    return data?.filter(({ rate, name, displayEmpty }) => {
       const dex = dexInfo[name];
-      return dex && (amount.eq('0') || rate !== null);
+      return dex && (amount.eq('0') || rate !== null || displayEmpty);
     });
   }, [amount, data]);
 


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

Withdrawal aggregator should be hidden only when respond error code is 500

### Demo

<img width="539" alt="image" src="https://github.com/lidofinance/ethereum-staking-widget/assets/7289992/ade77667-c979-4638-846b-78a9aff42565">

### Checklist:

- [x] Checked the changes locally.
