### PR TITLE
Remove Mumbai chain

### DIFF
--- a/config/rpc/index.ts
+++ b/config/rpc/index.ts
@@ -23,19 +23,6 @@ export const useGetRpcUrlByChainId = () => {
 
   return useCallback(
     (chainId: CHAINS) => {
-      // This condition is needed because in 'providers/web3.tsx' we add `wagmiChains.polygonMumbai` to supportedChains as a workaround.
-      // polygonMumbai (80001) may cause an invariant throwing.
-      // And we always need Mainnet RPC for some requests, e.g. ETH to USD price, ENS lookup.
-      if (
-        chainId !== CHAINS.Mainnet &&
-        !userConfig.supportedChainIds.includes(chainId)
-      ) {
-        // Has no effect on functionality. Just a fix.
-        // Return empty string as a stub
-        // (see: 'providers/web3.tsx' --> jsonRpcBatchProvider --> getStaticRpcBatchProvider)
-        return '';
-      }
-
       if (config.ipfsMode) {
         const rpc =
           userConfig.savedUserConfig.rpcUrls[chainId] ||
@@ -43,12 +30,12 @@ export const useGetRpcUrlByChainId = () => {
 
         invariant(rpc, '[useGetRpcUrlByChainId] RPC is required!');
         return rpc;
-      } else {
-        return (
-          userConfig.savedUserConfig.rpcUrls[chainId] ||
-          getBackendRPCPath(chainId)
-        );
       }
+
+      return (
+        userConfig.savedUserConfig.rpcUrls[chainId] ||
+        getBackendRPCPath(chainId)
+      );
     },
     [userConfig],
   );

--- a/providers/web3.tsx
+++ b/providers/web3.tsx
@@ -35,13 +35,6 @@ const Web3Provider: FC<PropsWithChildren> = ({ children }) => {
       supportedChainIds.includes(chain.id),
     );
 
-    // Adding Mumbai as a temporary workaround
-    // for the wagmi and walletconnect bug, when some wallets are failing to connect
-    // when there are only one supported network, so we need at least 2 of them.
-    // Mumbai should be the last in the array, otherwise wagmi can send request to it.
-    // TODO: remove after updating wagmi to v1+
-    supportedChains.push(wagmiChains.polygonMumbai);
-
     const defaultChain =
       supportedChains.find((chain) => chain.id === defaultChainId) ||
       supportedChains[0]; // first supported chain as fallback


### PR DESCRIPTION
### Description

The Polygon Mumbai chain was added when we updated from WC v1 to WC v2 a year ago. At that moment, we had issues with Zerion and Trust wallets connected via WC v2, adding an extra chain was a workaround.
The issue was fixed in wagmi 1+, so I'm removing this extra chain from the code after our recent update to wagmi v2.

### Testing notes
I guess we can check that Trust wallet works okay via WalletConnect.

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
