### PR TITLE
fix: use reef-knot 2.1.1 and useAutoConnectCheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "react-hook-form": "^7.45.2",
     "react-is": "^18.2.0",
     "react-transition-group": "^4.4.2",
-    "reef-knot": "^2.1.0",
+    "reef-knot": "^2.1.1",
     "remark": "^13.0.0",
     "remark-external-links": "^8.0.0",
     "remark-html": "^13.0.1",

--- a/shared/wallet/connect-wallet-modal/connect-wallet-modal.tsx
+++ b/shared/wallet/connect-wallet-modal/connect-wallet-modal.tsx
@@ -5,11 +5,11 @@ import type { ModalComponentType } from 'providers/modal-provider';
 
 export const ConnectWalletModal: ModalComponentType = (props) => {
   const { themeName } = useThemeToggle();
+
   return (
     <WalletsModalForEth
       {...props}
       shouldInvertWalletIcon={themeName === 'dark'}
-      hiddenWallets={['Opera Wallet']}
       metrics={walletsMetrics}
     />
   );

--- a/shared/wallet/connect/connect.tsx
+++ b/shared/wallet/connect/connect.tsx
@@ -4,13 +4,13 @@ import { wrapWithEventTrack } from '@lidofinance/analytics-matomo';
 import { MATOMO_CLICK_EVENTS } from 'config';
 import { useClientConfig } from 'providers/client-config';
 import { useConnectWalletModal } from '../connect-wallet-modal/use-connect-wallet-modal';
-import { useConnectorInfo, useEagerConnect } from 'reef-knot/core-react';
+import { useAutoConnectCheck, useEagerConnect } from 'reef-knot/core-react';
 
 export const Connect: FC<ButtonProps> = (props) => {
   const { isWalletConnectionAllowed } = useClientConfig();
   const { onClick, ...rest } = props;
   const { openModal } = useConnectWalletModal();
-  const { isAutoConnectionSuitable } = useConnectorInfo();
+  const { isAutoConnectionSuitable } = useAutoConnectCheck();
   const { eagerConnect } = useEagerConnect();
 
   const handleClick = wrapWithEventTrack(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2571,10 +2571,10 @@
     "@types/react" "18.2.45"
     "@types/react-dom" "18.2.17"
 
-"@reef-knot/core-react@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@reef-knot/core-react/-/core-react-2.1.0.tgz#acee578c5a51bf4fee83a9169e37e97f95539d40"
-  integrity sha512-7qAMmRacZ3x40lZj4esE514u63FwEk+pgeI0hQ+r98M8gJA6mVBZNn6rGU+Vq0JMcurwBnEOdF01+nHrgxJYkA==
+"@reef-knot/core-react@2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@reef-knot/core-react/-/core-react-2.1.1.tgz#ee5bae446fe1d9b43c048ba3b73dd6a9cab491a1"
+  integrity sha512-wHacmKV636c9K0uIQJUUASaG3Cg2oNFJMef2N7mFfRyz4iO3GKhiAI/yISNkJYiU5I3AUmlDk+airbS61dfiwQ==
   dependencies:
     ua-parser-js "1.0.33"
 
@@ -9218,13 +9218,13 @@ redis-parser@^3.0.0:
   dependencies:
     redis-errors "^1.0.0"
 
-reef-knot@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/reef-knot/-/reef-knot-2.1.0.tgz#a9cade9c73d675764b345380a28cf9adf116eaf1"
-  integrity sha512-sfANXjqfNeGjft9+ie+CRjjbYElNxnZ3NOPLcI+XifMv3/EwsXBlo6htGTDYMmyqZ+/Fj7DN00RLGLZJpMTxoA==
+reef-knot@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/reef-knot/-/reef-knot-2.1.1.tgz#cd90e9276aa351671a4516515895a88d52b21790"
+  integrity sha512-l9OHDOg7sWcZkql+3CF1DRAFBuWAZuP1CLFRq2CHJ3oNRsJC7+EFU8YNrvggtqSRM/FlKXI63vIl18ngAtpN/Q==
   dependencies:
     "@reef-knot/connect-wallet-modal" "2.1.0"
-    "@reef-knot/core-react" "2.1.0"
+    "@reef-knot/core-react" "2.1.1"
     "@reef-knot/ledger-connector" "3.0.0"
     "@reef-knot/types" "1.5.0"
     "@reef-knot/ui-react" "1.0.8"


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description
This PR solves issue with `isAutoConnectionSuitable` not working properly, which causes issues with autoConnect and transactions.

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
