### PR TITLE
feat: add operation to text on l2 banner on each page

### DIFF
--- a/features/stake/stake-form/wallet/wallet.tsx
+++ b/features/stake/stake-form/wallet/wallet.tsx
@@ -111,7 +111,7 @@ export const Wallet: WalletComponentType = memo((props) => {
   );
 
   if (isL2Chain && showL2Chain) {
-    return <L2Fallback {...props} />;
+    return <L2Fallback textEnding={'to stake'} {...props} />;
   }
 
   if (!isDappActive) {

--- a/features/withdrawals/claim/wallet/wallet.tsx
+++ b/features/withdrawals/claim/wallet/wallet.tsx
@@ -47,7 +47,7 @@ export const ClaimWallet: WalletComponentType = memo((props) => {
   );
 
   if (isL2Chain && showL2Chain) {
-    return <L2Fallback {...props} />;
+    return <L2Fallback textEnding={'to claim withdrawals'} {...props} />;
   }
 
   if (!isDappActive) {

--- a/features/withdrawals/request/wallet/wallet.tsx
+++ b/features/withdrawals/request/wallet/wallet.tsx
@@ -51,7 +51,7 @@ export const RequestWallet: WalletComponentType = memo((props) => {
   );
 
   if (isL2Chain && showL2Chain) {
-    return <L2Fallback {...props} />;
+    return <L2Fallback textEnding={'to request withdrawals'} {...props} />;
   }
 
   if (!isDappActive) {

--- a/features/wsteth/shared/wallet/wallet.tsx
+++ b/features/wsteth/shared/wallet/wallet.tsx
@@ -128,7 +128,7 @@ export const Wallet: WalletComponentType = memo((props) => {
   );
 
   if (isL2Chain && showL2Chain) {
-    return <L2Fallback {...props} />;
+    return <L2Fallback textEnding={'to wrap/unwrap'} {...props} />;
   }
 
   if (!isDappActive) {

--- a/shared/wallet/l2-fallback/l2-fallback.tsx
+++ b/shared/wallet/l2-fallback/l2-fallback.tsx
@@ -1,6 +1,6 @@
-import { useMemo } from 'react';
+import { FC, useMemo } from 'react';
 import { useAccount } from 'wagmi';
-import { Link } from '@lidofinance/lido-ui';
+import { BlockProps, Link } from '@lidofinance/lido-ui';
 
 import { ReactComponent as ArbitrumLogo } from 'assets/icons/l2/arbitrum.svg';
 import { ReactComponent as BaseLogo } from 'assets/icons/l2/base.svg';
@@ -15,9 +15,10 @@ import { config } from 'config';
 import { useUserConfig } from 'config/user-config';
 import { CHAINS, L2_CHAINS } from 'consts/chains';
 import { MATOMO_CLICK_EVENTS_TYPES } from 'consts/matomo-click-events';
-import { WalletCardComponent } from 'shared/wallet/card/types';
 
 import { L2FallbackWalletStyle, TextStyle, ButtonStyle } from './styles';
+
+export type L2FallbackComponent = FC<{ textEnding: string } & BlockProps>;
 
 const l2Logos = {
   [L2_CHAINS.Arbitrum]: ArbitrumLogo,
@@ -35,7 +36,7 @@ const getL2Logo = (chainId: L2_CHAINS) => {
   return SVGLogo ? <SVGLogo style={{ marginBottom: '13px' }} /> : null;
 };
 
-export const L2Fallback: WalletCardComponent = (props) => {
+export const L2Fallback: L2FallbackComponent = (props) => {
   const { chainId } = useAccount();
   const { defaultChain } = useUserConfig();
 
@@ -53,7 +54,7 @@ export const L2Fallback: WalletCardComponent = (props) => {
       {getL2Logo(chainId as L2_CHAINS)}
       <TextStyle>
         Learn about Lido on L2 opportunities on {l2ChainName} network or switch
-        to Ethereum {defaultChainName} to stake
+        to Ethereum {defaultChainName} {props.textEnding}
       </TextStyle>
       <Link
         href={`${config.rootOrigin}/lido-on-l2`}


### PR DESCRIPTION
### Description

Add operation to text on l2 banner on each page

### Demo

**stake**

<img width="690" alt="image" src="https://github.com/user-attachments/assets/a71bd1fd-1060-448a-8a52-0b749dc3b00d">


**wrap/unwrap**

<img width="692" alt="image" src="https://github.com/user-attachments/assets/b3f74861-332a-4b32-ac67-72db3b4f2464">

**withdrawals request**

<img width="697" alt="image" src="https://github.com/user-attachments/assets/af2774b5-767a-46d6-a563-c9e2b6fba72f">


**withdrawals claim**

<img width="681" alt="image" src="https://github.com/user-attachments/assets/53786c5c-025f-4b1e-b29c-b664e9582e43">



### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
