### PR TITLE
feat: add cron for ping IPFS gateway

### DIFF
--- a/.github/workflows/cron-ping-ipfs.yml
+++ b/.github/workflows/cron-ping-ipfs.yml
@@ -1,0 +1,30 @@
+name: Cron ping IPFS Gateway
+
+on:
+  schedule:
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+    inputs:
+      IPFS_CID:
+        description: 'IPFS CID'
+        required: true
+        type: string
+      GATEWAY:
+        description: 'Gateway'
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Ping IPFS Gateway
+    environment: Cron ping IPFS Gateway
+    steps:
+      - name: Ping IPFS Gateway
+        shell: bash
+        run: |
+          BODY_RESULT=`npx -y blumen@0.10.4 ping $IPFS_CID $GATEWAY`
+          echo "$BODY_RESULT" >> $GITHUB_STEP_SUMMARY
+        env:
+          IPFS_CID: ${{ inputs.IPFS_CID || vars.IPFS_CID }}
+          GATEWAY: ${{ inputs.GATEWAY || vars.GATEWAY }}


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

Add cron to ping IPFS gateway
- Cron starts at 12 UTC every day
- It is possible to launch manually for a specific CID and Gateway
- For cron to work needs 2 variables
  - CID
  - Gateway

### Demo

<img width="682" alt="image" src="https://github.com/lidofinance/ethereum-staking-widget/assets/20888859/700d6286-2747-4598-96de-9ffb7681e163">

### Testing notes

Just check the Actions tab

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
