### PR TITLE
Fix: error in logs from collectRequestAddressMetric on testnet

### DIFF
--- a/utilsApi/nextApiWrappers.ts
+++ b/utilsApi/nextApiWrappers.ts
@@ -136,7 +136,7 @@ const collectRequestAddressMetric = async ({
     ) {
       const { to, data } = call.params[0];
       const address = utils.getAddress(to) as `0x${string}`;
-      const contractName = METRIC_CONTRACT_ADDRESSES[chainId][address];
+      const contractName = METRIC_CONTRACT_ADDRESSES[chainId]?.[address];
       const methodEncoded = data?.slice(0, 10); // `0x` and 8 next symbols
       const methodDecoded = contractName
         ? getMetricContractInterface(contractName)?.getFunction(methodEncoded)


### PR DESCRIPTION
### Description
This PR should solve this kind of errors, which arrives in server logs on testnet:
```
TypeError: Cannot read properties of undefined (reading '******************************************')
    at /app/.next/server/chunks/299.js:4754:136
    at Array.forEach (<anonymous>)
    at collectRequestAddressMetric (/app/.next/server/chunks/299.js:4750:11)
```

### Testing notes
This PR adds a small additional check, nothing to test here

### Checklist:

- [ ] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
