### PR TITLE
[fix] claim request sorting

### DIFF
--- a/features/withdrawals/claim/claim-form-context/claim-form-context.tsx
+++ b/features/withdrawals/claim/claim-form-context/claim-form-context.tsx
@@ -79,7 +79,7 @@ export const ClaimFormProvider: FC<PropsWithChildren> = ({ children }) => {
       defaultSelectedRequestCount,
     ).requests.map((request) => ({
       ...request,
-      checked: checkedIds.has(request.token_id),
+      checked: request.status.isFinalized && checkedIds.has(request.token_id),
     }));
 
     setValue('requests', newRequests, {

--- a/features/withdrawals/hooks/contract/useWithdrawalsData.ts
+++ b/features/withdrawals/hooks/contract/useWithdrawalsData.ts
@@ -95,7 +95,7 @@ export const useWithdrawalRequests = () => {
 
       const [requestIds, lastCheckpointIndex] = await Promise.all([
         contractRpc.getWithdrawalRequests(account).then((ids) => {
-          return ids.toSorted((aId, bId) => (aId.gt(bId) ? 1 : -1));
+          return [...ids].sort((aId, bId) => (aId.gt(bId) ? 1 : -1));
         }),
         contractRpc.getLastCheckpointIndex(),
       ]);

--- a/features/withdrawals/hooks/contract/useWithdrawalsData.ts
+++ b/features/withdrawals/hooks/contract/useWithdrawalsData.ts
@@ -94,7 +94,9 @@ export const useWithdrawalRequests = () => {
       // const currentShareRate = args[3] as BigNumber;
 
       const [requestIds, lastCheckpointIndex] = await Promise.all([
-        contractRpc.getWithdrawalRequests(account),
+        contractRpc.getWithdrawalRequests(account).then((ids) => {
+          return ids.toSorted((aId, bId) => (aId.gt(bId) ? 1 : -1));
+        }),
         contractRpc.getLastCheckpointIndex(),
       ]);
       const requestStatuses = await contractRpc.getWithdrawalStatus(requestIds);
@@ -153,24 +155,21 @@ export const useWithdrawalRequests = () => {
       isClamped ||=
         pendingRequests.splice(MAX_SHOWN_REQUEST_PER_TYPE).length > 0;
 
-      const _sortedClaimableRequests = claimableRequests.sort((aReq, bReq) =>
-        aReq.id.gt(bReq.id) ? 1 : -1,
-      );
-
       const hints = await contractRpc.findCheckpointHints(
-        _sortedClaimableRequests.map(({ id }) => id),
+        claimableRequests.map(({ id }) => id),
         1,
         lastCheckpointIndex,
       );
 
       const claimableEth = await contractRpc.getClaimableEther(
-        _sortedClaimableRequests.map(({ id }) => id),
+        claimableRequests.map(({ id }) => id),
         hints,
       );
 
       let claimableAmountOfETH = BigNumber.from(0);
+
       const sortedClaimableRequests: RequestStatusClaimable[] =
-        _sortedClaimableRequests.map((request, index) => {
+        claimableRequests.map((request, index) => {
           claimableAmountOfETH = claimableAmountOfETH.add(claimableEth[index]);
           return {
             ...request,
@@ -195,6 +194,7 @@ export const useWithdrawalRequests = () => {
   );
   const oldData = swr.data;
   const mutate = swr.mutate;
+
   const optimisticClaimRequests = useCallback(
     async (requests: RequestStatusClaimable[]) => {
       if (!oldData) return undefined;


### PR DESCRIPTION
### Description

Enforce sorting for all requests ids in claim data to ensure withdrawal requests order.

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
