### PR TITLE
feat: add infra update banner

### DIFF
--- a/features/ipfs/security-status-banner/security-status-banner.tsx
+++ b/features/ipfs/security-status-banner/security-status-banner.tsx
@@ -51,7 +51,7 @@ const warningContent = ({
         canClose: false,
       };
     // we can show this banner on both infra and IPFS
-    case isVersionUnsafe && (!isIpfs || !isUpdateAvailable):
+    case isVersionUnsafe && !isUpdateAvailable:
       return {
         content: (
           <WarningText>
@@ -60,6 +60,17 @@ const warningContent = ({
         ),
         canClose: false,
         showTwitterLink: true,
+      };
+    case isVersionUnsafe && isUpdateAvailable:
+      return {
+        content: (
+          <WarningText>
+            This version of Lido staking widget has issues that could impact
+            your experience.
+          </WarningText>
+        ),
+        canClose: false,
+        showTwitterLink: false,
       };
     // outdated IPFS
     case isIpfs && isUpdateAvailable:
@@ -119,7 +130,15 @@ export const SecurityStatusBanner = () => {
           )}
           {isUpdateAvailable && (
             <a
-              href={data.remoteCidLink}
+              href={data.remoteCidLink ?? window.location.href}
+              onClick={
+                dynamics.ipfsMode
+                  ? undefined
+                  : (e) => {
+                      e.preventDefault();
+                      window.location.reload();
+                    }
+              }
               target="_self"
               rel="noopener noreferrer"
             >

--- a/features/ipfs/security-status-banner/use-version-check.ts
+++ b/features/ipfs/security-status-banner/use-version-check.ts
@@ -25,7 +25,7 @@ export const useVersionCheck = () => {
   const { forceDisconnect } = useForceDisconnect();
   const [areConditionsAccepted, setConditionsAccepted] = useState(false);
 
-  // local cid extraction
+  // only IPFS: local cid extraction
   const currentCidSWR = useLidoSWR(
     ['swr:ipfs-cid-extraction'],
     async () => {
@@ -42,11 +42,15 @@ export const useVersionCheck = () => {
   // ens cid extraction
   const remoteVersionSWR = useRemoteVersion();
 
+  // update is available
+  // for INFRA - leastSafeVersion is not NO_SAFE_VERSION
+  // for IPFS - ^this and current cid doesn't match
   const isUpdateAvailable = overrideWithQAMockBoolean(
     Boolean(
       remoteVersionSWR.data &&
-        currentCidSWR.data &&
-        remoteVersionSWR.data.cid !== currentCidSWR.data &&
+        ((currentCidSWR.data &&
+          remoteVersionSWR.data.cid !== currentCidSWR.data) ||
+          !dynamics.ipfsMode) &&
         remoteVersionSWR.data.leastSafeVersion !== NO_SAFE_VERSION,
     ),
     'mock-qa-helpers-security-banner-is-update-available',


### PR DESCRIPTION
### Description

Added banner for when infra version is unsafe but there is a safe version update available.

### Demo

<img width="647" alt="image" src="https://github.com/lidofinance/ethereum-staking-widget/assets/3705803/4340e455-df04-42cc-9942-0611aa08f7d8">

### Testing notes
Can be tested with localStorage and qa helpers:
`mock-qa-helpers-security-banner-is-update-available` = `true`
`mock-qa-helpers-security-banner-is-version-unsafe` = `true`


### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
