### PR TITLE
Stake referral metric

### DIFF
--- a/config/groups/stake.ts
+++ b/config/groups/stake.ts
@@ -1,5 +1,6 @@
 import { BigNumber } from 'ethers';
 import { parseEther } from '@ethersproject/units';
+import { AddressZero } from '@ethersproject/constants';
 
 import { StakeSwapDiscountIntegrationKey } from 'features/stake/swap-discount-banner';
 
@@ -9,7 +10,6 @@ import { IPFS_REFERRAL_ADDRESS } from './ipfs';
 // import { config } from '../get-config';
 // otherwise you will get something like a cyclic error!
 import { preConfig } from '../get-preconfig';
-import { AddressZero } from '@ethersproject/constants';
 
 export const PRECISION = 10 ** 6;
 

--- a/config/groups/stake.ts
+++ b/config/groups/stake.ts
@@ -26,6 +26,8 @@ export const STAKE_GASLIMIT_FALLBACK = BigNumber.from(
   ),
 );
 
+export const STAKE_WIDGET_METRIC_SUFFIX = '01';
+
 export const STAKE_FALLBACK_REFERRAL_ADDRESS = preConfig.ipfsMode
   ? IPFS_REFERRAL_ADDRESS
   : AddressZero;

--- a/config/groups/stake.ts
+++ b/config/groups/stake.ts
@@ -1,5 +1,4 @@
 import { BigNumber } from 'ethers';
-import { AddressZero } from '@ethersproject/constants';
 import { parseEther } from '@ethersproject/units';
 
 import { StakeSwapDiscountIntegrationKey } from 'features/stake/swap-discount-banner';
@@ -26,9 +25,12 @@ export const STAKE_GASLIMIT_FALLBACK = BigNumber.from(
   ),
 );
 
+export const STAKE_REFERRAL_OFFSET =
+  '0x11D00000000000000000000000000000000011D0';
+
 export const STAKE_FALLBACK_REFERRAL_ADDRESS = preConfig.ipfsMode
   ? IPFS_REFERRAL_ADDRESS
-  : AddressZero;
+  : STAKE_REFERRAL_OFFSET;
 
 export const STAKE_SWAP_INTEGRATION: StakeSwapDiscountIntegrationKey =
   'one-inch';

--- a/config/groups/stake.ts
+++ b/config/groups/stake.ts
@@ -9,6 +9,7 @@ import { IPFS_REFERRAL_ADDRESS } from './ipfs';
 // import { config } from '../get-config';
 // otherwise you will get something like a cyclic error!
 import { preConfig } from '../get-preconfig';
+import { AddressZero } from '@ethersproject/constants';
 
 export const PRECISION = 10 ** 6;
 
@@ -25,12 +26,9 @@ export const STAKE_GASLIMIT_FALLBACK = BigNumber.from(
   ),
 );
 
-export const STAKE_REFERRAL_OFFSET =
-  '0x11D00000000000000000000000000000000011D0';
-
 export const STAKE_FALLBACK_REFERRAL_ADDRESS = preConfig.ipfsMode
   ? IPFS_REFERRAL_ADDRESS
-  : STAKE_REFERRAL_OFFSET;
+  : AddressZero;
 
 export const STAKE_SWAP_INTEGRATION: StakeSwapDiscountIntegrationKey =
   'one-inch';

--- a/features/stake/stake-form/use-stake.ts
+++ b/features/stake/stake-form/use-stake.ts
@@ -74,17 +74,21 @@ export const useStake = ({ onConfirm, onRetry }: StakeOptions) => {
               maxFeePerGas,
             };
 
-            const originalGasLimit = await stethContractWeb3.estimateGas.submit(
+            const tx = await stethContractWeb3.populateTransaction.submit(
               referralAddress,
               overrides,
             );
 
+            // add tracking suffix
+            tx.data = tx.data + '01';
+
+            const originalGasLimit = await providerWeb3.estimateGas(tx);
             const gasLimit = applyGasLimitRatio(originalGasLimit);
 
-            return stethContractWeb3.submit(referralAddress, {
-              ...overrides,
-              gasLimit,
-            });
+            tx.gasLimit = gasLimit;
+
+            const signer = providerWeb3.getSigner();
+            return signer.sendTransaction(tx);
           }
         };
 

--- a/features/stake/stake-form/use-stake.ts
+++ b/features/stake/stake-form/use-stake.ts
@@ -11,7 +11,12 @@ import { isContract } from 'utils/isContract';
 import { getFeeData } from 'utils/getFeeData';
 import { runWithTransactionLogger } from 'utils';
 
-import { MockLimitReachedError, getAddress, applyGasLimitRatio } from './utils';
+import {
+  MockLimitReachedError,
+  getAddress,
+  applyGasLimitRatio,
+  applyCalldataSuffix,
+} from './utils';
 import { useTxModalStagesStake } from './hooks/use-tx-modal-stages-stake';
 
 type StakeArguments = {
@@ -79,8 +84,7 @@ export const useStake = ({ onConfirm, onRetry }: StakeOptions) => {
               overrides,
             );
 
-            // add tracking suffix
-            tx.data = tx.data + '01';
+            applyCalldataSuffix(tx);
 
             const originalGasLimit = await providerWeb3.estimateGas(tx);
             const gasLimit = applyGasLimitRatio(originalGasLimit);

--- a/features/stake/stake-form/utils.ts
+++ b/features/stake/stake-form/utils.ts
@@ -29,7 +29,7 @@ export const getAddress = async (
 export const applyCalldataSuffix = (tx: PopulatedTransaction) => {
   if (!config.ipfsMode) {
     invariant(tx.data, 'transaction must have calldata');
-    tx.data = tx.data + '01';
+    tx.data = tx.data + config.STAKE_WIDGET_METRIC_SUFFIX;
   }
   return tx;
 };

--- a/features/stake/stake-form/utils.ts
+++ b/features/stake/stake-form/utils.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from 'ethers';
-import { isAddress } from 'ethers/lib/utils';
+import { hexlify, isAddress } from 'ethers/lib/utils';
 import type { BaseProvider } from '@ethersproject/providers';
 
 import { config } from 'config';
@@ -9,17 +9,36 @@ export const applyGasLimitRatio = (gasLimit: BigNumber): BigNumber =>
     .mul(config.SUBMIT_EXTRA_GAS_TRANSACTION_RATIO * config.PRECISION)
     .div(config.PRECISION);
 
+const ADDRESS_MODULO = BigNumber.from(2).pow(160);
+const applyReferralShift = (address: string) => {
+  return hexlify(
+    BigNumber.from(address)
+      .add(config.STAKE_REFERRAL_OFFSET)
+      .mod(ADDRESS_MODULO),
+  );
+};
+
 export const getAddress = async (
   input: string,
   providerRpc: BaseProvider,
 ): Promise<string> => {
+  let address;
   try {
-    if (isAddress(input)) return input;
-    const address = await providerRpc.resolveName(input);
-    if (address) return address;
+    // extract address from url or from ens
+    if (isAddress(input)) {
+      address = input;
+    } else {
+      const resolved = await providerRpc.resolveName(input);
+      if (resolved) address = resolved;
+    }
+    // apply tracking shift
+    if (address) {
+      return applyReferralShift(address);
+    }
   } catch {
     // noop
   }
+  // if code gets here, ref is invalid and we need to throw error
   throw new ReferralAddressError();
 };
 

--- a/features/stake/stake-form/utils.ts
+++ b/features/stake/stake-form/utils.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from 'ethers';
-import { hexlify, isAddress } from 'ethers/lib/utils';
+import { isAddress } from 'ethers/lib/utils';
 import type { BaseProvider } from '@ethersproject/providers';
 
 import { config } from 'config';
@@ -8,15 +8,6 @@ export const applyGasLimitRatio = (gasLimit: BigNumber): BigNumber =>
   gasLimit
     .mul(config.SUBMIT_EXTRA_GAS_TRANSACTION_RATIO * config.PRECISION)
     .div(config.PRECISION);
-
-const ADDRESS_MODULO = BigNumber.from(2).pow(160);
-const applyReferralShift = (address: string) => {
-  return hexlify(
-    BigNumber.from(address)
-      .add(config.STAKE_REFERRAL_OFFSET)
-      .mod(ADDRESS_MODULO),
-  );
-};
 
 export const getAddress = async (
   input: string,
@@ -31,9 +22,8 @@ export const getAddress = async (
       const resolved = await providerRpc.resolveName(input);
       if (resolved) address = resolved;
     }
-    // apply tracking shift
     if (address) {
-      return applyReferralShift(address);
+      return address;
     }
   } catch {
     // noop

--- a/features/stake/stake-form/utils.ts
+++ b/features/stake/stake-form/utils.ts
@@ -14,18 +14,10 @@ export const getAddress = async (
   input: string,
   providerRpc: BaseProvider,
 ): Promise<string> => {
-  let address;
   try {
-    // extract address from url or from ens
-    if (isAddress(input)) {
-      address = input;
-    } else {
-      const resolved = await providerRpc.resolveName(input);
-      if (resolved) address = resolved;
-    }
-    if (address) {
-      return address;
-    }
+    if (isAddress(input)) return input;
+    const address = await providerRpc.resolveName(input);
+    if (address) return address;
   } catch {
     // noop
   }

--- a/features/stake/stake-form/utils.ts
+++ b/features/stake/stake-form/utils.ts
@@ -1,8 +1,9 @@
-import { BigNumber } from 'ethers';
+import type { BigNumber, PopulatedTransaction } from 'ethers';
 import { isAddress } from 'ethers/lib/utils';
 import type { BaseProvider } from '@ethersproject/providers';
 
 import { config } from 'config';
+import invariant from 'tiny-invariant';
 
 export const applyGasLimitRatio = (gasLimit: BigNumber): BigNumber =>
   gasLimit
@@ -30,6 +31,15 @@ export const getAddress = async (
   }
   // if code gets here, ref is invalid and we need to throw error
   throw new ReferralAddressError();
+};
+
+// adds metrics indicator for widget tx
+export const applyCalldataSuffix = (tx: PopulatedTransaction) => {
+  if (!config.ipfsMode) {
+    invariant(tx.data, 'transaction must have calldata');
+    tx.data = tx.data + '01';
+  }
+  return tx;
 };
 
 export class ReferralAddressError extends Error {


### PR DESCRIPTION
### Description
Adds metric indicator for stake tx on widget. 

### Testing notes

- send stake transaction with referral or without
- check raw tx call data on etherscan
- tx must succeced, no error
- you should see `01` at the end of data after ref address(or zero address)

Example:
<img width="1077" alt="image" src="https://github.com/lidofinance/ethereum-staking-widget/assets/3705803/703d6130-7201-4a37-a204-95d9fc9bd26c">


### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
