### PR TITLE
feat: 1inch integration mode classic

### DIFF
--- a/features/withdrawals/request/withdrawal-rates/integrations.ts
+++ b/features/withdrawals/request/withdrawal-rates/integrations.ts
@@ -173,9 +173,9 @@ const dexWithdrawalMap: DexWithdrawalIntegrationMap = {
     icon: OneInchIcon,
     matomoEvent: MATOMO_CLICK_EVENTS_TYPES.withdrawalGoTo1inch,
     link: (amount, token) =>
-      `https://app.1inch.io/#/1/simple/swap/${
+      `https://app.1inch.io/#/1/advanced/swap/${
         token == TOKENS.STETH ? 'stETH' : 'wstETH'
-      }/ETH?sourceTokenAmount=${formatEther(amount)}`,
+      }/ETH?mode=classic&sourceTokenAmount=${formatEther(amount)}`,
   },
   bebop: {
     title: 'Bebop',


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

In order to have the same rate on Lido UI and 1inch app, we need to change API navigation from "fusion mode" to “classic swap”.

### Checklist:

- [x] Checked the changes locally.
