### PR TITLE
fix: n/a status for "you will receive" wrap/unwrap fields

### DIFF
--- a/features/withdrawals/request/wallet/wallet-wsteth-balance.tsx
+++ b/features/withdrawals/request/wallet/wallet-wsteth-balance.tsx
@@ -7,7 +7,7 @@ import { useRequestFormData } from '../request-form-context';
 
 export const WalletWstethBalance = () => {
   const { balanceWSteth } = useRequestFormData();
-  const stethByWstethBalance = useStethByWsteth(balanceWSteth);
+  const { data: stethByWstethBalance } = useStethByWsteth(balanceWSteth);
 
   const stethBalanceValue = (
     <>

--- a/features/wsteth/shared/wallet/wallet.tsx
+++ b/features/wsteth/shared/wallet/wallet.tsx
@@ -26,8 +26,8 @@ const WalletComponent: WalletComponentType = (props) => {
   const stethAddress = useTokenAddress(TOKENS.STETH);
   const wstethAddress = useTokenAddress(TOKENS.WSTETH);
 
-  const wstethByStethBalance = useWstethBySteth(stethBalance.data);
-  const stethByWstethBalance = useStethByWsteth(wstethBalance.data);
+  const { data: wstethByStethBalance } = useWstethBySteth(stethBalance.data);
+  const { data: stethByWstethBalance } = useStethByWsteth(wstethBalance.data);
 
   return (
     <StyledCard data-testid="wrapCardSection" {...props}>

--- a/features/wsteth/unwrap/unwrap-form-context/types.ts
+++ b/features/wsteth/unwrap/unwrap-form-context/types.ts
@@ -16,6 +16,4 @@ export type UnwrapFormValidationContext = {
 };
 
 export type UnwrapFormDataContextValueType = UnwrapFormNetworkData &
-  FormControllerContextValueType<UnwrapFormInputType> & {
-    willReceiveStETH?: BigNumber;
-  };
+  FormControllerContextValueType<UnwrapFormInputType>;

--- a/features/wsteth/unwrap/unwrap-form-context/unwrap-form-context.tsx
+++ b/features/wsteth/unwrap/unwrap-form-context/unwrap-form-context.tsx
@@ -7,7 +7,6 @@ import {
   useContext,
 } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
-import { useStethByWsteth } from 'shared/hooks';
 import { useUnwrapFormNetworkData } from '../hooks/use-unwrap-form-network-data';
 import { useUnwrapFormProcessor } from '../hooks/use-unwrap-form-processing';
 import { useUnwrapFormValidationContext } from '../hooks/use-unwra-form-validation-context';
@@ -20,7 +19,6 @@ import {
   UnwrapFormValidationContext,
 } from './types';
 import { UnwrapFormValidationResolver } from './unwrap-form-validators';
-import { Zero } from '@ethersproject/constants';
 
 //
 // Data context
@@ -58,22 +56,16 @@ export const UnwrapFormProvider: FC<PropsWithChildren> = ({ children }) => {
     resolver: UnwrapFormValidationResolver,
   });
 
-  const { watch } = formObject;
-  const [amount] = watch(['amount']);
-
   const processUnwrapFormFlow = useUnwrapFormProcessor({
     onConfirm: networkData.revalidateUnwrapFormData,
   });
 
-  const willReceiveStETH = useStethByWsteth(amount ?? Zero);
-
   const value = useMemo(
     (): UnwrapFormDataContextValueType => ({
       ...networkData,
-      willReceiveStETH,
       onSubmit: processUnwrapFormFlow,
     }),
-    [networkData, processUnwrapFormFlow, willReceiveStETH],
+    [networkData, processUnwrapFormFlow],
   );
 
   return (

--- a/features/wsteth/unwrap/unwrap-form/unwrap-form-tx-modal.tsx
+++ b/features/wsteth/unwrap/unwrap-form/unwrap-form-tx-modal.tsx
@@ -1,12 +1,21 @@
+import { useWatch } from 'react-hook-form';
 import { useTransactionModal } from 'shared/transaction-modal';
+import { useStethByWsteth } from 'shared/hooks';
+import { useUnwrapFormData } from '../unwrap-form-context';
 import { convertTxStageToLegacy } from 'features/wsteth/shared/utils/convertTxModalStageToLegacy';
 import { TxStageModal } from 'shared/components';
-import { useUnwrapFormData } from '../unwrap-form-context';
 import { TX_OPERATION as TX_OPERATION_LEGACY } from 'shared/components/tx-stage-modal';
+import type { RequestFormInputType } from 'features/withdrawals/request/request-form-context';
+import { Zero } from '@ethersproject/constants';
 
 export const UnwrapFormTxModal = () => {
-  const { stethBalance, willReceiveStETH } = useUnwrapFormData();
+  const { stethBalance } = useUnwrapFormData();
   const { dispatchModalState, onRetry, ...modalState } = useTransactionModal();
+
+  const [amount] = useWatch<RequestFormInputType, ['amount']>({
+    name: ['amount'],
+  });
+  const { data: willReceiveStETH } = useStethByWsteth(amount ?? Zero);
 
   return (
     <TxStageModal

--- a/features/wsteth/unwrap/unwrap-form/unwrap-stats.tsx
+++ b/features/wsteth/unwrap/unwrap-form/unwrap-stats.tsx
@@ -32,7 +32,7 @@ export const UnwrapStats = () => {
       </DataTableRow>
       <DataTableRowStethByWsteth />
       <DataTableRow title="You will receive" loading={initialLoading}>
-        {!willReceiveStETH && 'N/A'}
+        {!willReceiveStETH && '-'}
         {willReceiveStETH && (
           <FormatToken
             data-testid="youWillReceive"

--- a/features/wsteth/unwrap/unwrap-form/unwrap-stats.tsx
+++ b/features/wsteth/unwrap/unwrap-form/unwrap-stats.tsx
@@ -1,16 +1,25 @@
-import { useTxCostInUsd } from 'shared/hooks';
+import { useStethByWsteth, useTxCostInUsd } from 'shared/hooks';
 import { useUnwrapGasLimit } from '../hooks/use-unwrap-gas-limit';
-import { useUnwrapFormData } from '../unwrap-form-context';
+import { useWatch } from 'react-hook-form';
 
 import { DataTableRow, DataTable } from '@lidofinance/lido-ui';
 import { FormatToken } from 'shared/formatters/format-token';
 import { DataTableRowStethByWsteth } from 'shared/components/data-table-row-steth-by-wsteth';
 import { FormatPrice } from 'shared/formatters';
+import { Zero } from '@ethersproject/constants';
+import type { RequestFormInputType } from 'features/withdrawals/request/request-form-context';
 
 export const UnwrapStats = () => {
   const unwrapGasLimit = useUnwrapGasLimit();
   const unwrapTxCostInUsd = useTxCostInUsd(Number(unwrapGasLimit));
-  const { willReceiveStETH } = useUnwrapFormData();
+
+  const [amount] = useWatch<RequestFormInputType, ['amount']>({
+    name: ['amount'],
+  });
+
+  const { data: willReceiveStETH, initialLoading } = useStethByWsteth(
+    amount ?? Zero,
+  );
 
   return (
     <DataTable>
@@ -22,14 +31,17 @@ export const UnwrapStats = () => {
         <FormatPrice amount={unwrapTxCostInUsd} />
       </DataTableRow>
       <DataTableRowStethByWsteth />
-      <DataTableRow title="You will receive" loading={!willReceiveStETH}>
-        <FormatToken
-          data-testid="youWillReceive"
-          amount={willReceiveStETH}
-          symbol="stETH"
-          showAmountTip
-          trimEllipsis
-        />
+      <DataTableRow title="You will receive" loading={initialLoading}>
+        {!willReceiveStETH && 'N/A'}
+        {willReceiveStETH && (
+          <FormatToken
+            data-testid="youWillReceive"
+            amount={willReceiveStETH}
+            symbol="stETH"
+            showAmountTip
+            trimEllipsis
+          />
+        )}
       </DataTableRow>
     </DataTable>
   );

--- a/features/wsteth/wrap/wrap-form-context/types.ts
+++ b/features/wsteth/wrap/wrap-form-context/types.ts
@@ -36,6 +36,5 @@ export type WrapFormDataContextValueType = WrapFormNetworkData &
     isSteth: boolean;
     maxAmount?: BigNumber;
     wrapGasLimit: BigNumber;
-    willReceiveWsteth?: BigNumber;
     stakeLimitInfo?: StakeLimitFullInfo;
   };

--- a/features/wsteth/wrap/wrap-form-context/wrap-form-context.tsx
+++ b/features/wsteth/wrap/wrap-form-context/wrap-form-context.tsx
@@ -7,7 +7,6 @@ import {
   useContext,
 } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
-import { useDebouncedValue, useWstethBySteth } from 'shared/hooks';
 import { useWrapTxApprove } from '../hooks/use-wrap-tx-approve';
 import { useWrapFormNetworkData } from '../hooks/use-wrap-form-network-data';
 import { useWrapFormProcessor } from '../hooks/use-wrap-form-processing';
@@ -69,10 +68,6 @@ export const WrapFormProvider: FC<PropsWithChildren> = ({ children }) => {
 
   const isSteth = token === TOKENS_TO_WRAP.STETH;
 
-  const amountDebounced = useDebouncedValue(amount, 500);
-
-  const willReceiveWsteth = useWstethBySteth(amountDebounced ?? Zero);
-
   const value = useMemo(
     (): WrapFormDataContextValueType => ({
       ...networkData,
@@ -83,16 +78,9 @@ export const WrapFormProvider: FC<PropsWithChildren> = ({ children }) => {
       wrapGasLimit: isSteth
         ? networkData.gasLimitStETH
         : networkData.gasLimitETH,
-      willReceiveWsteth,
       onSubmit: processWrapFormFlow,
     }),
-    [
-      networkData,
-      approvalData,
-      isSteth,
-      willReceiveWsteth,
-      processWrapFormFlow,
-    ],
+    [networkData, approvalData, isSteth, processWrapFormFlow],
   );
 
   return (

--- a/features/wsteth/wrap/wrap-form/wrap-form-tx-modal.tsx
+++ b/features/wsteth/wrap/wrap-form/wrap-form-tx-modal.tsx
@@ -1,6 +1,7 @@
 import { useTransactionModal } from 'shared/transaction-modal/transaction-modal-context';
 import { useFormContext } from 'react-hook-form';
 import { useWrapFormData, WrapFormInputType } from '../wrap-form-context';
+import { useWstethBySteth } from 'shared/hooks';
 
 import { TxStageModal } from 'shared/components';
 
@@ -9,10 +10,11 @@ import {
   convertTxStageToLegacy,
   convertTxStageToLegacyTxOperationWrap,
 } from 'features/wsteth/shared/utils/convertTxModalStageToLegacy';
+import { Zero } from '@ethersproject/constants';
 
 export const WrapFormTxModal = () => {
   const { watch } = useFormContext<WrapFormInputType>();
-  const { allowance, wstethBalance, willReceiveWsteth } = useWrapFormData();
+  const { allowance, wstethBalance } = useWrapFormData();
   const {
     dispatchModalState,
     onRetry,
@@ -24,6 +26,7 @@ export const WrapFormTxModal = () => {
     txOperation,
   } = useTransactionModal();
   const [token] = watch(['token']);
+  const { data: willReceiveWsteth } = useWstethBySteth(amount ?? Zero);
 
   return (
     <TxStageModal

--- a/features/wsteth/wrap/wrap-form/wrap-stats.tsx
+++ b/features/wsteth/wrap/wrap-form/wrap-stats.tsx
@@ -74,7 +74,7 @@ export const WrapFormStats = () => {
       />
 
       <DataTableRow title="You will receive" loading={initialLoading}>
-        {!willReceiveWsteth && 'N/A'}
+        {!willReceiveWsteth && '-'}
         {willReceiveWsteth && (
           <FormatToken
             amount={willReceiveWsteth}

--- a/shared/components/data-table-row-steth-by-wsteth/data-table-row-steth-by-wsteth.tsx
+++ b/shared/components/data-table-row-steth-by-wsteth/data-table-row-steth-by-wsteth.tsx
@@ -8,7 +8,7 @@ import { parseEther } from '@ethersproject/units';
 
 export const useWstethToStethRatio = () => {
   const oneWstethAsBigNumber = useMemo(() => parseEther('1'), []);
-  const wstethAsStethBN = useStethByWsteth(oneWstethAsBigNumber);
+  const { data: wstethAsStethBN } = useStethByWsteth(oneWstethAsBigNumber);
 
   return { wstethAsStethBN, loading: !wstethAsStethBN };
 };

--- a/shared/hooks/useStethByWsteth.ts
+++ b/shared/hooks/useStethByWsteth.ts
@@ -2,14 +2,12 @@ import { useContractSWR, useWSTETHContractRPC } from '@lido-sdk/react';
 import { BigNumber } from 'ethers';
 import { STRATEGY_LAZY } from 'utils/swrStrategies';
 
-export const useStethByWsteth = (
-  wsteth: BigNumber | undefined,
-): BigNumber | undefined => {
+export const useStethByWsteth = (wsteth: BigNumber | undefined) => {
   return useContractSWR({
     contract: useWSTETHContractRPC(),
     method: 'getStETHByWstETH',
     params: [wsteth],
     shouldFetch: !!wsteth,
     config: STRATEGY_LAZY,
-  }).data;
+  });
 };

--- a/shared/hooks/useWstethBySteth.ts
+++ b/shared/hooks/useWstethBySteth.ts
@@ -2,14 +2,12 @@ import { useContractSWR, useWSTETHContractRPC } from '@lido-sdk/react';
 import { BigNumber } from 'ethers';
 import { STRATEGY_LAZY } from 'utils/swrStrategies';
 
-export const useWstethBySteth = (
-  steth: BigNumber | undefined,
-): BigNumber | undefined => {
+export const useWstethBySteth = (steth: BigNumber | undefined) => {
   return useContractSWR({
     contract: useWSTETHContractRPC(),
     method: 'getWstETHByStETH',
     params: [steth],
     shouldFetch: !!steth,
     config: STRATEGY_LAZY,
-  }).data;
+  });
 };


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

"You will receive" field will display N/A for unsupported value entered

### Code review notes

- `useStethByWsteth` and  `useWstethBySteth` now returns swr response object to make it possible to detect loading status and request error.
- `willReceiveStETH` and `willReceiveWsteth` are removed from form context and requested on the place of demand now. SWR handles caching now so we do can de-bloat the context, also I am aware of putting such complex objects as SWR response object to the context avoiding extra data updates in places where this data is not in use.

### Testing notes

Wrap and Unwrap pages touched.

### Checklist:

- [x] Checked the changes locally.
