### PR TITLE
Add Cors to all external endpoints

### DIFF
--- a/pages/api/eth-apr.ts
+++ b/pages/api/eth-apr.ts
@@ -16,6 +16,7 @@ import {
   sunsetBy,
   httpMethodGuard,
   HttpMethod,
+  cors,
 } from 'utilsApi';
 import Metrics from 'utilsApi/metrics';
 
@@ -39,6 +40,7 @@ const ethApr: API = async (_, res) => {
 
 export default wrapNextRequest([
   httpMethodGuard([HttpMethod.GET]),
+  cors({ origin: ['*'], methods: [HttpMethod.GET] }),
   rateLimit,
   responseTimeMetric(Metrics.request.apiTimings, API_ROUTES.ETH_APR),
   sunsetBy({

--- a/pages/api/eth-price.ts
+++ b/pages/api/eth-price.ts
@@ -13,6 +13,7 @@ import {
   rateLimit,
   httpMethodGuard,
   HttpMethod,
+  cors,
 } from 'utilsApi';
 import Metrics from 'utilsApi/metrics';
 import { API } from 'types';
@@ -39,6 +40,7 @@ const ethPrice: API = async (req, res) => {
 
 export default wrapNextRequest([
   httpMethodGuard([HttpMethod.GET]),
+  cors({ origin: ['*'], methods: [HttpMethod.GET] }),
   rateLimit,
   responseTimeMetric(Metrics.request.apiTimings, API_ROUTES.ETH_PRICE),
   cacheControl({ headers: config.CACHE_ETH_PRICE_HEADERS }),

--- a/pages/api/ldo-stats.ts
+++ b/pages/api/ldo-stats.ts
@@ -12,6 +12,7 @@ import {
   sunsetBy,
   httpMethodGuard,
   HttpMethod,
+  cors,
 } from 'utilsApi';
 import Metrics from 'utilsApi/metrics';
 import { API } from 'types';
@@ -41,6 +42,7 @@ const ldoStats: API = async (req, res) => {
 
 export default wrapNextRequest([
   httpMethodGuard([HttpMethod.GET]),
+  cors({ origin: ['*'], methods: [HttpMethod.GET] }),
   rateLimit,
   responseTimeMetric(Metrics.request.apiTimings, API_ROUTES.LDO_STATS),
   sunsetBy({

--- a/pages/api/lido-stats.ts
+++ b/pages/api/lido-stats.ts
@@ -11,6 +11,7 @@ import {
   sunsetBy,
   httpMethodGuard,
   HttpMethod,
+  cors,
 } from 'utilsApi';
 import Metrics from 'utilsApi/metrics';
 import { API } from 'types';
@@ -39,6 +40,7 @@ const lidoStats: API = async (req, res) => {
 
 export default wrapNextRequest([
   httpMethodGuard([HttpMethod.GET]),
+  cors({ origin: ['*'], methods: [HttpMethod.GET] }),
   rateLimit,
   responseTimeMetric(Metrics.request.apiTimings, API_ROUTES.LIDO_STATS),
   sunsetBy({

--- a/pages/api/lidostats.ts
+++ b/pages/api/lidostats.ts
@@ -11,6 +11,7 @@ import {
   sunsetBy,
   httpMethodGuard,
   HttpMethod,
+  cors,
 } from 'utilsApi';
 import Metrics from 'utilsApi/metrics';
 import { API } from 'types';
@@ -40,6 +41,7 @@ const lidoStats: API = async (req, res) => {
 
 export default wrapNextRequest([
   httpMethodGuard([HttpMethod.GET]),
+  cors({ origin: ['*'], methods: [HttpMethod.GET] }),
   rateLimit,
   responseTimeMetric(Metrics.request.apiTimings, API_ROUTES.LIDOSTATS),
   sunsetBy({

--- a/pages/api/sma-steth-apr.ts
+++ b/pages/api/sma-steth-apr.ts
@@ -16,6 +16,7 @@ import {
   sunsetBy,
   httpMethodGuard,
   HttpMethod,
+  cors,
 } from 'utilsApi';
 import Metrics from 'utilsApi/metrics';
 
@@ -41,6 +42,7 @@ const smaStethApr: API = async (_, res) => {
 
 export default wrapNextRequest([
   httpMethodGuard([HttpMethod.GET]),
+  cors({ origin: ['*'], methods: [HttpMethod.GET] }),
   rateLimit,
   responseTimeMetric(Metrics.request.apiTimings, API_ROUTES.SMA_STETH_APR),
   sunsetBy({

--- a/pages/api/totalsupply.ts
+++ b/pages/api/totalsupply.ts
@@ -13,6 +13,7 @@ import {
   rateLimit,
   httpMethodGuard,
   HttpMethod,
+  cors,
 } from 'utilsApi';
 import Metrics from 'utilsApi/metrics';
 import { API } from 'types';
@@ -39,6 +40,7 @@ const totalSupply: API = async (req, res) => {
 
 export default wrapNextRequest([
   httpMethodGuard([HttpMethod.GET]),
+  cors({ origin: ['*'], methods: [HttpMethod.GET] }),
   rateLimit,
   responseTimeMetric(Metrics.request.apiTimings, API_ROUTES.TOTALSUPPLY),
   cacheControl({ headers: config.CACHE_TOTAL_SUPPLY_HEADERS }),

--- a/utilsApi/nextApiWrappers.ts
+++ b/utilsApi/nextApiWrappers.ts
@@ -61,8 +61,8 @@ export const cors =
 
     res.setHeader('Access-Control-Allow-Credentials', String(credentials));
     res.setHeader('Access-Control-Allow-Origin', origin);
-    res.setHeader('Access-Control-Allow-Methods', methods.toString());
-    res.setHeader('Access-Control-Allow-Headers', allowedHeaders.toString());
+    res.setHeader('Access-Control-Allow-Methods', methods.join(', '));
+    res.setHeader('Access-Control-Allow-Headers', allowedHeaders.join(', '));
 
     if (req.method === HttpMethod.OPTIONS) {
       // In preflight just need return a CORS headers
@@ -81,8 +81,12 @@ export const httpMethodGuard =
       !req.method ||
       !Object.values(methodAllowList).includes(req.method as HttpMethod)
     ) {
-      res.status(405);
-      throw new Error(`You can use only: ${methodAllowList.toString()}`);
+      // allow OPTIONS to pass trough but still add Allow header
+      res.setHeader('Allow', methodAllowList.join(', '));
+      if (req.method !== HttpMethod.OPTIONS) {
+        res.status(405);
+        throw new Error(`You can use only: ${methodAllowList.toString()}`);
+      }
     }
 
     await next?.(req, res, next);


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

- Add cors headers to all external endpoints
- allow correct OPTIONS header behavior with method guard

### Code review notes


### Testing notes

Endpoints to test on /api:
- eth-apr
- eth-price
- ldo-stats
- lido-stats
- lidostats
- sma-steth-apr
- totalsupply

Should have cors headers. Respond correctly to OPTIONS http request.

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
