### PR TITLE
Add a link to IPFS instruction from lido docs

### DIFF
--- a/features/ipfs/rpc-availability-check-result-box/rpc-availability-check-result-box.tsx
+++ b/features/ipfs/rpc-availability-check-result-box/rpc-availability-check-result-box.tsx
@@ -8,7 +8,7 @@ import { LinkArrow } from 'shared/components/link-arrow/link-arrow';
 
 import { Wrap, RpcStatusBox, Button, Text } from './styles';
 
-const IPFS_INFO_URL = 'https://docs.ipfs.tech/concepts/what-is-ipfs/';
+const IPFS_INFO_URL = 'https://docs.lido.fi/guides/ipfs/';
 
 export const RPCAvailabilityCheckResultBox = () => {
   const { isRPCAvailable, handleClickDismiss } = useIPFSInfoBoxStatuses();
@@ -25,7 +25,7 @@ export const RPCAvailabilityCheckResultBox = () => {
       <Text weight={700} size="xs" color="accentContrast">
         You are currently using the IPFS widget&apos;s version.
       </Text>
-      <LinkArrow href={IPFS_INFO_URL}>IPFS</LinkArrow>
+      <LinkArrow href={IPFS_INFO_URL}>What is IPFS</LinkArrow>
       {isRPCAvailable && (
         <>
           <RpcStatusBox status="success">

--- a/features/ipfs/rpc-availability-check-result-box/rpc-availability-check-result-box.tsx
+++ b/features/ipfs/rpc-availability-check-result-box/rpc-availability-check-result-box.tsx
@@ -8,7 +8,7 @@ import { LinkArrow } from 'shared/components/link-arrow/link-arrow';
 
 import { Wrap, RpcStatusBox, Button, Text } from './styles';
 
-const IPFS_INFO_URL = 'https://docs.lido.fi/guides/ipfs/';
+const IPFS_INFO_URL = 'https://docs.lido.fi/ipfs/ipfs-guide';
 
 export const RPCAvailabilityCheckResultBox = () => {
   const { isRPCAvailable, handleClickDismiss } = useIPFSInfoBoxStatuses();

--- a/features/ipfs/rpc-availability-check-result-box/rpc-availability-check-result-box.tsx
+++ b/features/ipfs/rpc-availability-check-result-box/rpc-availability-check-result-box.tsx
@@ -8,7 +8,7 @@ import { LinkArrow } from 'shared/components/link-arrow/link-arrow';
 
 import { Wrap, RpcStatusBox, Button, Text } from './styles';
 
-const IPFS_INFO_URL = 'https://docs.lido.fi/ipfs/ipfs-guide';
+const IPFS_INFO_URL = 'https://docs.lido.fi/ipfs/about';
 
 export const RPCAvailabilityCheckResultBox = () => {
   const { isRPCAvailable, handleClickDismiss } = useIPFSInfoBoxStatuses();


### PR DESCRIPTION
### Description
Resolves SI-1121

**Note!** https://github.com/lidofinance/docs/pull/332 must be released before this PR.

The task was to write an instruction about IPFS for our regular users and place a link to this instruction somewhere on IPFS version of the widget.

I place it here under "What is IPFS" link. Previously there was just "IPFS" labeled link to ipfs official docs.

<img width="287" alt="image" src="https://github.com/lidofinance/ethereum-staking-widget/assets/1245209/878750a2-ff85-4b62-8f0d-37492e7ddc23">

### Code review and Testing notes
The update is visible on IPFS version of the widget.
Maybe there is some better place for the instruction?

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
