### PR TITLE
Add "add token" button after successful tx

### DIFF
--- a/shared/transaction-modal/tx-stages-composed/tx-stage-operation-succeed-balance-shown.tsx
+++ b/shared/transaction-modal/tx-stages-composed/tx-stage-operation-succeed-balance-shown.tsx
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
 
+import { useTokenAddress } from '@lido-sdk/react';
+import { TOKENS } from '@lido-sdk/constants';
 import { InlineLoader } from '@lidofinance/lido-ui';
 import { L2AfterStake } from 'shared/banners/l2-banners/l2-after-stake';
 import { L2AfterWrap } from 'shared/banners/l2-banners/l2-after-wrap';
@@ -10,6 +12,7 @@ import { TxStageSuccess } from '../tx-stages-basic';
 
 import type { BigNumber } from 'ethers';
 import { useFeatureFlag, VAULTS_BANNER_IS_ENABLED } from 'config/feature-flags';
+import { TokenToWallet } from '../../components';
 
 export const SkeletonBalance = styled(InlineLoader).attrs({
   color: 'text',
@@ -32,6 +35,10 @@ export const TxStageOperationSucceedBalanceShown = ({
   txHash,
 }: TxStageOperationSucceedBalanceShownProps) => {
   const { vaultsBannerIsEnabled } = useFeatureFlag(VAULTS_BANNER_IS_ENABLED);
+  const stethAddress = useTokenAddress(TOKENS.STETH);
+  const wstethAddress = useTokenAddress(TOKENS.WSTETH);
+  const tokenToWalletAddress =
+    balanceToken === 'wstETH' ? wstethAddress : stethAddress;
 
   const balanceEl = balance && (
     <TxAmount amount={balance} symbol={balanceToken} />
@@ -51,6 +58,10 @@ export const TxStageOperationSucceedBalanceShown = ({
         <>
           Your new balance is <wbr />
           {balance ? balanceEl : <SkeletonBalance />}
+          <TokenToWallet
+            data-testid="txSuccessAddToken"
+            address={tokenToWalletAddress}
+          />
         </>
       }
       description={

--- a/shared/transaction-modal/tx-stages-composed/tx-stage-operation-succeed-balance-shown.tsx
+++ b/shared/transaction-modal/tx-stages-composed/tx-stage-operation-succeed-balance-shown.tsx
@@ -21,6 +21,11 @@ export const SkeletonBalance = styled(InlineLoader).attrs({
   width: 100px;
 `;
 
+export const BalanceContainer = styled('div')`
+  display: inline-block;
+  white-space: nowrap;
+`;
+
 type TxStageOperationSucceedBalanceShownProps = {
   balance?: BigNumber;
   balanceToken: string;
@@ -57,11 +62,13 @@ export const TxStageOperationSucceedBalanceShown = ({
       title={
         <>
           Your new balance is <wbr />
-          {balance ? balanceEl : <SkeletonBalance />}
-          <TokenToWallet
-            data-testid="txSuccessAddToken"
-            address={tokenToWalletAddress}
-          />
+          <BalanceContainer>
+            {balance ? balanceEl : <SkeletonBalance />}
+            <TokenToWallet
+              data-testid="txSuccessAddToken"
+              address={tokenToWalletAddress}
+            />
+          </BalanceContainer>
         </>
       }
       description={


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description
Adds "Add tokens to wallet" button on the Stake and Wrap pages after successful transaction.
Adds stETH or wstETH respectively.

Resolves SI-1409
See links to Figma in the task.

### Demo
<img width="448" alt="Screenshot 2024-07-10 at 18 22 36" src="https://github.com/lidofinance/ethereum-staking-widget/assets/1245209/dc8054a4-7487-4090-b1b8-382536b3e6d9">
<img width="487" alt="Screenshot 2024-07-10 at 18 33 35" src="https://github.com/lidofinance/ethereum-staking-widget/assets/1245209/c41bc688-0668-4eff-92f7-12229dd2d358">

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
