### PR TITLE
fix: matomo-wallets events

### DIFF
--- a/consts/matomo-wallets-events.ts
+++ b/consts/matomo-wallets-events.ts
@@ -4,8 +4,6 @@ import { Metrics as WalletsMetrics } from 'reef-knot/connect-wallet-modal';
 export const enum MATOMO_WALLETS_EVENTS_TYPES {
   onClickAmbire = 'onClickAmbire',
   onConnectAmbire = 'onConnectAmbire',
-  onClickBlockchaincom = 'onClickBlockchaincom',
-  onConnectBlockchaincom = 'onConnectBlockchaincom',
   onClickBrave = 'onClickBrave',
   onConnectBrave = 'onConnectBrave',
   onClickCoin98 = 'onClickCoin98',
@@ -14,36 +12,22 @@ export const enum MATOMO_WALLETS_EVENTS_TYPES {
   onConnectCoinbase = 'onConnectCoinbase',
   onClickExodus = 'onClickExodus',
   onConnectExodus = 'onConnectExodus',
-  onClickGamestop = 'onClickGamestop',
-  onConnectGamestop = 'onConnectGamestop',
   onClickImToken = 'onClickImToken',
   onConnectImToken = 'onConnectImToken',
   onClickLedger = 'onClickLedger',
   onConnectLedger = 'onConnectLedger',
-  onClickMathWallet = 'onClickMathWallet',
-  onConnectMathWallet = 'onConnectMathWallet',
   onClickMetamask = 'onClickMetamask',
   onConnectMetamask = 'onConnectMetamask',
-  onClickOperaWallet = 'onClickOperaWallet',
-  onConnectOperaWallet = 'onConnectOperaWallet',
-  onClickTally = 'onClickTally',
-  onConnectTally = 'onConnectTally',
   onClickTrust = 'onClickTrust',
   onConnectTrust = 'onConnectTrust',
   onClickWC = 'onClickWC',
   onConnectWC = 'onConnectWC',
   onClickXdefi = 'onClickXdefi',
   onConnectXdefi = 'onConnectXdefi',
-  onClickZenGo = 'onClickZenGo',
-  onConnectZenGo = 'onConnectZenGo',
-  onClickZerion = 'onClickZerion',
-  onConnectZerion = 'onConnectZerion',
   onClickOkx = 'onClickOkx',
   onConnectOkx = 'onConnectOkx',
-  onClickPhantom = 'onClickPhantom',
-  onConnectPhantom = 'onConnectPhantom',
-  onClickBitkeep = 'onClickBitkeep',
-  onConnectBitkeep = 'onConnectBitkeep',
+  onClickBitget = 'onClickBitget',
+  onConnectBitget = 'onConnectBitget',
 }
 
 export const MATOMO_WALLETS_EVENTS: Record<
@@ -59,16 +43,6 @@ export const MATOMO_WALLETS_EVENTS: Record<
     'Ethereum_Staking_Widget',
     'Connect Ambire wallet',
     'eth_widget_connect_ambire',
-  ],
-  [MATOMO_WALLETS_EVENTS_TYPES.onClickBlockchaincom]: [
-    'Ethereum_Staking_Widget',
-    'Click Blockchain.com wallet',
-    'eth_widget_click_blockchaincom',
-  ],
-  [MATOMO_WALLETS_EVENTS_TYPES.onConnectBlockchaincom]: [
-    'Ethereum_Staking_Widget',
-    'Connect Blockchain.com wallet',
-    'eth_widget_connect_blockchaincom',
   ],
   [MATOMO_WALLETS_EVENTS_TYPES.onClickBrave]: [
     'Ethereum_Staking_Widget',
@@ -110,16 +84,6 @@ export const MATOMO_WALLETS_EVENTS: Record<
     'Connect Exodus wallet',
     'eth_widget_connect_exodus',
   ],
-  [MATOMO_WALLETS_EVENTS_TYPES.onClickGamestop]: [
-    'Ethereum_Staking_Widget',
-    'Click Gamestop wallet',
-    'eth_widget_click_gamestop',
-  ],
-  [MATOMO_WALLETS_EVENTS_TYPES.onConnectGamestop]: [
-    'Ethereum_Staking_Widget',
-    'Connect Gamestop wallet',
-    'eth_widget_connect_gamestop',
-  ],
   [MATOMO_WALLETS_EVENTS_TYPES.onClickImToken]: [
     'Ethereum_Staking_Widget',
     'Click imToken wallet',
@@ -140,16 +104,6 @@ export const MATOMO_WALLETS_EVENTS: Record<
     'Connect Ledger wallet',
     'eth_widget_connect_ledger',
   ],
-  [MATOMO_WALLETS_EVENTS_TYPES.onClickMathWallet]: [
-    'Ethereum_Staking_Widget',
-    'Click MathWallet wallet',
-    'eth_widget_click_mathwallet',
-  ],
-  [MATOMO_WALLETS_EVENTS_TYPES.onConnectMathWallet]: [
-    'Ethereum_Staking_Widget',
-    'Connect MathWallet wallet',
-    'eth_widget_connect_mathwallet',
-  ],
   [MATOMO_WALLETS_EVENTS_TYPES.onClickMetamask]: [
     'Ethereum_Staking_Widget',
     'Click Metamask wallet',
@@ -159,26 +113,6 @@ export const MATOMO_WALLETS_EVENTS: Record<
     'Ethereum_Staking_Widget',
     'Connect Metamask wallet',
     'eth_widget_connect_metamask',
-  ],
-  [MATOMO_WALLETS_EVENTS_TYPES.onClickOperaWallet]: [
-    'Ethereum_Staking_Widget',
-    'Click Opera wallet',
-    'eth_widget_click_opera',
-  ],
-  [MATOMO_WALLETS_EVENTS_TYPES.onConnectOperaWallet]: [
-    'Ethereum_Staking_Widget',
-    'Connect Opera wallet',
-    'eth_widget_connect_opera',
-  ],
-  [MATOMO_WALLETS_EVENTS_TYPES.onClickTally]: [
-    'Ethereum_Staking_Widget',
-    'Click Tally wallet',
-    'eth_widget_click_tally',
-  ],
-  [MATOMO_WALLETS_EVENTS_TYPES.onConnectTally]: [
-    'Ethereum_Staking_Widget',
-    'Connect Tally wallet',
-    'eth_widget_connect_tally',
   ],
   [MATOMO_WALLETS_EVENTS_TYPES.onClickTrust]: [
     'Ethereum_Staking_Widget',
@@ -210,26 +144,6 @@ export const MATOMO_WALLETS_EVENTS: Record<
     'Connect XDEFI wallet',
     'eth_widget_connect_xdefi',
   ],
-  [MATOMO_WALLETS_EVENTS_TYPES.onClickZenGo]: [
-    'Ethereum_Staking_Widget',
-    'Click ZenGo wallet',
-    'eth_widget_click_zengo',
-  ],
-  [MATOMO_WALLETS_EVENTS_TYPES.onConnectZenGo]: [
-    'Ethereum_Staking_Widget',
-    'Connect ZenGo wallet',
-    'eth_widget_connect_zengo',
-  ],
-  [MATOMO_WALLETS_EVENTS_TYPES.onClickZerion]: [
-    'Ethereum_Staking_Widget',
-    'Click Zerion wallet',
-    'eth_widget_click_zerion',
-  ],
-  [MATOMO_WALLETS_EVENTS_TYPES.onConnectZerion]: [
-    'Ethereum_Staking_Widget',
-    'Connect Zerion wallet',
-    'eth_widget_connect_zerion',
-  ],
   [MATOMO_WALLETS_EVENTS_TYPES.onClickOkx]: [
     'Ethereum_Staking_Widget',
     'Click OKX wallet',
@@ -240,25 +154,15 @@ export const MATOMO_WALLETS_EVENTS: Record<
     'Connect OKX wallet',
     'eth_widget_connect_okx',
   ],
-  [MATOMO_WALLETS_EVENTS_TYPES.onClickPhantom]: [
+  [MATOMO_WALLETS_EVENTS_TYPES.onClickBitget]: [
     'Ethereum_Staking_Widget',
-    'Click Phantom wallet',
-    'eth_widget_click_phantom',
+    'Click BitGet wallet',
+    'eth_widget_click_bitget',
   ],
-  [MATOMO_WALLETS_EVENTS_TYPES.onConnectPhantom]: [
+  [MATOMO_WALLETS_EVENTS_TYPES.onConnectBitget]: [
     'Ethereum_Staking_Widget',
-    'Connect Phantom wallet',
-    'eth_widget_connect_phantom',
-  ],
-  [MATOMO_WALLETS_EVENTS_TYPES.onClickBitkeep]: [
-    'Ethereum_Staking_Widget',
-    'Click BitKeep wallet',
-    'eth_widget_click_bitkeep',
-  ],
-  [MATOMO_WALLETS_EVENTS_TYPES.onConnectBitkeep]: [
-    'Ethereum_Staking_Widget',
-    'Connect BitKeep wallet',
-    'eth_widget_connect_bitkeep',
+    'Connect BitGet wallet',
+    'eth_widget_connect_bitget',
   ],
 };
 
@@ -268,9 +172,6 @@ export const walletsMetrics: WalletsMetrics = {
       handlers: {
         onClickAmbire: () => {
           trackEvent(...MATOMO_WALLETS_EVENTS.onClickAmbire);
-        },
-        onClickBlockchaincom: () => {
-          trackEvent(...MATOMO_WALLETS_EVENTS.onClickBlockchaincom);
         },
         onClickBrave: () => {
           trackEvent(...MATOMO_WALLETS_EVENTS.onClickBrave);
@@ -284,26 +185,14 @@ export const walletsMetrics: WalletsMetrics = {
         onClickExodus: () => {
           trackEvent(...MATOMO_WALLETS_EVENTS.onClickExodus);
         },
-        onClickGamestop: () => {
-          trackEvent(...MATOMO_WALLETS_EVENTS.onClickGamestop);
-        },
         onClickImToken: () => {
           trackEvent(...MATOMO_WALLETS_EVENTS.onClickImToken);
         },
         onClickLedger: () => {
           trackEvent(...MATOMO_WALLETS_EVENTS.onClickLedger);
         },
-        onClickMathWallet: () => {
-          trackEvent(...MATOMO_WALLETS_EVENTS.onClickMathWallet);
-        },
         onClickMetamask: () => {
           trackEvent(...MATOMO_WALLETS_EVENTS.onClickMetamask);
-        },
-        onClickOperaWallet: () => {
-          trackEvent(...MATOMO_WALLETS_EVENTS.onClickOperaWallet);
-        },
-        onClickTally: () => {
-          trackEvent(...MATOMO_WALLETS_EVENTS.onClickTally);
         },
         onClickTrust: () => {
           trackEvent(...MATOMO_WALLETS_EVENTS.onClickTrust);
@@ -314,20 +203,11 @@ export const walletsMetrics: WalletsMetrics = {
         onClickXdefi: () => {
           trackEvent(...MATOMO_WALLETS_EVENTS.onClickXdefi);
         },
-        onClickZenGo: () => {
-          trackEvent(...MATOMO_WALLETS_EVENTS.onClickZenGo);
-        },
-        onClickZerion: () => {
-          trackEvent(...MATOMO_WALLETS_EVENTS.onClickZerion);
-        },
         onClickOkx: () => {
           trackEvent(...MATOMO_WALLETS_EVENTS.onClickOkx);
         },
-        onClickPhantom: () => {
-          trackEvent(...MATOMO_WALLETS_EVENTS.onClickPhantom);
-        },
-        onClickBitkeep: () => {
-          trackEvent(...MATOMO_WALLETS_EVENTS.onClickBitkeep);
+        onClickBitget: () => {
+          trackEvent(...MATOMO_WALLETS_EVENTS.onClickBitget);
         },
       },
     },
@@ -335,9 +215,6 @@ export const walletsMetrics: WalletsMetrics = {
       handlers: {
         onConnectAmbire: () => {
           trackEvent(...MATOMO_WALLETS_EVENTS.onConnectAmbire);
-        },
-        onConnectBlockchaincom: () => {
-          trackEvent(...MATOMO_WALLETS_EVENTS.onConnectBlockchaincom);
         },
         onConnectBrave: () => {
           trackEvent(...MATOMO_WALLETS_EVENTS.onConnectBrave);
@@ -351,26 +228,14 @@ export const walletsMetrics: WalletsMetrics = {
         onConnectExodus: () => {
           trackEvent(...MATOMO_WALLETS_EVENTS.onConnectExodus);
         },
-        onConnectGamestop: () => {
-          trackEvent(...MATOMO_WALLETS_EVENTS.onConnectGamestop);
-        },
         onConnectImToken: () => {
           trackEvent(...MATOMO_WALLETS_EVENTS.onConnectImToken);
         },
         onConnectLedger: () => {
           trackEvent(...MATOMO_WALLETS_EVENTS.onConnectLedger);
         },
-        onConnectMathWallet: () => {
-          trackEvent(...MATOMO_WALLETS_EVENTS.onConnectMathWallet);
-        },
         onConnectMetamask: () => {
           trackEvent(...MATOMO_WALLETS_EVENTS.onConnectMetamask);
-        },
-        onConnectOperaWallet: () => {
-          trackEvent(...MATOMO_WALLETS_EVENTS.onConnectOperaWallet);
-        },
-        onConnectTally: () => {
-          trackEvent(...MATOMO_WALLETS_EVENTS.onConnectTally);
         },
         onConnectTrust: () => {
           trackEvent(...MATOMO_WALLETS_EVENTS.onConnectTrust);
@@ -381,20 +246,11 @@ export const walletsMetrics: WalletsMetrics = {
         onConnectXdefi: () => {
           trackEvent(...MATOMO_WALLETS_EVENTS.onConnectXdefi);
         },
-        onConnectZenGo: () => {
-          trackEvent(...MATOMO_WALLETS_EVENTS.onConnectZenGo);
-        },
-        onConnectZerion: () => {
-          trackEvent(...MATOMO_WALLETS_EVENTS.onConnectZerion);
-        },
         onConnectOkx: () => {
           trackEvent(...MATOMO_WALLETS_EVENTS.onConnectOkx);
         },
-        onConnectPhantom: () => {
-          trackEvent(...MATOMO_WALLETS_EVENTS.onConnectPhantom);
-        },
-        onConnectBitkeep: () => {
-          trackEvent(...MATOMO_WALLETS_EVENTS.onConnectBitkeep);
+        onConnectBitget: () => {
+          trackEvent(...MATOMO_WALLETS_EVENTS.onConnectBitget);
         },
       },
     },


### PR DESCRIPTION
### Description
1. Fix matomo event for BitGet wallet (previously Bitkeep. The event became broken at some point because of wallet's rebranding.
2. Remove matomo events for some wallets, for which there is no point in collecting metrics

### Checklist:

- [ ] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
