### PR TITLE
Update header and footer styles, fix mobile nav on iPhones

### DIFF
--- a/shared/components/layout/footer/external-link.tsx
+++ b/shared/components/layout/footer/external-link.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { ExternalLinkIconFooter, FooterLink } from './styles';
+
+export const ExternalLink = ({
+  children,
+  ...props
+}: React.ComponentProps<typeof FooterLink>) => (
+  <FooterLink target="_blank" rel="noopener noreferrer" {...props}>
+    {children}
+    <ExternalLinkIconFooter />
+  </FooterLink>
+);

--- a/shared/components/layout/footer/link-to-ipfs.tsx
+++ b/shared/components/layout/footer/link-to-ipfs.tsx
@@ -1,7 +1,7 @@
 import { IPFS_INFO_URL, useRemoteVersion } from 'features/ipfs';
 
 import { OnlyInfraRender } from 'shared/components/only-infra-render';
-import { ExternalLink } from './styles';
+import { ExternalLink } from './external-link';
 
 export const LinkToIpfs = () => {
   const { data } = useRemoteVersion();

--- a/shared/components/layout/footer/styles.tsx
+++ b/shared/components/layout/footer/styles.tsx
@@ -2,10 +2,17 @@ import styled from 'styled-components';
 import { Container, Link } from '@lidofinance/lido-ui';
 
 import { LogoLido } from 'shared/components/logos/logos';
-import { NAV_MOBILE_MEDIA } from 'styles/constants';
+import {
+  FOOTER_DESKTOP_PADDING_X,
+  FOOTER_DESKTOP_PADDING_Y,
+  FOOTER_MAX_WIDTH,
+  FOOTER_MOBILE_MARGIN_BOTTOM,
+  FOOTER_MOBILE_PADDING_X,
+  FOOTER_MOBILE_PADDING_Y,
+  NAV_MOBILE_MEDIA,
+} from 'styles/constants';
 
 import { ReactComponent as ExternalLinkIcon } from 'assets/icons/external-link-icon.svg';
-import React from 'react';
 
 export const FooterStyle = styled(Container)`
   position: relative;
@@ -16,12 +23,12 @@ export const FooterStyle = styled(Container)`
   flex-wrap: wrap;
 
   width: 100%;
-  max-width: 1424px;
-  padding: 24px 32px;
+  max-width: ${FOOTER_MAX_WIDTH}px;
+  padding: ${FOOTER_DESKTOP_PADDING_Y}px ${FOOTER_DESKTOP_PADDING_X}px;
 
   ${NAV_MOBILE_MEDIA} {
-    margin-bottom: 60px;
-    padding: 20px 18px;
+    margin-bottom: ${FOOTER_MOBILE_MARGIN_BOTTOM}px;
+    padding: ${FOOTER_MOBILE_PADDING_X}px ${FOOTER_MOBILE_PADDING_Y}px;
     justify-content: center;
   }
 `;
@@ -70,14 +77,14 @@ export const LinkDivider = styled.div`
 `;
 
 export const LogoLidoStyle = styled(LogoLido)`
-  margin-right: 32px;
+  margin-right: ${({ theme }) => theme.spaceMap.xxl}px;
 `;
 
 export const FooterDivider = styled.div`
   position: absolute;
   top: 0;
-  left: 32px;
-  width: calc(100% - 64px);
+  left: ${FOOTER_DESKTOP_PADDING_X}px;
+  width: calc(100% - ${FOOTER_DESKTOP_PADDING_X * 2}px);
   height: 1px;
   background: var(--lido-color-popupMenuItemBgActiveHover);
   opacity: 0.12;
@@ -107,13 +114,3 @@ export const ExternalLinkIconFooter = styled(ExternalLinkIcon).attrs({
     fill: var(--lido-color-textSecondary);
   }
 `;
-
-export const ExternalLink = ({
-  children,
-  ...props
-}: React.ComponentProps<typeof FooterLink>) => (
-  <FooterLink target="_blank" rel="noopener noreferrer" {...props}>
-    {children}
-    <ExternalLinkIconFooter />
-  </FooterLink>
-);

--- a/shared/components/layout/header/components/navigation/styles.tsx
+++ b/shared/components/layout/header/components/navigation/styles.tsx
@@ -1,11 +1,15 @@
 import styled, { css } from 'styled-components';
 
-import { NAV_MOBILE_MEDIA, NAV_MOBILE_HEIGHT } from 'styles/constants';
+import {
+  NAV_MOBILE_MEDIA,
+  NAV_MOBILE_HEIGHT,
+  NAV_DESKTOP_GUTTER_X,
+} from 'styles/constants';
 
 export const desktopCss = css`
-  margin: 0 46px;
+  margin: 0 ${NAV_DESKTOP_GUTTER_X}px;
   display: flex;
-  gap: 32px;
+  gap: ${({ theme }) => theme.spaceMap.xxl}px;
 
   svg {
     margin-right: 10px;
@@ -18,18 +22,19 @@ const mobileCss = css`
   bottom: 0;
   left: 0;
   right: 0;
-  padding: 8px;
+  padding: ${({ theme: { spaceMap } }) =>
+    `${spaceMap.sm}px ${spaceMap.sm}px max(env(safe-area-inset-bottom), ${spaceMap.sm}px)`};
   background-color: var(--lido-color-foreground);
   display: flex;
-  gap: 32px;
+  gap: ${({ theme }) => theme.spaceMap.xxl}px;
   justify-content: space-around;
   align-items: center;
   border-top: 1px solid var(--lido-color-border);
-  height: ${NAV_MOBILE_HEIGHT}px;
+  height: calc(${NAV_MOBILE_HEIGHT}px + env(safe-area-inset-bottom));
 
   svg {
     margin-right: 0;
-    margin-bottom: 7px;
+    margin-bottom: ${({ theme }) => theme.spaceMap.sm}px;
   }
 `;
 
@@ -71,6 +76,7 @@ export const NavLink = styled.span<{ active: boolean }>`
   }
 
   ${NAV_MOBILE_MEDIA} {
+    width: ${({ theme }) => theme.spaceMap.xl}px;
     flex-direction: column;
     text-transform: none;
     font-weight: 500;

--- a/shared/components/layout/header/styles.tsx
+++ b/shared/components/layout/header/styles.tsx
@@ -1,12 +1,12 @@
 import { Container } from '@lidofinance/lido-ui';
 import styled, { keyframes } from 'styled-components';
 
-import { NAV_MOBILE_MEDIA } from 'styles/constants';
+import { DOT_SIZE, HEADER_PADDING_Y, NAV_MOBILE_MEDIA } from 'styles/constants';
 
 export const HeaderStyle = styled((props) => <Container {...props} />)`
   position: relative;
-  padding-top: 18px;
-  padding-bottom: 18px;
+  padding-top: ${HEADER_PADDING_Y}px;
+  padding-bottom: ${HEADER_PADDING_Y}px;
   display: flex;
   align-items: center;
 `;
@@ -33,8 +33,8 @@ const glimmer = keyframes`
 `;
 
 export const DotStyle = styled.p`
-  height: 6px;
-  width: 6px;
+  height: ${DOT_SIZE}px;
+  width: ${DOT_SIZE}px;
   background-color: lightgreen;
   border-radius: 50%;
   animation: ${glimmer} 2s ease-in-out infinite;

--- a/styles/constants.ts
+++ b/styles/constants.ts
@@ -1,5 +1,18 @@
 export const NAV_MOBILE_HEIGHT = 60;
-
 export const NAV_MOBILE_MAX_WIDTH = 880;
-
 export const NAV_MOBILE_MEDIA = `@media screen and (max-width: ${NAV_MOBILE_MAX_WIDTH}px)`;
+
+export const NAV_DESKTOP_GUTTER_X = 46;
+
+export const HEADER_PADDING_Y = 18;
+
+export const DOT_SIZE = 6;
+
+export const FOOTER_MAX_WIDTH = 1424;
+
+export const FOOTER_DESKTOP_PADDING_X = 32;
+export const FOOTER_DESKTOP_PADDING_Y = 24;
+
+export const FOOTER_MOBILE_PADDING_X = 20;
+export const FOOTER_MOBILE_PADDING_Y = 18;
+export const FOOTER_MOBILE_MARGIN_BOTTOM = 60;


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description
Resolves SI-1334, Si-1324

#### Changes
- Place icons in the mobile bottom navigation at the same distance from each other
- Fix mobile bottom navigation for iPhone X and newer with "Single Tab" option enabled in Safari settings.
- refactor header and footer styles: use constants

### Demo

#### Before
<img width="395" alt="image" src="https://github.com/lidofinance/ethereum-staking-widget/assets/1245209/0649db53-6b14-4662-80c9-93a680cfde01">


#### After
<img width="393" alt="image" src="https://github.com/lidofinance/ethereum-staking-widget/assets/1245209/3d8d942b-3ad9-4b6e-a84b-f4cc94f74fb5">

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
