### PR TITLE
fix: use token max amount limit after gas

### DIFF
--- a/shared/hooks/use-token-max-amount.ts
+++ b/shared/hooks/use-token-max-amount.ts
@@ -28,10 +28,6 @@ export const useTokenMaxAmount = ({
 
     let maxAmount: BigNumber | undefined = balance;
 
-    if (limit && balance.gt(limit)) {
-      maxAmount = limit;
-    }
-
     if (isPadded) {
       if (padding) {
         maxAmount = maxAmount.sub(padding);
@@ -41,6 +37,10 @@ export const useTokenMaxAmount = ({
         maxAmount = maxAmount.sub(gasLimit.mul(maxGasPrice));
         if (maxAmount.lt(Zero)) maxAmount = Zero;
       } else maxAmount = undefined;
+    }
+
+    if (limit && maxAmount && maxAmount.gt(limit)) {
+      maxAmount = limit;
     }
 
     return maxAmount;


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

> if user has more ETH than the limit, if he clicks to Max button, the amount to be <LIMIT - GAS> 
> Expected result: the amount equals with limit



### Checklist:

- [x] Checked the changes locally.
