### PR TITLE
feat: change wrap success banner

### DIFF
--- a/consts/matomo-click-events.ts
+++ b/consts/matomo-click-events.ts
@@ -18,6 +18,7 @@ export const enum MATOMO_CLICK_EVENTS_TYPES {
   obolBannerProceed = 'obolBannerProceed',
   obolBannerDVVLink = 'obolBannerDVVLink',
   exploreAllStrategiesAfterStake = 'exploreAllStrategiesAfterStake',
+  exploreAllStrategiesAfterWrap = 'exploreAllStrategiesAfterWrap',
   // FAQ
   faqSafeWorkWithLidoAudits = 'faqSafeWorkWithLidoAudits',
   faqLidoEthAprEthLandingPage = 'faqLidoEthAprEthLandingPage',
@@ -146,6 +147,11 @@ export const MATOMO_CLICK_EVENTS: Record<
     'Ethereum_Staking_Widget',
     'Push "Explore all strategies" after staking',
     'eth_widget_explore_all_strategies_after_staking',
+  ],
+  [MATOMO_CLICK_EVENTS_TYPES.exploreAllStrategiesAfterWrap]: [
+    'Ethereum_Staking_Widget',
+    'Push "Explore all strategies" after wrap',
+    'eth_widget_explore_all_strategies_after_wraping',
   ],
   // FAQ
   [MATOMO_CLICK_EVENTS_TYPES.faqSafeWorkWithLidoAudits]: [

--- a/features/stake/stake-form/hooks/use-tx-modal-stages-stake.tsx
+++ b/features/stake/stake-form/hooks/use-tx-modal-stages-stake.tsx
@@ -12,7 +12,7 @@ import { TxStageOperationSucceedBalanceShown } from 'shared/transaction-modal/tx
 import type { BigNumber } from 'ethers';
 import { trackEvent } from '@lidofinance/analytics-matomo';
 import { MATOMO_CLICK_EVENTS } from 'consts/matomo-click-events';
-import { LINK_EXPLORE_STRATEGIES } from '../../../../shared/banners/vaults-banner-info/const';
+import { LINK_EXPLORE_STRATEGIES } from 'shared/banners/vaults-banner-info/const';
 
 const STAGE_OPERATION_ARGS = {
   token: 'ETH',

--- a/features/stake/stake-form/hooks/use-tx-modal-stages-stake.tsx
+++ b/features/stake/stake-form/hooks/use-tx-modal-stages-stake.tsx
@@ -12,9 +12,7 @@ import { TxStageOperationSucceedBalanceShown } from 'shared/transaction-modal/tx
 import type { BigNumber } from 'ethers';
 import { trackEvent } from '@lidofinance/analytics-matomo';
 import { MATOMO_CLICK_EVENTS } from 'consts/matomo-click-events';
-
-const LINK_EXPLORE_STRATEGIES =
-  'https://lido.fi/?pk_vid=6c467e14095d5ea11723712888b1fe5f#defi-strategies';
+import { LINK_EXPLORE_STRATEGIES } from '../../../../shared/banners/vaults-banner-info/const';
 
 const STAGE_OPERATION_ARGS = {
   token: 'ETH',

--- a/features/wsteth/wrap/hooks/use-tx-modal-stages-wrap.tsx
+++ b/features/wsteth/wrap/hooks/use-tx-modal-stages-wrap.tsx
@@ -1,3 +1,6 @@
+import { Button, Link } from '@lidofinance/lido-ui';
+import { trackEvent } from '@lidofinance/analytics-matomo';
+
 import {
   TransactionModalTransitStage,
   useTransactionModalStage,
@@ -6,15 +9,14 @@ import { getGeneralTransactionModalStages } from 'shared/transaction-modal/hooks
 
 import { TxStageSignOperationAmount } from 'shared/transaction-modal/tx-stages-composed/tx-stage-amount-operation';
 import { TxStageOperationSucceedBalanceShown } from 'shared/transaction-modal/tx-stages-composed/tx-stage-operation-succeed-balance-shown';
+import { LINK_EXPLORE_STRATEGIES } from 'shared/banners/vaults-banner-info/const';
 
 import { getTokenDisplayName } from 'utils/getTokenDisplayName';
 import type { BigNumber } from 'ethers';
 import type { TokensWrappable } from 'features/wsteth/shared/types';
-import { VaultsBannerInfo } from '../../../../shared/banners/vaults-banner-info';
-import { Button, Link } from '@lidofinance/lido-ui';
-import { trackEvent } from '@lidofinance/analytics-matomo';
-import { MATOMO_CLICK_EVENTS } from '../../../../consts/matomo-click-events';
-import { LINK_EXPLORE_STRATEGIES } from '../../../../shared/banners/vaults-banner-info/const';
+import { VaultsBannerInfo } from 'shared/banners/vaults-banner-info';
+
+import { MATOMO_CLICK_EVENTS } from 'consts/matomo-click-events';
 
 const STAGE_APPROVE_ARGS = {
   willReceiveToken: 'wstETH',

--- a/features/wsteth/wrap/hooks/use-tx-modal-stages-wrap.tsx
+++ b/features/wsteth/wrap/hooks/use-tx-modal-stages-wrap.tsx
@@ -4,13 +4,17 @@ import {
 } from 'shared/transaction-modal/hooks/use-transaction-modal-stage';
 import { getGeneralTransactionModalStages } from 'shared/transaction-modal/hooks/get-general-transaction-modal-stages';
 
-import { VaultsBannerStrategies } from 'shared/banners/vaults-banner-strategies';
 import { TxStageSignOperationAmount } from 'shared/transaction-modal/tx-stages-composed/tx-stage-amount-operation';
 import { TxStageOperationSucceedBalanceShown } from 'shared/transaction-modal/tx-stages-composed/tx-stage-operation-succeed-balance-shown';
 
 import { getTokenDisplayName } from 'utils/getTokenDisplayName';
 import type { BigNumber } from 'ethers';
 import type { TokensWrappable } from 'features/wsteth/shared/types';
+import { VaultsBannerInfo } from '../../../../shared/banners/vaults-banner-info';
+import { Button, Link } from '@lidofinance/lido-ui';
+import { trackEvent } from '@lidofinance/analytics-matomo';
+import { MATOMO_CLICK_EVENTS } from '../../../../consts/matomo-click-events';
+import { LINK_EXPLORE_STRATEGIES } from '../../../../shared/banners/vaults-banner-info/const';
 
 const STAGE_APPROVE_ARGS = {
   willReceiveToken: 'wstETH',
@@ -83,7 +87,22 @@ const getTxModalStagesWrap = (transitStage: TransactionModalTransitStage) => ({
         balance={balance}
         balanceToken={'wstETH'}
         operationText={'Wrapping'}
-        footer={<VaultsBannerStrategies />}
+        footer={
+          <>
+            <VaultsBannerInfo isTitleCompact showLearnMoreButton={false} />
+            <br />
+            <Link
+              href={LINK_EXPLORE_STRATEGIES}
+              onClick={() =>
+                trackEvent(...MATOMO_CLICK_EVENTS.exploreAllStrategiesAfterWrap)
+              }
+            >
+              <Button fullwidth size="sm">
+                Explore strategies
+              </Button>
+            </Link>
+          </>
+        }
       />,
       {
         isClosableOnLedger: true,

--- a/shared/banners/vaults-banner-info/const.ts
+++ b/shared/banners/vaults-banner-info/const.ts
@@ -1,2 +1,1 @@
-export const LINK_EXPLORE_STRATEGIES =
-  'https://lido.fi/?pk_vid=6c467e14095d5ea11723712888b1fe5f#defi-strategies';
+export const LINK_EXPLORE_STRATEGIES = 'https://lido.fi/#defi-strategies';

--- a/shared/banners/vaults-banner-info/const.ts
+++ b/shared/banners/vaults-banner-info/const.ts
@@ -1,0 +1,2 @@
+export const LINK_EXPLORE_STRATEGIES =
+  'https://lido.fi/?pk_vid=6c467e14095d5ea11723712888b1fe5f#defi-strategies';


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description
- change wrap success banner as it is on stake success banner
- add matomo events on "Explore defi options" on success banner

<!--- Briefly note most valuable changes in what you did and why we need it, even if the task was described in detail in the task tracker. -->

### Demo
![image](https://github.com/user-attachments/assets/df248765-ab1f-4c82-82dc-6238ff6a0fdc)


<!--- If thee are visual changes, attach a link to a specific section on preview stand / add screenshots / record a [loom](https://www.loom.com/). -->

### Code review notes

<!--- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

<!--- List all possible edge cases and how to test them. -->

### Checklist:

- [x] Checked the changes locally.
- [x] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
