### PR TITLE
feat(rewards): hide pagination if pages < 2

### DIFF
--- a/features/rewards/components/rewardsTable/RewardsTable.tsx
+++ b/features/rewards/components/rewardsTable/RewardsTable.tsx
@@ -39,13 +39,15 @@ export const RewardsTable: FC<RewardsTableProps> = (props) => {
           </Tbody>
         </RewardsTableStyle>
       </RewardsTableWrapperStyle>
-      <RewardsTablePagination
-        pagesCount={pageCount}
-        onItemClick={(currentPage: number) => setPage(currentPage - 1)}
-        activePage={page + 1}
-        siblingCount={0}
-        data-testid="pagination"
-      />
+      {pageCount > 1 && (
+        <RewardsTablePagination
+          pagesCount={pageCount}
+          onItemClick={(currentPage: number) => setPage(currentPage - 1)}
+          activePage={page + 1}
+          siblingCount={0}
+          data-testid="pagination"
+        />
+      )}
     </>
   );
 };


### PR DESCRIPTION
### Description

Hide pagination on rewards page if pages < 2

### Testing notes

Needs check on /rewards page

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
