### PR TITLE
fix: disable wagmi autoConnect

### DIFF
--- a/providers/web3.tsx
+++ b/providers/web3.tsx
@@ -85,12 +85,11 @@ const Web3Provider: FC<PropsWithChildren> = ({ children }) => {
 
     return createClient({
       connectors,
-      autoConnect: isWalletConnectionAllowed,
+      autoConnect: false, // default wagmi autoConnect, MUST be false in our case, because we use custom autoConnect from Reef Knot
       provider,
       webSocketProvider,
     });
   }, [
-    isWalletConnectionAllowed,
     supportedChains,
     defaultChain,
     backendRPC,


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description
Disable wagmi default autoConnect, because it duplicates our custom Reef Knot autoConnect, which causes issues.

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
