### PR TITLE
fix: openocean gas price source updated

### DIFF
--- a/utils/get-open-ocean-rate.ts
+++ b/utils/get-open-ocean-rate.ts
@@ -6,6 +6,7 @@ import { formatEther } from '@ethersproject/units';
 type OpenOceanGetGasPartial = {
   without_decimals: {
     standard: {
+      maxFeePerGas: string;
       legacyGasPrice: string;
     };
   };
@@ -70,7 +71,7 @@ export const getOpenOceanRate = async (
   const params = new URLSearchParams({
     inTokenAddress: getRateTokenAddress(fromToken),
     outTokenAddress: getRateTokenAddress(toToken),
-    gasPrice: gasData.without_decimals.standard.legacyGasPrice,
+    gasPrice: gasData.without_decimals.standard.maxFeePerGas,
     amount: formatEther(amount),
   });
 


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

We need to get maxFeePerGas from gasPrice endpoint and pass it as gasPrice param in quote endpoint

### Checklist:

- [x] Checked the changes locally.
