### PR TITLE
fix: rollback "Connect wallet" eagerConnect behaviour

### DIFF
--- a/shared/wallet/connect/connect.tsx
+++ b/shared/wallet/connect/connect.tsx
@@ -4,31 +4,18 @@ import { wrapWithEventTrack } from '@lidofinance/analytics-matomo';
 import { MATOMO_CLICK_EVENTS } from 'config';
 import { useClientConfig } from 'providers/client-config';
 import { useConnectWalletModal } from '../connect-wallet-modal/use-connect-wallet-modal';
-import { useAutoConnectCheck, useEagerConnect } from 'reef-knot/core-react';
 
 export const Connect: FC<ButtonProps> = (props) => {
   const { isWalletConnectionAllowed } = useClientConfig();
   const { onClick, ...rest } = props;
   const { openModal } = useConnectWalletModal();
-  const { isAutoConnectionSuitable } = useAutoConnectCheck();
-  const { eagerConnect } = useEagerConnect();
 
   const handleClick = wrapWithEventTrack(
     MATOMO_CLICK_EVENTS.connectWallet,
     useCallback(() => {
       if (!isWalletConnectionAllowed) return;
-      // for auto-connect skip modal and try reconnect
-      if (isAutoConnectionSuitable) {
-        void eagerConnect();
-      } else {
-        openModal({});
-      }
-    }, [
-      eagerConnect,
-      isAutoConnectionSuitable,
-      isWalletConnectionAllowed,
-      openModal,
-    ]),
+      openModal({});
+    }, [isWalletConnectionAllowed, openModal]),
   );
 
   return (


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

Rollback "Connect wallet" eagerConnect behaviour as a temporary solution for the issue with Accept Terms modal and autoConnect.

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
