### PR TITLE
fix: ref param not parsing

### DIFF
--- a/features/stake/stake-form/stake-form-context/stake-form-context.tsx
+++ b/features/stake/stake-form/stake-form-context/stake-form-context.tsx
@@ -151,7 +151,6 @@ const useStakeFormNetworkData = (): StakeFormNetworkData => {
 // Data provider
 //
 export const StakeFormProvider: FC<PropsWithChildren> = ({ children }) => {
-  const router = useRouter();
   const networkData = useStakeFormNetworkData();
   const validationContextPromise = useStakeFormValidationContext(networkData);
 
@@ -168,22 +167,24 @@ export const StakeFormProvider: FC<PropsWithChildren> = ({ children }) => {
 
   // consumes amount query param
   // SSG safe
+  const { isReady, query, pathname, replace } = useRouter();
   useEffect(() => {
-    if (!router.isReady) return;
+    if (!isReady) return;
     try {
-      const { amount, ref, ...rest } = router.query;
+      const { amount, ref, ...rest } = query;
+
       if (typeof ref === 'string') {
         setValue('referral', ref);
       }
       if (typeof amount === 'string') {
-        void router.replace({ pathname: router.pathname, query: rest });
+        void replace({ pathname, query: rest });
         const amountBN = parseEther(amount);
         setValue('amount', amountBN);
       }
     } catch {
       //noop
     }
-  }, [router, setValue]);
+  }, [isReady, pathname, query, replace, setValue]);
 
   const { retryEvent, retryFire } = useFormControllerRetry();
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,5 +2,10 @@ import { config } from 'config';
 
 import { StakePage } from 'features/stake';
 import { HomePageIpfs } from 'features/ipfs';
+import { GetStaticProps } from 'next';
+
+export const getStaticProps: GetStaticProps = async () => {
+  return { props: {} };
+};
 
 export default config.ipfsMode ? HomePageIpfs : StakePage;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2429,10 +2429,15 @@
   dependencies:
     "@noble/hashes" "1.3.3"
 
-"@noble/hashes@1.3.3", "@noble/hashes@^1.3.2":
+"@noble/hashes@1.3.3":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.3.tgz#39908da56a4adc270147bb07968bf3b16cfe1699"
   integrity sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==
+
+"@noble/hashes@^1.3.3":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.4.0.tgz#45814aa329f30e4fe0ba49426f49dfccdd066426"
+  integrity sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -2793,13 +2798,13 @@
     buffer "~6.0.3"
 
 "@solana/web3.js@^1.70.1":
-  version "1.89.1"
-  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.89.1.tgz#52df6820f2d088c4558aa359af40580a03d10ec9"
-  integrity sha512-t9TTLtPQxtQB3SAf/5E8xPXfVDsC6WGOsgKY02l2cbe0HLymT7ynE8Hu48Lk5qynHCquj6nhISfEHcjMkYpu/A==
+  version "1.91.6"
+  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.91.6.tgz#c090661c344cbc61e6cdeb0da67d3ea80d5848e1"
+  integrity sha512-dm20nN6HQvXToo+kM51nxHdtaa2wMSRdeK37p+WIWESfeiVHqV8XbV4XnWupq6ngt5vIckhGFG7ZnTBxUgLzDA==
   dependencies:
     "@babel/runtime" "^7.23.4"
     "@noble/curves" "^1.2.0"
-    "@noble/hashes" "^1.3.2"
+    "@noble/hashes" "^1.3.3"
     "@solana/buffer-layout" "^4.0.1"
     agentkeepalive "^4.5.0"
     bigint-buffer "^1.1.5"


### PR DESCRIPTION
### Description

Fixed issue when after changing ref param, change would not reflect in code. Causing ref to be invalid or missing.
This might be caused by cloudfare caching ingoring query params + next.

### Testing notes

Test on deployed envs, change ref in url from valid(address or ens) to invalid (`?ref=aboba`), reload page and try to stake. With invalid ref you will get error when staking.
Also you can check metamask window, it should have ref address here at the end of `HEX DATA`
<img width="341" alt="image" src="https://github.com/lidofinance/ethereum-staking-widget/assets/3705803/48caadad-d138-4e6a-b8d2-bfb613724063">
 

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
