### PR TITLE
feat: ledger live claim tooltip

### DIFF
--- a/features/withdrawals/claim/claim-form-context/claim-form-context.tsx
+++ b/features/withdrawals/claim/claim-form-context/claim-form-context.tsx
@@ -26,7 +26,9 @@ import {
 import { useClaimData } from 'features/withdrawals/contexts/claim-data-context';
 import { useWeb3 } from 'reef-knot/web3-react';
 
-type ClaimFormDataContextValueType = ClaimFormHelperState;
+type ClaimFormDataContextValueType = ClaimFormHelperState & {
+  maxSelectedCountReason: string | null;
+};
 
 const claimFormDataContext =
   createContext<ClaimFormDataContextValueType | null>(null);
@@ -42,8 +44,11 @@ export const ClaimFormProvider: FC<PropsWithChildren> = ({ children }) => {
   const { active } = useWeb3();
   const { data } = useClaimData();
 
-  const { maxSelectedRequestCount, defaultSelectedRequestCount } =
-    useMaxSelectedCount();
+  const {
+    maxSelectedRequestCount,
+    defaultSelectedRequestCount,
+    maxSelectedCountReason,
+  } = useMaxSelectedCount();
   const { getDefaultValues } = useGetDefaultValues(defaultSelectedRequestCount);
 
   const formObject = useForm<ClaimFormInputType, ClaimFormValidationContext>({
@@ -54,10 +59,14 @@ export const ClaimFormProvider: FC<PropsWithChildren> = ({ children }) => {
     reValidateMode: 'onChange',
   });
   const { watch, reset, setValue, getValues, formState } = formObject;
-  const claimFormDataContextValue = useHelperState(
-    watch,
-    maxSelectedRequestCount,
+
+  const helperState = useHelperState(watch, maxSelectedRequestCount);
+
+  const claimFormDataContextValue = useMemo(
+    () => ({ ...helperState, maxSelectedCountReason }),
+    [helperState, maxSelectedCountReason],
   );
+
   const { retryEvent, retryFire } = useFormControllerRetry();
 
   const claim = useClaim({ onRetry: retryFire });

--- a/features/withdrawals/claim/claim-form-context/use-max-selected-count.ts
+++ b/features/withdrawals/claim/claim-form-context/use-max-selected-count.ts
@@ -15,8 +15,14 @@ export const useMaxSelectedCount = () => {
     DEFAULT_CLAIM_REQUEST_SELECTED,
     maxSelectedRequestCount,
   );
+
+  const maxSelectedCountReason = isLedgerLive
+    ? 'Ledger Clear Sign allows to claim up to 2 requests per transaction'
+    : null;
+
   return {
     maxSelectedRequestCount,
     defaultSelectedRequestCount,
+    maxSelectedCountReason,
   };
 };

--- a/features/withdrawals/claim/form/requests-list/request-item.tsx
+++ b/features/withdrawals/claim/form/requests-list/request-item.tsx
@@ -2,7 +2,12 @@ import { forwardRef } from 'react';
 import { useWeb3 } from 'reef-knot/web3-react';
 import { useFormState, useWatch } from 'react-hook-form';
 
-import { Checkbox, CheckboxProps, External } from '@lidofinance/lido-ui';
+import {
+  Checkbox,
+  CheckboxProps,
+  External,
+  Tooltip,
+} from '@lidofinance/lido-ui';
 import { FormatToken } from 'shared/formatters';
 
 import { RequestStatus } from './request-item-status';
@@ -21,7 +26,7 @@ export const RequestItem = forwardRef<HTMLInputElement, RequestItemProps>(
   ({ token_id, name, disabled, index, ...props }, ref) => {
     const { chainId } = useWeb3();
     const { isSubmitting } = useFormState();
-    const { canSelectMore } = useClaimFormData();
+    const { canSelectMore, maxSelectedCountReason } = useClaimFormData();
     const { checked, status } = useWatch<
       ClaimFormInputType,
       `requests.${number}`
@@ -42,15 +47,23 @@ export const RequestItem = forwardRef<HTMLInputElement, RequestItemProps>(
       : status.amountOfStETH;
     const symbol = isClaimable ? 'ETH' : 'stETH';
 
+    const showDisabledReasonTooltip =
+      maxSelectedCountReason &&
+      !canSelectMore &&
+      status.isFinalized &&
+      !checked;
+
     const label = (
       <FormatToken
         data-testid="requestAmount"
         amount={amountValue}
         symbol={symbol}
+        // prevents tip overlap
+        showAmountTip={!showDisabledReasonTooltip}
       />
     );
 
-    return (
+    const requestBody = (
       <RequestStyled data-testid={'requestItem'} $disabled={isDisabled}>
         <Checkbox
           {...props}
@@ -71,6 +84,14 @@ export const RequestItem = forwardRef<HTMLInputElement, RequestItemProps>(
           <External />
         </LinkStyled>
       </RequestStyled>
+    );
+
+    return showDisabledReasonTooltip ? (
+      <Tooltip title={maxSelectedCountReason} placement="top">
+        {requestBody}
+      </Tooltip>
+    ) : (
+      requestBody
     );
   },
 );

--- a/features/withdrawals/withdrawals-constants/index.ts
+++ b/features/withdrawals/withdrawals-constants/index.ts
@@ -3,6 +3,7 @@ import type { DexWithdrawalApi } from '../request/withdrawal-rates';
 
 // max requests count for one tx
 export const MAX_REQUESTS_COUNT = 256;
+// Leger Clear Sign only allows 2 requests per claim
 export const MAX_REQUESTS_COUNT_LEDGER_LIMIT = 2;
 
 export const DEFAULT_CLAIM_REQUEST_SELECTED = 80;


### PR DESCRIPTION

### Description

Tooltip for when ledger clear sign only allows 2 requests claim

### Demo

<img width="513" alt="image" src="https://github.com/user-attachments/assets/32176256-26b1-4e2c-9359-28f9e7691c08">

### Code review notes
Double checked this restriction, if you give more requests only 2 will be displayed in ledger

### Testing notes

Only in Ledger Live

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
