### PR TITLE
chore: consistency of last symbol-dot of sub-tittle of each page

### DIFF
--- a/features/stake/stake-page.tsx
+++ b/features/stake/stake-page.tsx
@@ -9,7 +9,7 @@ export const StakePage: FC = () => {
   return (
     <Layout
       title="Stake Ether"
-      subtitle="Stake ETH and receive stETH while staking."
+      subtitle="Stake ETH and receive stETH while staking"
     >
       <Head>
         <title>Stake with Lido | Lido</title>

--- a/pages/rewards.tsx
+++ b/pages/rewards.tsx
@@ -11,7 +11,7 @@ const Rewards: FC = () => {
   return (
     <Layout
       title="Reward History"
-      subtitle="Track your Ethereum staking rewards with Lido."
+      subtitle="Track your Ethereum staking rewards with Lido"
       containerSize="content"
     >
       <Head>


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

Removing a dot symbols at the end of the page sub-titles

### Demo

<img width="671" alt="image" src="https://github.com/lidofinance/ethereum-staking-widget/assets/7289992/445b6b9e-899b-4285-b00d-f39514b607fd">

### Checklist:

- [x] Checked the changes locally.