### PR TITLE
Add better handling for ENS errors

### DIFF
--- a/features/rewards/components/addressInput/AddressInput.tsx
+++ b/features/rewards/components/addressInput/AddressInput.tsx
@@ -6,7 +6,13 @@ import { isValidAnyAddress } from 'features/rewards/utils';
 import { AddressInputProps } from './types';
 
 export const AddressInput: FC<AddressInputProps> = (props) => {
-  const { inputValue, isAddressResolving, handleInputChange, address } = props;
+  const {
+    inputValue,
+    isAddressResolving,
+    handleInputChange,
+    address,
+    addressError,
+  } = props;
 
   return (
     <Input
@@ -23,7 +29,10 @@ export const AddressInput: FC<AddressInputProps> = (props) => {
       }
       rightDecorator={address ? <CopyAddressUrl address={inputValue} /> : null}
       spellCheck="false"
-      error={inputValue.length > 0 && !isValidAnyAddress(inputValue)}
+      error={
+        (inputValue.length > 0 && !isValidAnyAddress(inputValue)) ||
+        addressError
+      }
     />
   );
 };

--- a/features/rewards/components/addressInput/types.ts
+++ b/features/rewards/components/addressInput/types.ts
@@ -3,4 +3,5 @@ export type AddressInputProps = {
   isAddressResolving: boolean;
   handleInputChange: (value: string) => void;
   address: string;
+  addressError: string;
 };

--- a/features/rewards/features/top-card/top-card.tsx
+++ b/features/rewards/features/top-card/top-card.tsx
@@ -11,8 +11,13 @@ const INPUT_DESC_TEXT =
   'Current balance may differ from last balance in the table due to rounding.';
 
 export const TopCard: FC = () => {
-  const { address, isAddressResolving, inputValue, setInputValue } =
-    useRewardsHistory();
+  const {
+    address,
+    addressError,
+    isAddressResolving,
+    inputValue,
+    setInputValue,
+  } = useRewardsHistory();
 
   return (
     <Block color="accent" style={{ padding: 0 }}>
@@ -20,6 +25,7 @@ export const TopCard: FC = () => {
         <ThemeProvider theme={themeDark}>
           <AddressInput
             address={address}
+            addressError={addressError}
             inputValue={inputValue}
             handleInputChange={setInputValue}
             isAddressResolving={isAddressResolving}

--- a/features/rewards/hooks/useGetCurrentAddress.ts
+++ b/features/rewards/hooks/useGetCurrentAddress.ts
@@ -9,6 +9,7 @@ import { useCurrentStaticRpcProvider } from 'shared/hooks/use-current-static-rpc
 
 type UseGetCurrentAddress = () => {
   address: string;
+  addressError: string;
   inputValue: string;
   isAddressResolving: boolean;
   setInputValue: (value: string) => void;
@@ -21,6 +22,7 @@ export const useGetCurrentAddress: UseGetCurrentAddress = () => {
   }, []);
   const [isAddressResolving, setIsAddressResolving] = useState(false);
   const [address, setAddress] = useState('');
+  const [addressError, setAddressError] = useState('');
 
   const { account } = useSDK();
   const { staticRpcProvider } = useCurrentStaticRpcProvider();
@@ -29,12 +31,26 @@ export const useGetCurrentAddress: UseGetCurrentAddress = () => {
   const getEnsAddress = useCallback(
     async (value: string) => {
       setAddress('');
+      let result: string | null = null;
+      let error: string | null = null;
 
       setIsAddressResolving(true);
-      const result = await resolveEns(value, staticRpcProvider);
-      setIsAddressResolving(false);
+      try {
+        result = await resolveEns(value, staticRpcProvider);
+      } catch (e) {
+        console.error(e);
+        error = 'An error happened during ENS name resolving';
+      } finally {
+        setIsAddressResolving(false);
+      }
 
-      if (result) setAddress(result);
+      if (result) {
+        setAddress(result);
+      } else if (error) {
+        setAddressError(error);
+      } else {
+        setAddressError("The ENS name entered couldn't be found");
+      }
     },
     [staticRpcProvider],
   );
@@ -76,6 +92,7 @@ export const useGetCurrentAddress: UseGetCurrentAddress = () => {
 
   return {
     address,
+    addressError,
     inputValue,
     isAddressResolving,
     setInputValue,

--- a/providers/rewardsHistory.tsx
+++ b/providers/rewardsHistory.tsx
@@ -32,6 +32,7 @@ export type RewardsHistoryValue = {
   page: number;
   skip: number;
   address: string;
+  addressError: string;
   inputValue: string;
   isOnlyRewards: boolean;
   isUseArchiveExchangeRate: boolean;
@@ -63,8 +64,13 @@ const RewardsHistoryProvider: FC<PropsWithChildren> = (props) => {
   const skip = page * PAGE_ITEMS;
   const limit = PAGE_ITEMS;
 
-  const { address, inputValue, setInputValue, isAddressResolving } =
-    useGetCurrentAddress();
+  const {
+    address,
+    addressError,
+    inputValue,
+    setInputValue,
+    isAddressResolving,
+  } = useGetCurrentAddress();
 
   const { data, error, loading, initialLoading, isLagging } =
     useRewardsDataLoad({
@@ -100,12 +106,14 @@ const RewardsHistoryProvider: FC<PropsWithChildren> = (props) => {
       setCurrency,
       isAddressResolving,
       address,
+      addressError,
       inputValue,
       setInputValue,
       isLagging,
     }),
     [
       address,
+      addressError,
       currencyObject,
       data,
       error,


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

Handle ENS errors better:

1. Holesky doesn't support ENS. If an error happened during ENS name resolving, show error message near the input. Infinite loader is fixed too. 
<img width="606" alt="image" src="https://github.com/lidofinance/ethereum-staking-widget/assets/1245209/08b1e847-bb6f-4a53-a6aa-2b748ee44006">

2. If there are no errors with ENS resolving, but the name simply wasn't found (e.g. it is not registered), show another error
<img width="674" alt="Screenshot 2024-06-25 at 14 27 10" src="https://github.com/lidofinance/ethereum-staking-widget/assets/1245209/90782ad2-b76a-4c55-8f54-478474c094bc">

### Testing notes

The error 1 can be tested on testnet.
To check error 2 you should deploy the PR on mainnet.

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
