### PR TITLE
fix: use ISO for dates in rewards csv

### DIFF
--- a/features/rewards/utils/genExportData.ts
+++ b/features/rewards/utils/genExportData.ts
@@ -7,7 +7,7 @@ import { fromUnixTime } from 'date-fns';
 export const genExportData = (currency: CurrencyType, data: Event[] | null) =>
   data
     ? data.map((item) => ({
-        date: fromUnixTime(parseInt(item.blockTime)),
+        date: fromUnixTime(parseInt(item.blockTime)).toISOString(),
         type: item.type,
         direction: item.direction,
         change: weiToEther(item.change).toString(),


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

Use ISO8601 date when exporting rewards to csv 

### Demo

<img width="513" alt="image" src="https://github.com/user-attachments/assets/d98ba863-3134-4628-8fdd-da7580a44453">

### Code review notes

<!--- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

<!--- List all possible edge cases and how to test them. -->

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
