### PR TITLE
Fix Mainnet RPC Url

### DIFF
--- a/shared/hooks/use-mainnet-static-rpc-provider.ts
+++ b/shared/hooks/use-mainnet-static-rpc-provider.ts
@@ -2,12 +2,12 @@ import { useMemo } from 'react';
 import { getStaticRpcBatchProvider } from '@lido-sdk/providers';
 import { StaticJsonRpcBatchProvider } from '@lidofinance/eth-providers';
 
-import { useRpcUrl } from 'config';
+import { useGetRpcUrlByChainId } from 'config';
+import { CHAINS } from 'utils';
 
 export const useMainnetStaticRpcProvider = (): StaticJsonRpcBatchProvider => {
-  const rpcUrl = useRpcUrl();
-
+  const getRpcUrl = useGetRpcUrlByChainId();
   return useMemo(() => {
-    return getStaticRpcBatchProvider(1, rpcUrl);
-  }, [rpcUrl]);
+    return getStaticRpcBatchProvider(1, getRpcUrl(CHAINS.Mainnet));
+  }, [getRpcUrl]);
 };


### PR DESCRIPTION
### Description

In `useMainnetStaticRpcProvider` wrong rpc was passed to provider.


### Testing notes

Functionality affected:

- On testnets where mainnet RPC is used.
- IPFS upgrade banner, ens look up


### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
