### PR TITLE
[fix] remove usage of wallet rpc during tx

### DIFF
--- a/features/stake/stake-form/hooks.ts
+++ b/features/stake/stake-form/hooks.ts
@@ -5,7 +5,7 @@ import { useLidoSWR, useSDK, useSTETHContractRPC } from '@lido-sdk/react';
 import { config } from 'config';
 import { STRATEGY_CONSTANT } from 'consts/swr-strategies';
 
-import { applyGasLimitRatio } from './utils';
+import { applyGasLimitRatio } from 'utils/apply-gas-limit-ratio';
 
 type UseStethSubmitGasLimit = () => BigNumber;
 

--- a/features/stake/stake-form/utils.ts
+++ b/features/stake/stake-form/utils.ts
@@ -1,14 +1,9 @@
-import type { BigNumber, PopulatedTransaction } from 'ethers';
+import type { PopulatedTransaction } from 'ethers';
 import { isAddress } from 'ethers/lib/utils';
 import type { BaseProvider } from '@ethersproject/providers';
 
 import { config } from 'config';
 import invariant from 'tiny-invariant';
-
-export const applyGasLimitRatio = (gasLimit: BigNumber): BigNumber =>
-  gasLimit
-    .mul(config.SUBMIT_EXTRA_GAS_TRANSACTION_RATIO * config.PRECISION)
-    .div(config.PRECISION);
 
 export const getAddress = async (
   input: string,

--- a/features/withdrawals/hooks/contract/useClaim.ts
+++ b/features/withdrawals/hooks/contract/useClaim.ts
@@ -11,6 +11,8 @@ import { isContract } from 'utils/isContract';
 import { useWeb3 } from 'reef-knot/web3-react';
 import { useSDK } from '@lido-sdk/react';
 import { useTxModalStagesClaim } from 'features/withdrawals/claim/transaction-modal-claim/use-tx-modal-stages-claim';
+import { useCurrentStaticRpcProvider } from 'shared/hooks/use-current-static-rpc-provider';
+import { sendTx } from 'utils/send-tx';
 
 type Args = {
   onRetry?: () => void;
@@ -20,6 +22,7 @@ export const useClaim = ({ onRetry }: Args) => {
   const { account } = useWeb3();
   const { providerWeb3 } = useSDK();
   const { contractWeb3 } = useWithdrawalsContract();
+  const { staticRpcProvider } = useCurrentStaticRpcProvider();
   const { optimisticClaimRequests } = useClaimData();
   const { txModalStages } = useTxModalStagesClaim();
 
@@ -43,31 +46,16 @@ export const useClaim = ({ onRetry }: Args) => {
         const ids = sortedRequests.map((r) => r.id);
         const hints = sortedRequests.map((r) => r.hint);
         const callback = async () => {
-          if (isMultisig) {
-            const tx = await contractWeb3.populateTransaction.claimWithdrawals(
-              ids,
-              hints,
-            );
-            return providerWeb3.getSigner().sendUncheckedTransaction(tx);
-          } else {
-            const feeData = await contractWeb3.provider.getFeeData();
-            const maxFeePerGas = feeData.maxFeePerGas ?? undefined;
-            const maxPriorityFeePerGas =
-              feeData.maxPriorityFeePerGas ?? undefined;
-            const gasLimit = await contractWeb3.estimateGas.claimWithdrawals(
-              ids,
-              hints,
-              {
-                maxFeePerGas,
-                maxPriorityFeePerGas,
-              },
-            );
-            return contractWeb3.claimWithdrawals(ids, hints, {
-              maxFeePerGas,
-              maxPriorityFeePerGas,
-              gasLimit,
-            });
-          }
+          const tx = await contractWeb3.populateTransaction.claimWithdrawals(
+            ids,
+            hints,
+          );
+          return sendTx({
+            tx,
+            isMultisig,
+            staticProvider: staticRpcProvider,
+            walletProvider: providerWeb3,
+          });
         };
 
         const tx = await runWithTransactionLogger('Claim signing', callback);
@@ -100,8 +88,9 @@ export const useClaim = ({ onRetry }: Args) => {
       contractWeb3,
       account,
       providerWeb3,
-      optimisticClaimRequests,
       txModalStages,
+      staticRpcProvider,
+      optimisticClaimRequests,
       onRetry,
     ],
   );

--- a/features/withdrawals/hooks/contract/useRequest.ts
+++ b/features/withdrawals/hooks/contract/useRequest.ts
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/no-identical-functions */
 import { useCallback } from 'react';
 import { BigNumber } from 'ethers';
 import invariant from 'tiny-invariant';
@@ -22,11 +23,11 @@ import { useCurrentStaticRpcProvider } from 'shared/hooks/use-current-static-rpc
 import { useApprove } from 'shared/hooks/useApprove';
 import { runWithTransactionLogger } from 'utils';
 import { isContract } from 'utils/isContract';
-import { getFeeData } from 'utils/getFeeData';
 
 import { useWithdrawalsContract } from './useWithdrawalsContract';
 import { useTxModalStagesRequest } from 'features/withdrawals/request/transaction-modal-request/use-tx-modal-stages-request';
 import { useTransactionModal } from 'shared/transaction-modal/transaction-modal';
+import { sendTx } from 'utils/send-tx';
 
 // this encapsulates permit/approval & steth/wsteth flows
 const useWithdrawalRequestMethods = () => {
@@ -44,41 +45,34 @@ const useWithdrawalRequestMethods = () => {
     }) => {
       invariant(chainId, 'must have chainId');
       invariant(account, 'must have account');
+      invariant(providerWeb3, 'must have providerWeb3');
       invariant(signature, 'must have signature');
       invariant(contractWeb3, 'must have contractWeb3');
 
-      const params = [
-        requests,
-        signature.owner,
-        {
-          value: signature.value,
-          deadline: signature.deadline,
-          v: signature.v,
-          r: signature.r,
-          s: signature.s,
-        },
-      ] as const;
-
-      const { maxFeePerGas, maxPriorityFeePerGas } =
-        await getFeeData(staticRpcProvider);
-      const gasLimit =
-        await contractWeb3.estimateGas.requestWithdrawalsWithPermit(...params, {
-          maxFeePerGas,
-          maxPriorityFeePerGas,
-        });
-
-      const txOptions = {
-        maxFeePerGas,
-        maxPriorityFeePerGas,
-        gasLimit,
-      };
+      const tx =
+        await contractWeb3.populateTransaction.requestWithdrawalsWithPermit(
+          requests,
+          signature.owner,
+          {
+            value: signature.value,
+            deadline: signature.deadline,
+            v: signature.v,
+            r: signature.r,
+            s: signature.s,
+          },
+        );
 
       const callback = () =>
-        contractWeb3.requestWithdrawalsWithPermit(...params, txOptions);
+        sendTx({
+          tx,
+          isMultisig: false,
+          staticProvider: staticRpcProvider,
+          walletProvider: providerWeb3,
+        });
 
       return callback;
     },
-    [account, chainId, contractWeb3, staticRpcProvider],
+    [account, chainId, contractWeb3, providerWeb3, staticRpcProvider],
   );
 
   const permitWsteth = useCallback(
@@ -92,44 +86,33 @@ const useWithdrawalRequestMethods = () => {
       invariant(chainId, 'must have chainId');
       invariant(account, 'must have account');
       invariant(signature, 'must have signature');
+      invariant(providerWeb3, 'must have providerWeb3');
       invariant(contractWeb3, 'must have contractWeb3');
 
-      const params = [
-        requests,
-        signature.owner,
-        {
-          value: signature.value,
-          deadline: signature.deadline,
-          v: signature.v,
-          r: signature.r,
-          s: signature.s,
-        },
-      ] as const;
-
-      const feeData = await getFeeData(staticRpcProvider);
-      const maxFeePerGas = feeData.maxFeePerGas ?? undefined;
-      const maxPriorityFeePerGas = feeData.maxPriorityFeePerGas ?? undefined;
-      const gasLimit =
-        await contractWeb3.estimateGas.requestWithdrawalsWstETHWithPermit(
-          ...params,
+      const tx =
+        await contractWeb3.populateTransaction.requestWithdrawalsWstETHWithPermit(
+          requests,
+          signature.owner,
           {
-            maxFeePerGas,
-            maxPriorityFeePerGas,
+            value: signature.value,
+            deadline: signature.deadline,
+            v: signature.v,
+            r: signature.r,
+            s: signature.s,
           },
         );
 
-      const txOptions = {
-        maxFeePerGas,
-        maxPriorityFeePerGas,
-        gasLimit,
-      };
-
       const callback = () =>
-        contractWeb3.requestWithdrawalsWstETHWithPermit(...params, txOptions);
+        sendTx({
+          tx,
+          isMultisig: false,
+          staticProvider: staticRpcProvider,
+          walletProvider: providerWeb3,
+        });
 
       return callback;
     },
-    [account, chainId, contractWeb3, staticRpcProvider],
+    [account, chainId, contractWeb3, providerWeb3, staticRpcProvider],
   );
 
   const steth = useCallback(
@@ -141,31 +124,18 @@ const useWithdrawalRequestMethods = () => {
 
       const isMultisig = await isContract(account, contractWeb3.provider);
 
-      const params = [requests, account] as const;
+      const tx = await contractWeb3.populateTransaction.requestWithdrawals(
+        requests,
+        account,
+      );
 
-      const callback = async () => {
-        if (isMultisig) {
-          const tx = await contractWeb3.populateTransaction.requestWithdrawals(
-            ...params,
-          );
-          return providerWeb3?.getSigner().sendUncheckedTransaction(tx);
-        } else {
-          const { maxFeePerGas, maxPriorityFeePerGas } =
-            await getFeeData(staticRpcProvider);
-          const gasLimit = await contractWeb3.estimateGas.requestWithdrawals(
-            ...params,
-            {
-              maxFeePerGas,
-              maxPriorityFeePerGas,
-            },
-          );
-          return contractWeb3.requestWithdrawals(...params, {
-            maxFeePerGas,
-            maxPriorityFeePerGas,
-            gasLimit,
-          });
-        }
-      };
+      const callback = async () =>
+        sendTx({
+          tx,
+          isMultisig,
+          staticProvider: staticRpcProvider,
+          walletProvider: providerWeb3,
+        });
 
       return callback;
     },
@@ -180,30 +150,19 @@ const useWithdrawalRequestMethods = () => {
       invariant(providerWeb3, 'must have providerWeb3');
       const isMultisig = await isContract(account, contractWeb3.provider);
 
-      const params = [requests, account] as const;
-      const callback = async () => {
-        if (isMultisig) {
-          const tx =
-            await contractWeb3.populateTransaction.requestWithdrawalsWstETH(
-              requests,
-              account,
-            );
-          return providerWeb3?.getSigner().sendUncheckedTransaction(tx);
-        } else {
-          const { maxFeePerGas, maxPriorityFeePerGas } =
-            await getFeeData(staticRpcProvider);
-          const gasLimit =
-            await contractWeb3.estimateGas.requestWithdrawalsWstETH(...params, {
-              maxFeePerGas,
-              maxPriorityFeePerGas,
-            });
-          return contractWeb3.requestWithdrawalsWstETH(...params, {
-            maxFeePerGas,
-            maxPriorityFeePerGas,
-            gasLimit,
-          });
-        }
-      };
+      const tx =
+        await contractWeb3.populateTransaction.requestWithdrawalsWstETH(
+          requests,
+          account,
+        );
+
+      const callback = async () =>
+        sendTx({
+          tx,
+          isMultisig,
+          staticProvider: staticRpcProvider,
+          walletProvider: providerWeb3,
+        });
 
       return callback;
     },

--- a/features/wsteth/wrap/hooks/use-wrap-gas-limit.ts
+++ b/features/wsteth/wrap/hooks/use-wrap-gas-limit.ts
@@ -9,7 +9,7 @@ import {
   WRAP_GAS_LIMIT_GOERLI,
 } from 'consts/tx';
 import { useCurrentStaticRpcProvider } from 'shared/hooks/use-current-static-rpc-provider';
-import { applyGasLimitRatio } from 'features/stake/stake-form/utils';
+import { applyGasLimitRatio } from 'utils/apply-gas-limit-ratio';
 
 export const useWrapGasLimit = () => {
   const wsteth = useWSTETHContractRPC();
@@ -23,11 +23,13 @@ export const useWrapGasLimit = () => {
 
       const fetchGasLimitETH = async () => {
         try {
-          return await staticRpcProvider.estimateGas({
-            from: config.ESTIMATE_ACCOUNT,
-            to: wsteth.address,
-            value: config.ESTIMATE_AMOUNT,
-          });
+          return applyGasLimitRatio(
+            await staticRpcProvider.estimateGas({
+              from: config.ESTIMATE_ACCOUNT,
+              to: wsteth.address,
+              value: config.ESTIMATE_AMOUNT,
+            }),
+          );
         } catch (error) {
           console.warn(`${_key}::[eth]`, error);
           return applyGasLimitRatio(WRAP_FROM_ETH_GAS_LIMIT);

--- a/utils/apply-gas-limit-ratio.ts
+++ b/utils/apply-gas-limit-ratio.ts
@@ -1,0 +1,7 @@
+import { config } from 'config';
+import type { BigNumber } from 'ethers';
+
+export const applyGasLimitRatio = (gasLimit: BigNumber): BigNumber =>
+  gasLimit
+    .mul(config.SUBMIT_EXTRA_GAS_TRANSACTION_RATIO * config.PRECISION)
+    .div(config.PRECISION);

--- a/utils/estimate-gas.ts
+++ b/utils/estimate-gas.ts
@@ -1,0 +1,25 @@
+import { StaticJsonRpcBatchProvider } from '@lidofinance/eth-providers';
+import { PopulatedTransaction } from 'ethers';
+
+export const estimateGas = async (
+  tx: PopulatedTransaction,
+  provider: StaticJsonRpcBatchProvider,
+) => {
+  try {
+    return await provider.estimateGas(tx);
+  } catch (error) {
+    // retry without fees to see if just fails
+    const result = await provider
+      .estimateGas({
+        ...tx,
+        maxFeePerGas: undefined,
+        maxPriorityFeePerGas: undefined,
+      })
+      .catch(() => null);
+    // rethrow original not enough ether error
+    if (result) {
+      throw error;
+    }
+    throw new Error('Something went wrong');
+  }
+};

--- a/utils/send-tx.ts
+++ b/utils/send-tx.ts
@@ -1,0 +1,42 @@
+import type {
+  JsonRpcBatchProvider,
+  Web3Provider,
+} from '@ethersproject/providers';
+import type { PopulatedTransaction } from 'ethers';
+
+import { getFeeData } from './getFeeData';
+import { estimateGas } from './estimate-gas';
+import { applyGasLimitRatio } from 'utils/apply-gas-limit-ratio';
+
+export type SendTxOptions = {
+  tx: PopulatedTransaction;
+  isMultisig: boolean;
+  walletProvider: Web3Provider;
+  staticProvider: JsonRpcBatchProvider;
+  shouldApplyGasLimitRatio?: boolean;
+};
+
+export const sendTx = async ({
+  tx,
+  isMultisig,
+  staticProvider,
+  walletProvider,
+  shouldApplyGasLimitRatio = false,
+}: SendTxOptions) => {
+  if (isMultisig)
+    return walletProvider.getSigner().sendUncheckedTransaction(tx);
+
+  const { maxFeePerGas, maxPriorityFeePerGas } =
+    await getFeeData(staticProvider);
+
+  tx.maxFeePerGas = maxFeePerGas;
+  tx.maxPriorityFeePerGas = maxPriorityFeePerGas;
+
+  const gasLimit = await estimateGas(tx, staticProvider);
+
+  tx.gasLimit = shouldApplyGasLimitRatio
+    ? applyGasLimitRatio(gasLimit)
+    : gasLimit;
+
+  return walletProvider.getSigner().sendTransaction(tx);
+};


### PR DESCRIPTION
### Description

- use sendTx callback for unified tx sending
- remove usage of walletRPC during tx preparation to prevent unsynced/broken nodes messing up
-  double estimate gas flow to distinguish between` not enough ether` and tx failing 


### Code review notes

<!--- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

Unfortunately, this touches ALL TXs.
Please check multisigs. 

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
