### PR TITLE
Fix invalid states in dex withdrawals

### DIFF
--- a/features/withdrawals/request/form/options/dex-options.tsx
+++ b/features/withdrawals/request/form/options/dex-options.tsx
@@ -66,7 +66,7 @@ const DexOption: React.FC<DexOptionProps> = ({
 export const DexOptions: React.FC<
   React.ComponentProps<typeof DexOptionsContainer>
 > = (props) => {
-  const { data, initialLoading, loading, amount, selectedToken, enabledDexes } =
+  const { data, initialLoading, amount, selectedToken, enabledDexes } =
     useWithdrawalRates();
 
   const isAnyDexEnabled = enabledDexes.length > 0;
@@ -92,7 +92,6 @@ export const DexOptions: React.FC<
               onClickGoTo={() => trackMatomoEvent(matomoEvent)}
               url={link(amount, selectedToken)}
               key={title}
-              loading={loading}
               toReceive={rate ? toReceive : null}
             />
           );

--- a/features/withdrawals/request/form/options/dex-options.tsx
+++ b/features/withdrawals/request/form/options/dex-options.tsx
@@ -33,6 +33,19 @@ const DexOption: React.FC<DexOptionProps> = ({
   loading,
   onClickGoTo,
 }) => {
+  let amountComponent: React.ReactNode = '-';
+  if (loading) {
+    amountComponent = <InlineLoaderSmall />;
+  } else if (toReceive) {
+    amountComponent = (
+      <FormatToken
+        approx
+        amount={toReceive ?? BigNumber.from(0)}
+        symbol="ETH"
+      />
+    );
+  }
+
   return (
     <DexOptionStyled>
       <Icon />
@@ -45,18 +58,7 @@ const DexOption: React.FC<DexOptionProps> = ({
       >
         Go to {title}
       </DexOptionBlockLink>
-      <DexOptionAmount>
-        {loading && !toReceive && <InlineLoaderSmall />}
-        {toReceive ? (
-          <FormatToken
-            approx
-            amount={toReceive ?? BigNumber.from(0)}
-            symbol="ETH"
-          />
-        ) : (
-          '-'
-        )}
-      </DexOptionAmount>
+      <DexOptionAmount>{amountComponent}</DexOptionAmount>
     </DexOptionStyled>
   );
 };

--- a/features/withdrawals/request/form/options/options-picker.tsx
+++ b/features/withdrawals/request/form/options/options-picker.tsx
@@ -83,7 +83,7 @@ const toFloor = (num: number): string =>
   (Math.floor(num * 10000) / 10000).toString();
 
 const DexButton: React.FC<OptionButtonProps> = ({ isActive, onClick }) => {
-  const { loading, bestRate, enabledDexes } = useWithdrawalRates({
+  const { initialLoading, bestRate, enabledDexes } = useWithdrawalRates({
     fallbackValue: DEFAULT_VALUE_FOR_RATE,
   });
   const isAnyDexEnabled = enabledDexes.length > 0;
@@ -107,7 +107,7 @@ const DexButton: React.FC<OptionButtonProps> = ({ isActive, onClick }) => {
       </OptionsPickerRow>
       <OptionsPickerRow data-testid="dexBestRate">
         <OptionsPickerSubLabel>Best Rate:</OptionsPickerSubLabel>
-        {loading ? <InlineLoaderSmall /> : bestRateValue}
+        {initialLoading ? <InlineLoaderSmall /> : bestRateValue}
       </OptionsPickerRow>
       <OptionsPickerRow data-testid="dexWaitingTime">
         <OptionsPickerSubLabel>Waiting time:</OptionsPickerSubLabel>{' '}


### PR DESCRIPTION
### Description

- fixed best rate flashing loaders
- fixed double state in dex options



### Testing notes

<!--- List all possible edge cases and how to test them. -->

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
