### PR TITLE
feat: removed waiting time range

### DIFF
--- a/features/withdrawals/hooks/useWaitingTime.ts
+++ b/features/withdrawals/hooks/useWaitingTime.ts
@@ -62,7 +62,7 @@ export const useWaitingTime = (
 
   const waitingTime =
     days && days > 1
-      ? `${isApproximate ? '~ ' : ''}1-${days} day(s)`
+      ? `${isApproximate ? '~ ' : ''}${days} days`
       : `${isApproximate ? '~ ' : ''}${days} day`;
   const value =
     isPaused || isRequestError ? '—' : isBunker ? 'Not estimated' : waitingTime;


### PR DESCRIPTION
### Description
- change range `~1 - ${calcTime}` to single number `~${calcTime}`

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
