### PR TITLE
fix: qa helper stake limit for wrap eth

### DIFF
--- a/features/wsteth/wrap/hooks/use-wrap-tx-processing.ts
+++ b/features/wsteth/wrap/hooks/use-wrap-tx-processing.ts
@@ -9,7 +9,12 @@ import { useCurrentStaticRpcProvider } from 'shared/hooks/use-current-static-rpc
 import { getFeeData } from 'utils/getFeeData';
 
 import type { WrapFormInputType } from '../wrap-form-context';
-import { applyGasLimitRatio } from 'features/stake/stake-form/utils';
+import {
+  MockLimitReachedError,
+  applyGasLimitRatio,
+} from 'features/stake/stake-form/utils';
+
+import { enableQaHelpers } from 'utils/qa';
 
 export const getGasParameters = async (
   provider: StaticJsonRpcBatchProvider,
@@ -48,6 +53,13 @@ export const useWrapTxProcessing = () => {
           );
         }
       } else {
+        if (
+          enableQaHelpers &&
+          window.localStorage.getItem('mockLimitReached') === 'true'
+        ) {
+          throw new MockLimitReachedError('Stake limit reached');
+        }
+
         const wstethTokenAddress = getTokenAddress(chainId, TOKENS.WSTETH);
         if (isMultisig) {
           return providerWeb3.getSigner().sendUncheckedTransaction({


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

Fixed QA helper for Wrap eth.

### Demo

<img width="1189" alt="image" src="https://github.com/lidofinance/ethereum-staking-widget/assets/3705803/a3285cb6-0bef-424a-beee-ea7d77f15f8c">



### Testing notes

`localStorage.setItem('mockLimitReached',true)`

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
