### PR TITLE
fix: do not send dexes rate request if tvl error occured

### DIFF
--- a/features/withdrawals/hooks/useTvlError.ts
+++ b/features/withdrawals/hooks/useTvlError.ts
@@ -1,0 +1,26 @@
+import { useMemo } from 'react';
+import { useController } from 'react-hook-form';
+import {
+  TvlErrorPayload,
+  ValidationTvlJoke,
+} from '../request/request-form-context/validators';
+import { RequestFormInputType } from 'features/withdrawals/request/request-form-context';
+
+const getTvlError = (error?: unknown) =>
+  error &&
+  typeof error === 'object' &&
+  'type' in error &&
+  error.type == ValidationTvlJoke.type &&
+  'payload' in error
+    ? (error.payload as TvlErrorPayload)
+    : { balanceDiffSteth: undefined, tvlDiff: undefined };
+
+export const useTvlError = () => {
+  const {
+    fieldState: { error },
+  } = useController<RequestFormInputType, 'amount'>({
+    name: 'amount',
+  });
+
+  return useMemo(() => getTvlError(error), [error]);
+};

--- a/features/withdrawals/hooks/useTvlMessage.ts
+++ b/features/withdrawals/hooks/useTvlMessage.ts
@@ -2,10 +2,7 @@ import { useMemo } from 'react';
 import { formatEther } from '@ethersproject/units';
 
 import { shortenTokenValue } from 'utils';
-import {
-  TvlErrorPayload,
-  ValidationTvlJoke,
-} from '../request/request-form-context/validators';
+import { useTvlError } from './useTvlError';
 
 const texts: ((amount: string) => string)[] = [
   (amount) =>
@@ -17,18 +14,11 @@ const texts: ((amount: string) => string)[] = [
 
 const getText = () => texts[Math.floor(Math.random() * texts.length)];
 
-export const useTvlMessage = (error?: unknown) => {
+export const useTvlMessage = () => {
   // To render one text per page before refresh
   const textTemplate = useMemo(() => getText(), []);
 
-  const { balanceDiffSteth, tvlDiff } =
-    error &&
-    typeof error === 'object' &&
-    'type' in error &&
-    error.type == ValidationTvlJoke.type &&
-    'payload' in error
-      ? (error.payload as TvlErrorPayload)
-      : { balanceDiffSteth: undefined, tvlDiff: undefined };
+  const { balanceDiffSteth, tvlDiff } = useTvlError();
 
   return {
     balanceDiff: balanceDiffSteth,

--- a/features/withdrawals/request/form/controls/input-group-request.tsx
+++ b/features/withdrawals/request/form/controls/input-group-request.tsx
@@ -1,14 +1,9 @@
 import { FC, PropsWithChildren } from 'react';
 import { useTvlMessage } from 'features/withdrawals/hooks';
-import { useFormState } from 'react-hook-form';
 import { InputGroupHookForm } from 'shared/hook-form/controls/input-group-hook-form';
-import { RequestFormInputType } from '../../request-form-context';
 
 export const InputGroupRequest: FC<PropsWithChildren> = ({ children }) => {
-  const {
-    errors: { amount: amountError },
-  } = useFormState<RequestFormInputType>({ name: 'amount' });
-  const { tvlMessage } = useTvlMessage(amountError);
+  const { tvlMessage } = useTvlMessage();
   return (
     <InputGroupHookForm errorField="amount" success={tvlMessage}>
       {children}

--- a/features/withdrawals/request/form/controls/token-amount-input-request.tsx
+++ b/features/withdrawals/request/form/controls/token-amount-input-request.tsx
@@ -1,4 +1,4 @@
-import { useController, useWatch } from 'react-hook-form';
+import { useWatch } from 'react-hook-form';
 
 import { MATOMO_CLICK_EVENTS_TYPES } from 'consts/matomo-click-events';
 import { InputDecoratorTvlStake } from 'features/withdrawals/shared/input-decorator-tvl-stake';
@@ -17,13 +17,7 @@ export const TokenAmountInputRequest = () => {
   const token = useWatch<RequestFormInputType, 'token'>({ name: 'token' });
   const { maxAmount, isTokenLocked } = useRequestFormData();
 
-  const {
-    fieldState: { error },
-  } = useController<RequestFormInputType, 'amount'>({
-    name: 'amount',
-  });
-
-  const { balanceDiff } = useTvlMessage(error);
+  const { balanceDiff } = useTvlMessage();
 
   return (
     <TokenAmountInputHookForm

--- a/features/withdrawals/request/form/options/options-picker.tsx
+++ b/features/withdrawals/request/form/options/options-picker.tsx
@@ -91,9 +91,13 @@ const DexButton: React.FC<OptionButtonProps> = ({ isActive, onClick }) => {
     fallbackValue: DEFAULT_VALUE_FOR_RATE,
   });
   const isAnyDexEnabled = enabledDexes.length > 0;
+  const bestRateFloored = bestRate !== null && toFloor(bestRate);
   const bestRateValue =
-    !isPausedByTvlError && bestRate && isAnyDexEnabled
-      ? `1 : ${toFloor(bestRate)}`
+    !isPausedByTvlError &&
+    isAnyDexEnabled &&
+    bestRateFloored &&
+    bestRateFloored !== '0'
+      ? `1 : ${bestRateFloored}`
       : '—';
 
   return (

--- a/features/withdrawals/request/form/options/options-picker.tsx
+++ b/features/withdrawals/request/form/options/options-picker.tsx
@@ -6,6 +6,7 @@ import { TOKENS } from '@lido-sdk/constants';
 import { MATOMO_CLICK_EVENTS_TYPES } from 'consts/matomo-click-events';
 import { DATA_UNAVAILABLE } from 'consts/text';
 import { useWaitingTime } from 'features/withdrawals/hooks/useWaitingTime';
+import { useTvlError } from 'features/withdrawals/hooks/useTvlError';
 import { RequestFormInputType } from 'features/withdrawals/request/request-form-context';
 import { ENABLED_WITHDRAWAL_DEXES } from 'features/withdrawals/withdrawals-constants';
 import {
@@ -83,12 +84,18 @@ const toFloor = (num: number): string =>
   (Math.floor(num * 10000) / 10000).toString();
 
 const DexButton: React.FC<OptionButtonProps> = ({ isActive, onClick }) => {
+  const { balanceDiffSteth } = useTvlError();
+  const isPausedByTvlError = balanceDiffSteth !== undefined;
   const { initialLoading, bestRate, enabledDexes } = useWithdrawalRates({
+    isPaused: isPausedByTvlError,
     fallbackValue: DEFAULT_VALUE_FOR_RATE,
   });
   const isAnyDexEnabled = enabledDexes.length > 0;
   const bestRateValue =
-    bestRate && isAnyDexEnabled ? `1 : ${toFloor(bestRate)}` : '—';
+    !isPausedByTvlError && bestRate && isAnyDexEnabled
+      ? `1 : ${toFloor(bestRate)}`
+      : '—';
+
   return (
     <OptionsPickerButton
       data-testid="dexOptions"
@@ -107,7 +114,11 @@ const DexButton: React.FC<OptionButtonProps> = ({ isActive, onClick }) => {
       </OptionsPickerRow>
       <OptionsPickerRow data-testid="dexBestRate">
         <OptionsPickerSubLabel>Best Rate:</OptionsPickerSubLabel>
-        {initialLoading ? <InlineLoaderSmall /> : bestRateValue}
+        {initialLoading && !isPausedByTvlError ? (
+          <InlineLoaderSmall />
+        ) : (
+          bestRateValue
+        )}
       </OptionsPickerRow>
       <OptionsPickerRow data-testid="dexWaitingTime">
         <OptionsPickerSubLabel>Waiting time:</OptionsPickerSubLabel>{' '}

--- a/features/withdrawals/request/withdrawal-rates/use-withdrawal-rates.ts
+++ b/features/withdrawals/request/withdrawal-rates/use-withdrawal-rates.ts
@@ -21,6 +21,7 @@ import type {
 
 export type useWithdrawalRatesOptions = {
   fallbackValue?: BigNumber;
+  isPaused?: boolean;
 };
 
 const getWithdrawalRates = async (
@@ -53,6 +54,7 @@ const getWithdrawalRates = async (
 
 export const useWithdrawalRates = ({
   fallbackValue = Zero,
+  isPaused,
 }: useWithdrawalRatesOptions = {}) => {
   const [token, amount] = useWatch<RequestFormInputType, ['token', 'amount']>({
     name: ['token', 'amount'],
@@ -76,6 +78,7 @@ export const useWithdrawalRates = ({
     {
       ...STRATEGY_LAZY,
       isPaused: () =>
+        isPaused ||
         !debouncedAmount ||
         !debouncedAmount._isBigNumber ||
         ENABLED_WITHDRAWAL_DEXES.length === 0,


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

If withdrawal request input value is larger than TVL then '–' is displayed as changing rate.

### Demo

<img width="511" alt="image" src="https://github.com/user-attachments/assets/33b74770-7b23-4ff5-a224-c46590650982">

### Checklist:

- [x] Checked the changes locally.
