### PR TITLE
Fix: "more info" link href

### DIFF
--- a/features/rewards/components/stats/Stats.tsx
+++ b/features/rewards/components/stats/Stats.tsx
@@ -70,7 +70,7 @@ export const Stats: React.FC = () => {
           )}
         </Stat>
         <Title hideMobile>
-          <Link href={`${config.rootOrigin}/faq`}>
+          <Link href={`${config.rootOrigin}/ethereum#apr`}>
             <Box
               data-testid="moreInfo"
               color="secondary"


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description
Fixes "More info" link's href in the "Average APR" section on the `/rewards` page.
At the moment of writing, the `/ethereum#apr` is not working as expected, there is no such anchor on the page. But it will start working after the nearest landing release.

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
