### PR TITLE
Close WalletModal if a wallet was disconnected

### DIFF
--- a/shared/wallet/wallet-modal/wallet-modal.tsx
+++ b/shared/wallet/wallet-modal/wallet-modal.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import {
   ButtonIcon,
   Modal,
@@ -35,6 +35,13 @@ export const WalletModal: ModalComponentType = ({ onClose, ...props }) => {
 
   const handleCopy = useCopyToClipboard(account ?? '');
   const handleEtherscan = useEtherscanOpen(account ?? '', 'address');
+
+  useEffect(() => {
+    // Close the modal if a wallet was somehow disconnected while the modal was open
+    if (account == null || account.length === 0) {
+      onClose?.();
+    }
+  }, [account, onClose]);
 
   return (
     <Modal title="Account" onClose={onClose} {...props}>


### PR DESCRIPTION
### Description
The issue:
1. A user connects a wallet and opens a modal with details about the connected wallet.
2. The user somehow disconnects the wallet (plugs off ledger, disconnects via browser extension wallet UI, etc.)
3. The modal stays opened but becomes broken

The PR fixes the issue by closing the modal in event of wallet's address became unavailable.

### Testing notes
Actually, the initial issue can be reproduced with any wallet, including MetaMask browser extension:
1. Connect wallet
5. Open modal with account address, "Connected with ..." and "Disconnect" button
6. Go to MetaMask extension screen, find "Connected sites" in a dropdown menu, choose it and disconnect from the widget
7. So, we disconnected a wallet while the Wallet Modal was opened – the issue reproduced

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
