### PR TITLE
fix: 1inch discount link

### DIFF
--- a/features/stake/swap-discount-banner/integrations.tsx
+++ b/features/stake/swap-discount-banner/integrations.tsx
@@ -53,7 +53,7 @@ const STAKE_SWAP_INTEGRATION_CONFIG: StakeSwapDiscountIntegrationMap = {
       );
     },
     Icon: OneInchIcon,
-    linkHref: `https://app.1inch.io/#/1/simple/swap/ETH/stETH`,
+    linkHref: `https://app.1inch.io/#/1/advanced/swap/ETH/stETH`,
     matomoEvent: MATOMO_CLICK_EVENTS.oneInchDiscount,
     CustomLink({ children, ...props }) {
       const customProps = use1inchDeepLinkProps();


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

Change the link of the "Get discount" button on the Stake page 1inch banner

### Demo

<img width="775" alt="image" src="https://github.com/lidofinance/ethereum-staking-widget/assets/7289992/53ce60ab-af12-4e06-9c38-7993b27ea076">
