### PR TITLE
chore: balance labels lowercased

### DIFF
--- a/features/withdrawals/request/wallet/wallet-steth-balance.tsx
+++ b/features/withdrawals/request/wallet/wallet-steth-balance.tsx
@@ -16,7 +16,7 @@ export const WalletStethBalance = () => {
   return (
     <CardBalance
       small
-      title="stETH Balance"
+      title="stETH balance"
       loading={loading.isStethBalanceLoading}
       value={stethBalanceValue}
     />

--- a/features/withdrawals/request/wallet/wallet-wsteth-balance.tsx
+++ b/features/withdrawals/request/wallet/wallet-wsteth-balance.tsx
@@ -31,7 +31,7 @@ export const WalletWstethBalance = () => {
   return (
     <CardBalance
       small
-      title="wstETH Balance"
+      title="wstETH balance"
       loading={loading.isStethBalanceLoading || isStethByWstethLoading}
       value={stethBalanceValue}
     />

--- a/features/wsteth/shared/wallet/wallet.tsx
+++ b/features/wsteth/shared/wallet/wallet.tsx
@@ -33,7 +33,7 @@ const WalletComponent: WalletComponentType = (props) => {
     <StyledCard data-testid="wrapCardSection" {...props}>
       <CardRow>
         <CardBalance
-          title="ETH Balance"
+          title="ETH balance"
           loading={ethBalance.initialLoading}
           value={
             <FormatToken
@@ -49,7 +49,7 @@ const WalletComponent: WalletComponentType = (props) => {
       <CardRow>
         <CardBalance
           small
-          title="stETH Balance"
+          title="stETH balance"
           loading={stethBalance.initialLoading || wstethBySteth.initialLoading}
           value={
             <>
@@ -75,7 +75,7 @@ const WalletComponent: WalletComponentType = (props) => {
         />
         <CardBalance
           small
-          title="wstETH Balance"
+          title="wstETH balance"
           loading={wstethBalance.initialLoading || stethByWsteth.initialLoading}
           value={
             <>


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

Lowercase for "ETH/stETH/wstETH [B]alance" labels

### Demo

<img width="596" alt="image" src="https://github.com/lidofinance/ethereum-staking-widget/assets/7289992/07a6ad99-ba0b-49d7-ac06-77d329435a23">

### Checklist:

- [x] Checked the changes locally.
