### PR TITLE
feat: return unsupported banner to reward page

### DIFF
--- a/features/rewards/components/address-input/address-input.tsx
+++ b/features/rewards/components/address-input/address-input.tsx
@@ -13,7 +13,6 @@ export const AddressInput: FC<AddressInputProps> = (props) => {
     handleInputChange,
     address,
     addressError: invalidENSAddress,
-    loading,
   } = props;
 
   const invalidEthereumAddress = useMemo(
@@ -28,7 +27,7 @@ export const AddressInput: FC<AddressInputProps> = (props) => {
       onChange={(e) => handleInputChange(e.target.value)}
       placeholder="Ethereum address"
       leftDecorator={
-        loading || isAddressResolving ? (
+        isAddressResolving ? (
           <Loader size="small" />
         ) : invalidEthereumAddress || invalidENSAddress ? (
           <ErrorTriangle />

--- a/features/rewards/components/rewardsListContent/RewardsListContent.tsx
+++ b/features/rewards/components/rewardsListContent/RewardsListContent.tsx
@@ -1,6 +1,7 @@
 import { FC } from 'react';
 import { Loader, Divider } from '@lidofinance/lido-ui';
-import { useSTETHBalance } from '@lido-sdk/react';
+import { useSDK, useTokenBalance } from '@lido-sdk/react';
+import { TOKENS, getTokenAddress } from '@lido-sdk/constants';
 import { Zero } from '@ethersproject/constants';
 
 import { STRATEGY_LAZY } from 'consts/swr-strategies';
@@ -21,6 +22,7 @@ import {
 export const RewardsListContent: FC = () => {
   const { isWalletConnected, isSupportedChain } = useDappStatus();
   const {
+    address,
     error,
     initialLoading,
     data,
@@ -29,8 +31,14 @@ export const RewardsListContent: FC = () => {
     setPage,
     isLagging,
   } = useRewardsHistory();
+  // temporarily until we switched to a new SDK
+  const { chainId } = useSDK();
   const { data: stethBalance, initialLoading: isStethBalanceLoading } =
-    useSTETHBalance(STRATEGY_LAZY);
+    useTokenBalance(
+      getTokenAddress(chainId || 1, TOKENS.STETH),
+      address,
+      STRATEGY_LAZY,
+    );
   const hasSteth = stethBalance?.gt(Zero);
 
   if (isWalletConnected && !isSupportedChain)

--- a/features/rewards/components/rewardsListContent/RewardsListContent.tsx
+++ b/features/rewards/components/rewardsListContent/RewardsListContent.tsx
@@ -7,9 +7,11 @@ import { STRATEGY_LAZY } from 'consts/swr-strategies';
 import { useRewardsHistory } from 'features/rewards/hooks';
 import { ErrorBlockNoSteth } from 'features/rewards/components/errorBlocks/ErrorBlockNoSteth';
 import { RewardsTable } from 'features/rewards/components/rewardsTable';
+import { useDappStatus } from 'shared/hooks/use-dapp-status';
 
 import { RewardsListsEmpty } from './RewardsListsEmpty';
 import { RewardsListErrorMessage } from './RewardsListErrorMessage';
+import { RewardsListsUnsupportedChain } from './RewardsListsUnsupportedChain';
 import {
   LoaderWrapper,
   TableWrapperStyle,
@@ -17,6 +19,7 @@ import {
 } from './RewardsListContentStyles';
 
 export const RewardsListContent: FC = () => {
+  const { isWalletConnected, isSupportedChain } = useDappStatus();
   const {
     error,
     initialLoading,
@@ -30,7 +33,11 @@ export const RewardsListContent: FC = () => {
     useSTETHBalance(STRATEGY_LAZY);
   const hasSteth = stethBalance?.gt(Zero);
 
+  if (isWalletConnected && !isSupportedChain)
+    return <RewardsListsUnsupportedChain />;
+
   if (!data && !initialLoading && !error) return <RewardsListsEmpty />;
+
   // showing loading when canceling requests and empty response
   if (
     (!data && !error) ||
@@ -46,6 +53,7 @@ export const RewardsListContent: FC = () => {
       </>
     );
   }
+
   if (error) {
     return (
       <ErrorWrapper>

--- a/features/rewards/components/rewardsListContent/RewardsListsUnsupportedChain.tsx
+++ b/features/rewards/components/rewardsListContent/RewardsListsUnsupportedChain.tsx
@@ -21,10 +21,7 @@ export const RewardsListsUnsupportedChain: FC = () => {
     <>
       <Divider indents="lg" />
       <RewardsListEmptyWrapper>
-        <p>
-          Please switch to {supportedChainsNames} in your wallet and restart the
-          page.
-        </p>
+        <p>Please switch to {supportedChainsNames} in your wallet.</p>
       </RewardsListEmptyWrapper>
     </>
   );

--- a/features/rewards/components/rewardsListContent/RewardsListsUnsupportedChain.tsx
+++ b/features/rewards/components/rewardsListContent/RewardsListsUnsupportedChain.tsx
@@ -22,7 +22,10 @@ export const RewardsListsUnsupportedChain: FC = () => {
     <>
       <Divider indents="lg" />
       <RewardsListEmptyWrapper>
-        <p>Please switch to {supportedChainsNames} in your wallet.</p>
+        <p>
+          Please switch to {supportedChainsNames} in your wallet to see the
+          stats.
+        </p>
       </RewardsListEmptyWrapper>
     </>
   );

--- a/features/rewards/components/rewardsListContent/RewardsListsUnsupportedChain.tsx
+++ b/features/rewards/components/rewardsListContent/RewardsListsUnsupportedChain.tsx
@@ -14,6 +14,7 @@ export const RewardsListsUnsupportedChain: FC = () => {
     // 'Chain ID' array to 'Chain name' array exclude unknown chain id
     const chains = supportedChains.map((id) => CHAINS[id]).filter(Boolean);
     const lastChain = chains.pop();
+    // to str
     return [chains.join(', '), lastChain].filter((chain) => chain).join(' or ');
   }, [supportedChains]);
 

--- a/features/rewards/components/rewardsListContent/RewardsListsUnsupportedChain.tsx
+++ b/features/rewards/components/rewardsListContent/RewardsListsUnsupportedChain.tsx
@@ -1,0 +1,31 @@
+import { FC, useMemo } from 'react';
+import { Divider } from '@lidofinance/lido-ui';
+
+import { useConfig } from 'config';
+import { CHAINS } from 'consts/chains';
+import { RewardsListEmptyWrapper } from './RewardsListsEmptyStyles';
+
+export const RewardsListsUnsupportedChain: FC = () => {
+  const {
+    config: { supportedChains },
+  } = useConfig();
+
+  const supportedChainsNames = useMemo(() => {
+    // 'Chain ID' array to 'Chain name' array exclude unknown chain id
+    const chains = supportedChains.map((id) => CHAINS[id]).filter(Boolean);
+    const lastChain = chains.pop();
+    return [chains.join(', '), lastChain].filter((chain) => chain).join(' or ');
+  }, [supportedChains]);
+
+  return (
+    <>
+      <Divider indents="lg" />
+      <RewardsListEmptyWrapper>
+        <p>
+          Please switch to {supportedChainsNames} in your wallet and restart the
+          page.
+        </p>
+      </RewardsListEmptyWrapper>
+    </>
+  );
+};

--- a/features/rewards/components/rewardsListHeader/RewardsListHeader.tsx
+++ b/features/rewards/components/rewardsListHeader/RewardsListHeader.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react';
 import { useRewardsHistory } from 'features/rewards/hooks';
+import { useDappStatus } from 'shared/hooks/use-dapp-status';
 
 import { LeftOptions } from './LeftOptions';
 import { RightOptions } from './RightOptions';
@@ -7,17 +8,21 @@ import { RewardsListHeaderStyle } from './styles';
 import { TitleStyle } from './styles';
 
 export const RewardsListHeader: FC = () => {
+  const { isWalletConnected, isSupportedChain } = useDappStatus();
   const { error, data } = useRewardsHistory();
 
   return (
     <RewardsListHeaderStyle data-testid="rewardsHeader">
       <TitleStyle>Reward history</TitleStyle>
-      {!error && data && data?.events.length > 0 && (
-        <>
-          <LeftOptions />
-          <RightOptions />
-        </>
-      )}
+      {!error &&
+        data &&
+        data?.events.length > 0 &&
+        (!isWalletConnected || (isWalletConnected && isSupportedChain)) && (
+          <>
+            <LeftOptions />
+            <RightOptions />
+          </>
+        )}
     </RewardsListHeaderStyle>
   );
 };

--- a/features/rewards/components/rewardsListHeader/RewardsListHeader.tsx
+++ b/features/rewards/components/rewardsListHeader/RewardsListHeader.tsx
@@ -1,6 +1,5 @@
 import { FC } from 'react';
 import { useRewardsHistory } from 'features/rewards/hooks';
-import { useDappStatus } from 'shared/hooks/use-dapp-status';
 
 import { LeftOptions } from './LeftOptions';
 import { RightOptions } from './RightOptions';
@@ -8,12 +7,12 @@ import { RewardsListHeaderStyle } from './styles';
 import { TitleStyle } from './styles';
 
 export const RewardsListHeader: FC = () => {
-  const { isDappActive } = useDappStatus();
   const { error, data } = useRewardsHistory();
+
   return (
     <RewardsListHeaderStyle data-testid="rewardsHeader">
       <TitleStyle>Reward history</TitleStyle>
-      {isDappActive && !error && data && data?.events.length > 0 && (
+      {!error && data && data?.events.length > 0 && (
         <>
           <LeftOptions />
           <RightOptions />

--- a/features/rewards/components/stats/average-apr-block.tsx
+++ b/features/rewards/components/stats/average-apr-block.tsx
@@ -8,11 +8,7 @@ import { Item } from './components/item';
 import { FlexCenter } from './components/styles';
 
 export const AverageAprBlock: FC = () => {
-  const {
-    data,
-    isDataAvailable,
-    initialLoading: loading,
-  } = useRewardsHistory();
+  const { data, initialLoading: loading } = useRewardsHistory();
 
   return (
     <Item
@@ -27,7 +23,7 @@ export const AverageAprBlock: FC = () => {
         </FlexCenter>
       }
       value={
-        parseFloat(data?.averageApr || '0') && isDataAvailable ? (
+        parseFloat(data?.averageApr || '0') ? (
           <>
             <NumberFormat number={data?.averageApr} percent />
             <Box display="inline-block" pl="3px">

--- a/features/rewards/components/stats/average-apr-block.tsx
+++ b/features/rewards/components/stats/average-apr-block.tsx
@@ -3,43 +3,40 @@ import { Box, Question, Tooltip } from '@lidofinance/lido-ui';
 
 import NumberFormat from 'features/rewards/components/NumberFormat';
 import { useRewardsHistory } from 'features/rewards/hooks';
-import { useDappStatus } from 'shared/hooks/use-dapp-status';
 
 import { Item } from './components/item';
 import { FlexCenter } from './components/styles';
 
 export const AverageAprBlock: FC = () => {
-  const { isWalletConnected, isSupportedChain } = useDappStatus();
-  const { data, initialLoading: loading } = useRewardsHistory();
+  const {
+    data,
+    isDataAvailable,
+    initialLoading: loading,
+  } = useRewardsHistory();
 
   return (
     <Item
       loading={loading}
       dataTestId="averageAprBlock"
       title={
-        <>
-          <FlexCenter>
-            Average APR
-            <Tooltip title={'APR on stETH over your staking period'}>
-              <Question />
-            </Tooltip>
-          </FlexCenter>
-        </>
+        <FlexCenter>
+          Average APR
+          <Tooltip title={'APR on stETH over your staking period'}>
+            <Question />
+          </Tooltip>
+        </FlexCenter>
       }
       value={
-        <>
-          {(isWalletConnected && !isSupportedChain) ||
-          !parseFloat(data?.averageApr || '0') ? (
-            '—'
-          ) : (
-            <>
-              <NumberFormat number={data?.averageApr} percent />
-              <Box display="inline-block" pl="3px">
-                %
-              </Box>
-            </>
-          )}
-        </>
+        parseFloat(data?.averageApr || '0') && isDataAvailable ? (
+          <>
+            <NumberFormat number={data?.averageApr} percent />
+            <Box display="inline-block" pl="3px">
+              %
+            </Box>
+          </>
+        ) : (
+          '—'
+        )
       }
       valueDataTestId="averageApr"
     />

--- a/features/rewards/components/stats/average-apr-block.tsx
+++ b/features/rewards/components/stats/average-apr-block.tsx
@@ -3,11 +3,13 @@ import { Box, Question, Tooltip } from '@lidofinance/lido-ui';
 
 import NumberFormat from 'features/rewards/components/NumberFormat';
 import { useRewardsHistory } from 'features/rewards/hooks';
+import { useDappStatus } from 'shared/hooks/use-dapp-status';
 
 import { Item } from './components/item';
 import { FlexCenter } from './components/styles';
 
 export const AverageAprBlock: FC = () => {
+  const { isWalletConnected, isSupportedChain } = useDappStatus();
   const { data, initialLoading: loading } = useRewardsHistory();
 
   return (
@@ -26,15 +28,16 @@ export const AverageAprBlock: FC = () => {
       }
       value={
         <>
-          {parseFloat(data?.averageApr || '0') ? (
+          {(isWalletConnected && !isSupportedChain) ||
+          !parseFloat(data?.averageApr || '0') ? (
+            '—'
+          ) : (
             <>
               <NumberFormat number={data?.averageApr} percent />
               <Box display="inline-block" pl="3px">
                 %
               </Box>
             </>
-          ) : (
-            '—'
           )}
         </>
       }

--- a/features/rewards/components/stats/steth-balance-block.tsx
+++ b/features/rewards/components/stats/steth-balance-block.tsx
@@ -10,8 +10,8 @@ import { Item } from './components/item';
 export const StEthBalanceBlock: FC = () => {
   const { data: balanceData } = useRewardsBalanceData();
   const {
+    data: dataRewards,
     currencyObject: currency,
-    isDataAvailable,
     loading,
   } = useRewardsHistory();
 
@@ -21,7 +21,7 @@ export const StEthBalanceBlock: FC = () => {
       dataTestId="stEthBalanceBlock"
       title="stETH balance"
       value={
-        balanceData?.stEthBalanceParsed && isDataAvailable ? (
+        balanceData?.stEthBalanceParsed && dataRewards ? (
           <>
             <NumberFormat number={balanceData?.stEthBalanceParsed} />
             <Box display="inline-block" pl={'3px'}>
@@ -34,7 +34,7 @@ export const StEthBalanceBlock: FC = () => {
       }
       valueDataTestId="stEthBalance"
       underValue={
-        balanceData?.stEthCurrencyBalance && isDataAvailable ? (
+        balanceData?.stEthCurrencyBalance ? (
           <>
             <Box display="inline-block" pr={'3px'}>
               {currency.symbol}

--- a/features/rewards/components/stats/steth-balance-block.tsx
+++ b/features/rewards/components/stats/steth-balance-block.tsx
@@ -4,14 +4,16 @@ import { Box } from '@lidofinance/lido-ui';
 import NumberFormat from 'features/rewards/components/NumberFormat';
 import { useRewardsHistory } from 'features/rewards/hooks';
 import { useRewardsBalanceData } from 'features/rewards/hooks/use-rewards-balance-data';
-import { useDappStatus } from 'shared/hooks/use-dapp-status';
 
 import { Item } from './components/item';
 
 export const StEthBalanceBlock: FC = () => {
-  const { isWalletConnected, isSupportedChain } = useDappStatus();
   const { data: balanceData } = useRewardsBalanceData();
-  const { currencyObject: currency, loading } = useRewardsHistory();
+  const {
+    currencyObject: currency,
+    isDataAvailable,
+    loading,
+  } = useRewardsHistory();
 
   return (
     <Item
@@ -19,30 +21,28 @@ export const StEthBalanceBlock: FC = () => {
       dataTestId="stEthBalanceBlock"
       title="stETH balance"
       value={
-        (isWalletConnected && !isSupportedChain) ||
-        !balanceData?.stEthBalanceParsed ? (
-          '—'
-        ) : (
+        balanceData?.stEthBalanceParsed && isDataAvailable ? (
           <>
             <NumberFormat number={balanceData?.stEthBalanceParsed} />
             <Box display="inline-block" pl={'3px'}>
               stETH
             </Box>
           </>
+        ) : (
+          '—'
         )
       }
       valueDataTestId="stEthBalance"
       underValue={
-        (isWalletConnected && !isSupportedChain) ||
-        !balanceData?.stEthCurrencyBalance ? (
-          '—'
-        ) : (
+        balanceData?.stEthCurrencyBalance && isDataAvailable ? (
           <>
             <Box display="inline-block" pr={'3px'}>
               {currency.symbol}
             </Box>
             <NumberFormat number={balanceData?.stEthCurrencyBalance} currency />
           </>
+        ) : (
+          '—'
         )
       }
       underValueDataTestId="stEthBalanceIn$"

--- a/features/rewards/components/stats/steth-balance-block.tsx
+++ b/features/rewards/components/stats/steth-balance-block.tsx
@@ -4,10 +4,12 @@ import { Box } from '@lidofinance/lido-ui';
 import NumberFormat from 'features/rewards/components/NumberFormat';
 import { useRewardsHistory } from 'features/rewards/hooks';
 import { useRewardsBalanceData } from 'features/rewards/hooks/use-rewards-balance-data';
+import { useDappStatus } from 'shared/hooks/use-dapp-status';
 
 import { Item } from './components/item';
 
 export const StEthBalanceBlock: FC = () => {
+  const { isWalletConnected, isSupportedChain } = useDappStatus();
   const { data: balanceData } = useRewardsBalanceData();
   const { currencyObject: currency, loading } = useRewardsHistory();
 
@@ -17,6 +19,7 @@ export const StEthBalanceBlock: FC = () => {
       dataTestId="stEthBalanceBlock"
       title="stETH balance"
       value={
+        (isWalletConnected && !isSupportedChain) ||
         !balanceData?.stEthBalanceParsed ? (
           '—'
         ) : (
@@ -30,6 +33,7 @@ export const StEthBalanceBlock: FC = () => {
       }
       valueDataTestId="stEthBalance"
       underValue={
+        (isWalletConnected && !isSupportedChain) ||
         !balanceData?.stEthCurrencyBalance ? (
           '—'
         ) : (

--- a/features/rewards/components/stats/steth-price-block.tsx
+++ b/features/rewards/components/stats/steth-price-block.tsx
@@ -4,10 +4,12 @@ import { Box } from '@lidofinance/lido-ui';
 import NumberFormat from 'features/rewards/components/NumberFormat';
 import { useRewardsHistory } from 'features/rewards/hooks';
 import { useStethEthRate } from 'features/rewards/hooks/use-steth-eth-rate';
+import { useDappStatus } from 'shared/hooks/use-dapp-status';
 
 import { Item } from './components/item';
 
 export const StEthPriceBlock: FC = () => {
+  const { isWalletConnected, isSupportedChain } = useDappStatus();
   const {
     currencyObject: currency,
     data,
@@ -21,6 +23,7 @@ export const StEthPriceBlock: FC = () => {
       dataTestId="stEthPriceBlock"
       title="stETH price"
       value={
+        (isWalletConnected && !isSupportedChain) ||
         !data?.stETHCurrencyPrice[currency.id] ? (
           '—'
         ) : (
@@ -35,15 +38,16 @@ export const StEthPriceBlock: FC = () => {
       valueDataTestId="stEthPrice"
       underValue={
         <>
-          {data?.stETHCurrencyPrice[currency.id] ? (
+          {(isWalletConnected && !isSupportedChain) ||
+          !data?.stETHCurrencyPrice[currency.id] ? (
+            '—'
+          ) : (
             <>
               <NumberFormat number={stEthEth?.toString()} StEthEth />
               <Box display="inline-block" pl={'3px'}>
                 ETH
               </Box>
             </>
-          ) : (
-            '—'
           )}
         </>
       }

--- a/features/rewards/components/stats/steth-price-block.tsx
+++ b/features/rewards/components/stats/steth-price-block.tsx
@@ -11,7 +11,6 @@ export const StEthPriceBlock: FC = () => {
   const {
     currencyObject: currency,
     data,
-    isDataAvailable,
     initialLoading: loading,
   } = useRewardsHistory();
   const stEthEth = useStethEthRate();
@@ -22,7 +21,7 @@ export const StEthPriceBlock: FC = () => {
       dataTestId="stEthPriceBlock"
       title="stETH price"
       value={
-        data?.stETHCurrencyPrice[currency.id] && isDataAvailable ? (
+        data?.stETHCurrencyPrice[currency.id] ? (
           <>
             <Box display="inline-block" pr="3px">
               {currency.symbol}
@@ -35,7 +34,7 @@ export const StEthPriceBlock: FC = () => {
       }
       valueDataTestId="stEthPrice"
       underValue={
-        data?.stETHCurrencyPrice[currency.id] && isDataAvailable ? (
+        data?.stETHCurrencyPrice[currency.id] ? (
           <>
             <NumberFormat number={stEthEth?.toString()} StEthEth />
             <Box display="inline-block" pl={'3px'}>

--- a/features/rewards/components/stats/steth-price-block.tsx
+++ b/features/rewards/components/stats/steth-price-block.tsx
@@ -4,15 +4,14 @@ import { Box } from '@lidofinance/lido-ui';
 import NumberFormat from 'features/rewards/components/NumberFormat';
 import { useRewardsHistory } from 'features/rewards/hooks';
 import { useStethEthRate } from 'features/rewards/hooks/use-steth-eth-rate';
-import { useDappStatus } from 'shared/hooks/use-dapp-status';
 
 import { Item } from './components/item';
 
 export const StEthPriceBlock: FC = () => {
-  const { isWalletConnected, isSupportedChain } = useDappStatus();
   const {
     currencyObject: currency,
     data,
+    isDataAvailable,
     initialLoading: loading,
   } = useRewardsHistory();
   const stEthEth = useStethEthRate();
@@ -23,33 +22,29 @@ export const StEthPriceBlock: FC = () => {
       dataTestId="stEthPriceBlock"
       title="stETH price"
       value={
-        (isWalletConnected && !isSupportedChain) ||
-        !data?.stETHCurrencyPrice[currency.id] ? (
-          '—'
-        ) : (
+        data?.stETHCurrencyPrice[currency.id] && isDataAvailable ? (
           <>
             <Box display="inline-block" pr="3px">
               {currency.symbol}
             </Box>
             <NumberFormat number={data?.stETHCurrencyPrice[currency.id]} ETH />
           </>
+        ) : (
+          '—'
         )
       }
       valueDataTestId="stEthPrice"
       underValue={
-        <>
-          {(isWalletConnected && !isSupportedChain) ||
-          !data?.stETHCurrencyPrice[currency.id] ? (
-            '—'
-          ) : (
-            <>
-              <NumberFormat number={stEthEth?.toString()} StEthEth />
-              <Box display="inline-block" pl={'3px'}>
-                ETH
-              </Box>
-            </>
-          )}
-        </>
+        data?.stETHCurrencyPrice[currency.id] && isDataAvailable ? (
+          <>
+            <NumberFormat number={stEthEth?.toString()} StEthEth />
+            <Box display="inline-block" pl={'3px'}>
+              ETH
+            </Box>
+          </>
+        ) : (
+          '—'
+        )
       }
       underValueDataTestId="ethRate"
     />

--- a/features/rewards/components/stats/steth-rewarded-block.tsx
+++ b/features/rewards/components/stats/steth-rewarded-block.tsx
@@ -3,11 +3,13 @@ import { Box } from '@lidofinance/lido-ui';
 
 import { useRewardsHistory } from 'features/rewards/hooks';
 import NumberFormat from 'features/rewards/components/NumberFormat';
+import { useDappStatus } from 'shared/hooks/use-dapp-status';
 
 import { Item } from './components/item';
 import { GreenText } from './components/styles';
 
 export const StEthRewardedBlock: FC = () => {
+  const { isWalletConnected, isSupportedChain } = useDappStatus();
   const {
     currencyObject: currency,
     data,
@@ -20,7 +22,7 @@ export const StEthRewardedBlock: FC = () => {
       dataTestId="stEthRewardedBlock"
       title="stETH rewarded"
       value={
-        !data?.totals.ethRewards ? (
+        (isWalletConnected && !isSupportedChain) || !data?.totals.ethRewards ? (
           '—'
         ) : (
           <GreenText>
@@ -33,6 +35,7 @@ export const StEthRewardedBlock: FC = () => {
       }
       valueDataTestId="stEthRewarded"
       underValue={
+        (isWalletConnected && !isSupportedChain) ||
         !data?.totals.currencyRewards ? (
           '—'
         ) : (

--- a/features/rewards/components/stats/steth-rewarded-block.tsx
+++ b/features/rewards/components/stats/steth-rewarded-block.tsx
@@ -11,7 +11,6 @@ export const StEthRewardedBlock: FC = () => {
   const {
     currencyObject: currency,
     data,
-    isDataAvailable,
     initialLoading: loading,
   } = useRewardsHistory();
 
@@ -21,7 +20,7 @@ export const StEthRewardedBlock: FC = () => {
       dataTestId="stEthRewardedBlock"
       title="stETH rewarded"
       value={
-        data?.totals.ethRewards && isDataAvailable ? (
+        data?.totals.ethRewards ? (
           <GreenText>
             <NumberFormat number={data?.totals.ethRewards} />
             <Box display="inline-block" pl={'3px'}>
@@ -34,7 +33,7 @@ export const StEthRewardedBlock: FC = () => {
       }
       valueDataTestId="stEthRewarded"
       underValue={
-        data?.totals.currencyRewards && isDataAvailable ? (
+        data?.totals.currencyRewards ? (
           <>
             <Box display="inline-block" pr={'3px'}>
               {currency.symbol}

--- a/features/rewards/components/stats/steth-rewarded-block.tsx
+++ b/features/rewards/components/stats/steth-rewarded-block.tsx
@@ -3,16 +3,15 @@ import { Box } from '@lidofinance/lido-ui';
 
 import { useRewardsHistory } from 'features/rewards/hooks';
 import NumberFormat from 'features/rewards/components/NumberFormat';
-import { useDappStatus } from 'shared/hooks/use-dapp-status';
 
 import { Item } from './components/item';
 import { GreenText } from './components/styles';
 
 export const StEthRewardedBlock: FC = () => {
-  const { isWalletConnected, isSupportedChain } = useDappStatus();
   const {
     currencyObject: currency,
     data,
+    isDataAvailable,
     initialLoading: loading,
   } = useRewardsHistory();
 
@@ -22,29 +21,28 @@ export const StEthRewardedBlock: FC = () => {
       dataTestId="stEthRewardedBlock"
       title="stETH rewarded"
       value={
-        (isWalletConnected && !isSupportedChain) || !data?.totals.ethRewards ? (
-          '—'
-        ) : (
+        data?.totals.ethRewards && isDataAvailable ? (
           <GreenText>
             <NumberFormat number={data?.totals.ethRewards} />
             <Box display="inline-block" pl={'3px'}>
               stETH
             </Box>
           </GreenText>
+        ) : (
+          '—'
         )
       }
       valueDataTestId="stEthRewarded"
       underValue={
-        (isWalletConnected && !isSupportedChain) ||
-        !data?.totals.currencyRewards ? (
-          '—'
-        ) : (
+        data?.totals.currencyRewards && isDataAvailable ? (
           <>
             <Box display="inline-block" pr={'3px'}>
               {currency.symbol}
             </Box>
             <NumberFormat number={data?.totals.currencyRewards} currency />
           </>
+        ) : (
+          '—'
         )
       }
       underValueDataTestId="stEthRewardedIn$"

--- a/features/rewards/components/stats/steth-rewarded-block.tsx
+++ b/features/rewards/components/stats/steth-rewarded-block.tsx
@@ -31,7 +31,7 @@ export const StEthRewardedBlock: FC = () => {
           </GreenText>
         )
       }
-      valueDataTestId="stEthRewardedIn$"
+      valueDataTestId="stEthRewarded"
       underValue={
         !data?.totals.currencyRewards ? (
           '—'
@@ -44,7 +44,7 @@ export const StEthRewardedBlock: FC = () => {
           </>
         )
       }
-      underValueDataTestId="stEthBalanceIn$"
+      underValueDataTestId="stEthRewardedIn$"
     />
   );
 };

--- a/features/rewards/features/top-card/top-card.tsx
+++ b/features/rewards/features/top-card/top-card.tsx
@@ -2,11 +2,14 @@ import { FC, useEffect, useState } from 'react';
 
 import { StatsWrapper } from 'features/rewards/components/statsWrapper';
 import { Stats } from 'features/rewards/components/stats';
+import { useDappStatus } from 'shared/hooks/use-dapp-status';
+import { Fallback } from 'shared/wallet';
 
 import { Wallet } from './wallet';
 
 export const TopCard: FC = () => {
   const [visible, setVisible] = useState(false);
+  const { isWalletConnected, isSupportedChain } = useDappStatus();
 
   // fix flash after reload page
   useEffect(() => {
@@ -17,7 +20,8 @@ export const TopCard: FC = () => {
 
   return (
     <>
-      <Wallet />
+      {isWalletConnected && !isSupportedChain ? <Fallback /> : <Wallet />}
+
       <StatsWrapper>
         <Stats />
       </StatsWrapper>

--- a/features/rewards/features/top-card/wallet.tsx
+++ b/features/rewards/features/top-card/wallet.tsx
@@ -17,7 +17,7 @@ export const Wallet: FC = () => {
   } = useRewardsHistory();
 
   return (
-    <WalletStyle>
+    <WalletStyle data-testid="inputSection">
       <ThemeProvider theme={themeDark}>
         <WalletContentStyle>
           <AddressInput

--- a/features/rewards/hooks/useGetCurrentAddress.ts
+++ b/features/rewards/hooks/useGetCurrentAddress.ts
@@ -7,7 +7,6 @@ import { useSDK } from '@lido-sdk/react';
 import { resolveEns, isValidEns, isValidAddress } from 'features/rewards/utils';
 import { useCurrentStaticRpcProvider } from 'shared/hooks/use-current-static-rpc-provider';
 import { useDappStatus } from 'shared/hooks/use-dapp-status';
-import { overrideWithQAMockString } from 'utils/qa';
 
 type UseGetCurrentAddress = () => {
   address: string;
@@ -90,9 +89,7 @@ export const useGetCurrentAddress: UseGetCurrentAddress = () => {
       }
       // From a connected wallet
       if (account && isSupportedChain) {
-        setInputValue(
-          overrideWithQAMockString(account, 'mock-qa-rewards-address'),
-        );
+        setInputValue(account);
       }
     }
   }, [account, query.address, isReady, setInputValue, isSupportedChain]);

--- a/features/rewards/hooks/useGetCurrentAddress.ts
+++ b/features/rewards/hooks/useGetCurrentAddress.ts
@@ -6,6 +6,7 @@ import { useSDK } from '@lido-sdk/react';
 
 import { resolveEns, isValidEns, isValidAddress } from 'features/rewards/utils';
 import { useCurrentStaticRpcProvider } from 'shared/hooks/use-current-static-rpc-provider';
+import { useDappStatus } from 'shared/hooks/use-dapp-status';
 import { overrideWithQAMockString } from 'utils/qa';
 
 type UseGetCurrentAddress = () => {
@@ -28,6 +29,7 @@ export const useGetCurrentAddress: UseGetCurrentAddress = () => {
   const { account } = useSDK();
   const { staticRpcProvider } = useCurrentStaticRpcProvider();
   const { isReady, query } = useRouter();
+  const { isSupportedChain } = useDappStatus();
 
   const getEnsAddress = useCallback(
     async (value: string) => {
@@ -87,13 +89,13 @@ export const useGetCurrentAddress: UseGetCurrentAddress = () => {
         return;
       }
       // From a connected wallet
-      if (account) {
+      if (account && isSupportedChain) {
         setInputValue(
           overrideWithQAMockString(account, 'mock-qa-rewards-address'),
         );
       }
     }
-  }, [account, query.address, isReady, setInputValue]);
+  }, [account, query.address, isReady, setInputValue, isSupportedChain]);
 
   return {
     address,

--- a/providers/rewardsHistory.tsx
+++ b/providers/rewardsHistory.tsx
@@ -18,11 +18,12 @@ import {
   useRewardsDataLoad,
   useGetCurrentAddress,
 } from 'features/rewards/hooks';
-
 import { getCurrencyCookie } from 'features/rewards/components/CurrencySelector';
+import { useDappStatus } from 'shared/hooks/use-dapp-status';
 
 export type RewardsHistoryValue = {
   currencyObject: CurrencyType;
+  isDataAvailable: boolean;
   data?: Backend;
   error?: unknown;
   initialLoading: boolean;
@@ -48,6 +49,8 @@ export const RewardsHistoryContext = createContext({} as RewardsHistoryValue);
 
 const RewardsHistoryProvider: FC<PropsWithChildren> = (props) => {
   const { children } = props;
+
+  const { isWalletConnected, isSupportedChain } = useDappStatus();
 
   const [currency, setCurrency] = useState(DEFAULT_CURRENCY.id);
 
@@ -88,8 +91,14 @@ const RewardsHistoryProvider: FC<PropsWithChildren> = (props) => {
 
   const currencyObject = getCurrency(currency);
 
+  const isDataNotAvailable = useMemo(
+    () => !data || (isWalletConnected && !isSupportedChain),
+    [data, isWalletConnected, isSupportedChain],
+  );
+
   const value = useMemo(
     (): RewardsHistoryValue => ({
+      isDataAvailable: !isDataNotAvailable,
       data,
       error,
       loading,
@@ -115,6 +124,7 @@ const RewardsHistoryProvider: FC<PropsWithChildren> = (props) => {
       address,
       addressError,
       currencyObject,
+      isDataNotAvailable,
       data,
       error,
       initialLoading,

--- a/providers/rewardsHistory.tsx
+++ b/providers/rewardsHistory.tsx
@@ -23,7 +23,6 @@ import { useDappStatus } from 'shared/hooks/use-dapp-status';
 
 export type RewardsHistoryValue = {
   currencyObject: CurrencyType;
-  isDataAvailable: boolean;
   data?: Backend;
   error?: unknown;
   initialLoading: boolean;
@@ -91,15 +90,16 @@ const RewardsHistoryProvider: FC<PropsWithChildren> = (props) => {
 
   const currencyObject = getCurrency(currency);
 
-  const isDataNotAvailable = useMemo(
-    () => !data || (isWalletConnected && !isSupportedChain),
-    [data, isWalletConnected, isSupportedChain],
-  );
+  const isDataAvailable = useMemo(() => {
+    const isDataNotAvailable =
+      !data || (isWalletConnected && !isSupportedChain);
+    return !isDataNotAvailable;
+  }, [data, isWalletConnected, isSupportedChain]);
 
   const value = useMemo(
     (): RewardsHistoryValue => ({
-      isDataAvailable: !isDataNotAvailable,
-      data,
+      // we want user to not confuse which chain rewards are showing
+      data: isDataAvailable ? data : undefined,
       error,
       loading,
       initialLoading,
@@ -124,7 +124,7 @@ const RewardsHistoryProvider: FC<PropsWithChildren> = (props) => {
       address,
       addressError,
       currencyObject,
-      isDataNotAvailable,
+      isDataAvailable,
       data,
       error,
       initialLoading,


### PR DESCRIPTION
### Description

- Show the 'unsupported chain' banner  if connected wallet and unsupported chain.
- fix: Return data-testid="inputSection".
- fix: Return showing filters, currency select and export button for not connected wallets state.

### Demo

- not connected wallet
- unsupported chain OR supported chain
- empty address input
<img width="1405" alt="Снимок экрана 2024-08-21 в 13 37 36" src="https://github.com/user-attachments/assets/eba4a231-ec80-4307-ad9d-e0bf5a54fc3e">

---

- connected wallet
- unsupported chain
- there aren't rewards
<img width="1037" alt="Снимок экрана 2024-08-21 в 21 54 44" src="https://github.com/user-attachments/assets/32e165a6-f65f-4f9f-99bc-9667294cfc1e">

---

a 'unsupported chain' text instead of rewards table
<img width="966" alt="Снимок экрана 2024-08-21 в 21 55 47" src="https://github.com/user-attachments/assets/a040d844-a961-4eeb-9642-f4d1aa8dfd4d">

---

- connected wallet (supported chain) OR not connected wallet
- address input was filled by user --> there are rewards
<img width="814" alt="Снимок экрана 2024-08-21 в 21 58 25" src="https://github.com/user-attachments/assets/97bd04de-0be1-49be-b6d6-cb1adb29fa76">



### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
