### PR TITLE
fix: use 'config' instead of 'dynamics'

### DIFF
--- a/features/ipfs/security-status-banner/security-status-banner.tsx
+++ b/features/ipfs/security-status-banner/security-status-banner.tsx
@@ -132,7 +132,7 @@ export const SecurityStatusBanner = () => {
             <a
               href={data.remoteCidLink ?? window.location.href}
               onClick={
-                dynamics.ipfsMode
+                config.ipfsMode
                   ? undefined
                   : (e) => {
                       e.preventDefault();

--- a/features/ipfs/security-status-banner/use-version-check.ts
+++ b/features/ipfs/security-status-banner/use-version-check.ts
@@ -52,7 +52,7 @@ export const useVersionCheck = () => {
       remoteVersionSWR.data &&
         ((currentCidSWR.data &&
           remoteVersionSWR.data.cid !== currentCidSWR.data) ||
-          !dynamics.ipfsMode) &&
+          !config.ipfsMode) &&
         remoteVersionSWR.data.leastSafeVersion !== NO_SAFE_VERSION,
     ),
     'mock-qa-helpers-security-banner-is-update-available',


### PR DESCRIPTION
### Description

Fix using config after merged https://github.com/lidofinance/ethereum-staking-widget/pull/303 to develop

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
