### PR TITLE
Error handling for failed tx

### DIFF
--- a/utils/getErrorMessage.ts
+++ b/utils/getErrorMessage.ts
@@ -2,6 +2,7 @@ export enum ErrorMessage {
   NOT_ENOUGH_ETHER = 'Not enough ether for gas.',
   DENIED_SIG = 'User denied the transaction signature.',
   SOMETHING_WRONG = 'Something went wrong.',
+  TRANSACTION_REVERTED = 'Transaction was included into block but reverted during execution',
   ENABLE_BLIND_SIGNING = 'Please enable blind signing on your Ledger hardware wallet.',
   LIMIT_REACHED = 'Transaction could not be completed because stake limit is exhausted. Please wait until the stake limit restores and try again. Otherwise, you can swap your Ethereum on 1inch platform instantly.',
   DEVICE_LOCKED = 'Please unlock your Ledger hardware wallet',
@@ -32,6 +33,8 @@ export const getErrorMessage = (error: unknown): ErrorMessage => {
       return ErrorMessage.LIMIT_REACHED;
     case 'INVALID_REFERRAL':
       return ErrorMessage.INVALID_REFERRAL;
+    case 'TRANSACTION_REVERTED':
+      return ErrorMessage.TRANSACTION_REVERTED;
     case 'ENABLE_BLIND_SIGNING':
       return ErrorMessage.ENABLE_BLIND_SIGNING;
     case 'DEVICE_LOCKED':
@@ -48,6 +51,15 @@ export const extractCodeFromError = (
 ): number | string => {
   // early exit on non object error
   if (!error || typeof error != 'object') return 0;
+
+  if (
+    'code' in error &&
+    error.code === 'CALL_EXCEPTION' &&
+    'receipt' in error
+  ) {
+    const receipt = error.receipt as { blockHash?: string };
+    if (receipt.blockHash?.startsWith('0x')) return 'TRANSACTION_REVERTED';
+  }
 
   if ('reason' in error && typeof error.reason == 'string') {
     if (error.reason.includes('STAKE_LIMIT')) return 'LIMIT_REACHED';


### PR DESCRIPTION
### Description

Adds special message when TX  reverts inside the block (but passes all checks before sending)

### Demo

<img width="595" alt="image" src="https://github.com/lidofinance/ethereum-staking-widget/assets/3705803/1bdcdd1f-c043-4fe5-a433-500f6cf994f3">

### Code review notes

Original task was to show Stake Limit error, but ethereum does not return error codes from transactions, just says they are failed. So it's not possible to know exact reason tx failed from just RPC error. Workarounds are possible but require extra rpc requests. I don't think it makes sense to go this far. 

### Testing notes

It's a bit hard to fail tx INSIDE block but you can do this:
 - go all the way to signing wrap stETH tx but don't sign in the wallet and leave it hanging
 - from **other wallet app** with **same private key** move stETH to other address
 - sign original tx
 - see message

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
