### PR TITLE
Add httpMethodGuard middleware for api endpoints

### DIFF
--- a/pages/api/eth-apr.ts
+++ b/pages/api/eth-apr.ts
@@ -9,6 +9,8 @@ import {
   errorAndCacheDefaultWrappers,
   responseTimeMetric,
   rateLimit,
+  httpMethodGuard,
+  HttpMethod,
 } from 'utilsApi';
 import Metrics from 'utilsApi/metrics';
 
@@ -31,6 +33,7 @@ const ethApr: API = async (_, res) => {
 };
 
 export default wrapNextRequest([
+  httpMethodGuard([HttpMethod.GET]),
   rateLimit,
   responseTimeMetric(Metrics.request.apiTimings, API_ROUTES.ETH_APR),
   ...errorAndCacheDefaultWrappers,

--- a/pages/api/eth-price.ts
+++ b/pages/api/eth-price.ts
@@ -11,6 +11,8 @@ import {
   defaultErrorHandler,
   responseTimeMetric,
   rateLimit,
+  httpMethodGuard,
+  HttpMethod,
 } from 'utilsApi';
 import Metrics from 'utilsApi/metrics';
 import { API } from 'types';
@@ -36,6 +38,7 @@ const ethPrice: API = async (req, res) => {
 };
 
 export default wrapNextRequest([
+  httpMethodGuard([HttpMethod.GET]),
   rateLimit,
   responseTimeMetric(Metrics.request.apiTimings, API_ROUTES.ETH_PRICE),
   cacheControl({ headers: config.CACHE_ETH_PRICE_HEADERS }),

--- a/pages/api/ldo-stats.ts
+++ b/pages/api/ldo-stats.ts
@@ -9,6 +9,8 @@ import {
   errorAndCacheDefaultWrappers,
   responseTimeMetric,
   rateLimit,
+  httpMethodGuard,
+  HttpMethod,
 } from 'utilsApi';
 import Metrics from 'utilsApi/metrics';
 import { API } from 'types';
@@ -37,6 +39,7 @@ const ldoStats: API = async (req, res) => {
 };
 
 export default wrapNextRequest([
+  httpMethodGuard([HttpMethod.GET]),
   rateLimit,
   responseTimeMetric(Metrics.request.apiTimings, API_ROUTES.LDO_STATS),
   ...errorAndCacheDefaultWrappers,

--- a/pages/api/lido-stats.ts
+++ b/pages/api/lido-stats.ts
@@ -8,6 +8,8 @@ import {
   errorAndCacheDefaultWrappers,
   responseTimeMetric,
   rateLimit,
+  httpMethodGuard,
+  HttpMethod,
 } from 'utilsApi';
 import Metrics from 'utilsApi/metrics';
 import { API } from 'types';
@@ -35,6 +37,7 @@ const lidoStats: API = async (req, res) => {
 };
 
 export default wrapNextRequest([
+  httpMethodGuard([HttpMethod.GET]),
   rateLimit,
   responseTimeMetric(Metrics.request.apiTimings, API_ROUTES.LIDO_STATS),
   ...errorAndCacheDefaultWrappers,

--- a/pages/api/lidostats.ts
+++ b/pages/api/lidostats.ts
@@ -8,6 +8,8 @@ import {
   responseTimeMetric,
   errorAndCacheDefaultWrappers,
   rateLimit,
+  httpMethodGuard,
+  HttpMethod,
 } from 'utilsApi';
 import Metrics from 'utilsApi/metrics';
 import { API } from 'types';
@@ -36,6 +38,7 @@ const lidoStats: API = async (req, res) => {
 };
 
 export default wrapNextRequest([
+  httpMethodGuard([HttpMethod.GET]),
   rateLimit,
   responseTimeMetric(Metrics.request.apiTimings, API_ROUTES.LIDOSTATS),
   ...errorAndCacheDefaultWrappers,

--- a/pages/api/rpc.ts
+++ b/pages/api/rpc.ts
@@ -10,6 +10,8 @@ import {
   responseTimeMetric,
   defaultErrorHandler,
   requestAddressMetric,
+  httpMethodGuard,
+  HttpMethod,
 } from 'utilsApi';
 import Metrics from 'utilsApi/metrics';
 import { rpcUrls } from 'utilsApi/rpcUrls';
@@ -44,6 +46,7 @@ const rpc = rpcFactory({
 });
 
 export default wrapNextRequest([
+  httpMethodGuard([HttpMethod.POST]),
   rateLimit,
   responseTimeMetric(Metrics.request.apiTimings, API_ROUTES.RPC),
   requestAddressMetric(Metrics.request.ethCallToAddress),

--- a/pages/api/sma-steth-apr.ts
+++ b/pages/api/sma-steth-apr.ts
@@ -9,6 +9,8 @@ import {
   errorAndCacheDefaultWrappers,
   rateLimit,
   getSmaStethApr,
+  httpMethodGuard,
+  HttpMethod,
 } from 'utilsApi';
 import Metrics from 'utilsApi/metrics';
 
@@ -33,6 +35,7 @@ const smaStethApr: API = async (_, res) => {
 };
 
 export default wrapNextRequest([
+  httpMethodGuard([HttpMethod.GET]),
   rateLimit,
   responseTimeMetric(Metrics.request.apiTimings, API_ROUTES.SMA_STETH_APR),
   ...errorAndCacheDefaultWrappers,

--- a/pages/api/totalsupply.ts
+++ b/pages/api/totalsupply.ts
@@ -11,6 +11,8 @@ import {
   defaultErrorHandler,
   responseTimeMetric,
   rateLimit,
+  httpMethodGuard,
+  HttpMethod,
 } from 'utilsApi';
 import Metrics from 'utilsApi/metrics';
 import { API } from 'types';
@@ -36,6 +38,7 @@ const totalSupply: API = async (req, res) => {
 };
 
 export default wrapNextRequest([
+  httpMethodGuard([HttpMethod.GET]),
   rateLimit,
   responseTimeMetric(Metrics.request.apiTimings, API_ROUTES.TOTALSUPPLY),
   cacheControl({ headers: config.CACHE_TOTAL_SUPPLY_HEADERS }),


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description
We use `httpMethodGuard` middleware for some API methods to allow only specific HTTP methods. But some endpoints, specifically `/api/rpc`, are not guarded from the widget side. This leads to errors in server logs when some bots or script kiddies are trying to send requests with incorrect HTTP methods to our endpoints.

### Code review notes
Please, check that I used correct HTTP methods for the guards.

### Testing notes
You can check that `/api/rpc` endpoint works as expected.
Some other endpoints were guarded too, but they are deprecated, and I'm not sure, that you will be able to test them all:
- `/api/eth-apr`
- `/api/eth-price`
- `/api/ldo-stats`
- `/api/lido-stats`
- `/api/lidostats`
- `/api/sma-steth-apr`
- `/api/totalsupply`

### Checklist:

- [ ] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
