### PR TITLE
Fix: remove solana from FAQ

### DIFF
--- a/features/stake/stake-faq/list/what-is-lido.tsx
+++ b/features/stake/stake-faq/list/what-is-lido.tsx
@@ -6,9 +6,9 @@ export const WhatIsLido: FC = () => {
     <Accordion defaultExpanded summary="What is Lido?">
       <p>
         Lido is the name of a family of open-source peer-to-system software
-        tools deployed and functioning on the Ethereum, Solana, and Polygon
-        blockchain networks. The software enables users to mint transferable
-        utility tokens, which receive rewards linked to the related validation
+        tools deployed and functioning on the Ethereum and Polygon blockchain
+        networks. The software enables users to mint transferable utility
+        tokens, which receive rewards linked to the related validation
         activities of writing data to the blockchain, while the tokens can be
         used in other on-chain activities.
       </p>


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description
Removes "Solana" from here:

<img src=https://github.com/lidofinance/ethereum-staking-widget/assets/1245209/0dfc47f1-b2b2-4ce3-8a6e-97a3e77d9838 width=200 />

### Checklist:

- [ ] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
