### PR TITLE
chore: moduleResolution is nodenext

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,13 +9,13 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
     "baseUrl": ".",
-    "incremental": true
+    "incremental": true,
   },
   "include": ["**/*"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
 }


### PR DESCRIPTION
### Description

Changed TS compilerOptions.moduleResolution from `node` to `nodenext`

### Testing notes

Check all widget critical functional

P.S. successful local tested on the sepolia network

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
