### PR TITLE
feat: mode network multichain banner

### DIFF
--- a/IPFS.json
+++ b/IPFS.json
@@ -3,7 +3,8 @@
     "cid": "bafybeib3zmyqlmantvdd6i5q4ehmo4larvorgquyanne3uoqdbedwgh3aq",
     "leastSafeVersion": "0.36.1",
     "config": {
-      "enabledWithdrawalDexes": ["one-inch", "paraswap", "bebop"]
+      "enabledWithdrawalDexes": ["one-inch", "paraswap", "bebop"],
+      "multiChainBanner": [324, 10, 42161, 137, 8453, 5000, 59144, 534352, 56]
     }
   },
   "5": {
@@ -16,7 +17,10 @@
     "cid": "bafybeibbsoqlofslw273b4ih2pdxfaz2zbjmred2ijog725tcmfoewix7y",
     "leastSafeVersion": "0.36.1",
     "config": {
-      "enabledWithdrawalDexes": ["one-inch", "paraswap", "bebop"]
+      "enabledWithdrawalDexes": ["one-inch", "paraswap", "bebop"],
+      "multiChainBanner": [
+        324, 10, 42161, 137, 8453, 5000, 59144, 534352, 56, 34443
+      ]
     }
   }
 }

--- a/assets/icons/lido-multichain/mode.svg
+++ b/assets/icons/lido-multichain/mode.svg
@@ -1,0 +1,11 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_8028_12494)">
+<path d="M32 0H0V32H32V0Z" fill="#E5FD52"/>
+<path d="M23.9859 22.9972H20.8647V16.0223L22.1143 12.0437L21.2278 11.7321L17.1807 22.9972H14.8053L10.7553 11.7321L9.87159 12.0437L11.1212 16.0223V23H8V9H12.6466L15.5286 17.0127V19.3665H16.4714V17.0127L19.3534 9H24V22.9972H23.9859Z" fill="black"/>
+</g>
+<defs>
+<clipPath id="clip0_8028_12494">
+<rect width="32" height="32" rx="16" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/config/external-config/types.ts
+++ b/config/external-config/types.ts
@@ -12,6 +12,7 @@ export type ManifestEntry = {
 
 export type ManifestConfig = {
   enabledWithdrawalDexes: DexWithdrawalApi[];
+  multiChainBanner: number[];
 };
 
 export type ExternalConfig = Omit<ManifestEntry, 'config'> &

--- a/config/groups/revalidation.ts
+++ b/config/groups/revalidation.ts
@@ -1,15 +1,2 @@
-import type { ManifestConfig, ManifestEntry } from 'config/external-config';
-
 export const DEFAULT_REVALIDATION = 60 * 15; // 15 minutes
 export const ERROR_REVALIDATION_SECONDS = 60; // 1 minute
-
-export const FALLBACK_CONFIG: ManifestConfig = {
-  enabledWithdrawalDexes: [],
-};
-
-export const FALLBACK_MANIFEST_ENTRY: ManifestEntry = {
-  cid: undefined,
-  ens: undefined,
-  leastSafeVersion: undefined,
-  config: FALLBACK_CONFIG,
-};

--- a/consts/chains.ts
+++ b/consts/chains.ts
@@ -14,4 +14,5 @@ export enum LIDO_MULTICHAIN_CHAINS {
   Linea = 59144,
   Scroll = 534352,
   'BNB Chain' = 56,
+  'Mode Chain' = 34443,
 }

--- a/consts/external-links.ts
+++ b/consts/external-links.ts
@@ -5,6 +5,6 @@ export const LINK_ADD_NFT_GUIDE = `${config.helpOrigin}/en/articles/7858367-how-
 export const OPEN_OCEAN_REFERRAL_ADDRESS =
   '0xbb1263222b2c020f155d409dba05c4a3861f18f8';
 
-// for dev and local testing you can set to 'http:/localhost:3000/runtime/IPFS.json' and have file at /public/runtime/IPFS.json
+// for dev and local testing you can set to 'http://localhost:3000/runtime/IPFS.json' and have file at /public/runtime/IPFS.json
 export const IPFS_MANIFEST_URL =
   'https://raw.githubusercontent.com/lidofinance/ethereum-staking-widget/main/IPFS.json';

--- a/shared/hooks/use-dapp-status.ts
+++ b/shared/hooks/use-dapp-status.ts
@@ -4,14 +4,19 @@ import { useAccount } from 'wagmi';
 import { LIDO_MULTICHAIN_CHAINS } from 'consts/chains';
 
 import { useIsSupportedChain } from './use-is-supported-chain';
+import { useConfig } from 'config';
 
 export const useDappStatus = () => {
+  const { multiChainBanner } = useConfig().externalConfig;
   const { chainId, isConnected: isWalletConnected } = useAccount();
   const isSupportedChain = useIsSupportedChain();
 
   const isLidoMultichainChain = useMemo(
-    () => !!chainId && !!LIDO_MULTICHAIN_CHAINS[chainId],
-    [chainId],
+    () =>
+      !!chainId &&
+      !!LIDO_MULTICHAIN_CHAINS[chainId] &&
+      multiChainBanner.includes(chainId),
+    [chainId, multiChainBanner],
   );
 
   const isDappActive = useMemo(() => {

--- a/shared/wallet/lido-multichain-fallback/lido-multichain-fallback.tsx
+++ b/shared/wallet/lido-multichain-fallback/lido-multichain-fallback.tsx
@@ -11,6 +11,7 @@ import { ReactComponent as PolygonLogo } from 'assets/icons/lido-multichain/poly
 import { ReactComponent as ZkSyncLogo } from 'assets/icons/lido-multichain/zk-sync.svg';
 import { ReactComponent as ScrollLogo } from 'assets/icons/lido-multichain/scroll.svg';
 import { ReactComponent as BNBLogo } from 'assets/icons/lido-multichain/bnb.svg';
+import { ReactComponent as ModeLogo } from 'assets/icons/lido-multichain/mode.svg';
 
 import { config } from 'config';
 import { useUserConfig } from 'config/user-config';
@@ -34,6 +35,7 @@ const multichainLogos = {
   [LIDO_MULTICHAIN_CHAINS['zkSync Era']]: ZkSyncLogo,
   [LIDO_MULTICHAIN_CHAINS.Scroll]: ScrollLogo,
   [LIDO_MULTICHAIN_CHAINS['BNB Chain']]: BNBLogo,
+  [LIDO_MULTICHAIN_CHAINS['Mode Chain']]: ModeLogo,
 };
 
 const getChainLogo = (chainId: LIDO_MULTICHAIN_CHAINS) => {

--- a/shared/wallet/lido-multichain-fallback/styles.tsx
+++ b/shared/wallet/lido-multichain-fallback/styles.tsx
@@ -63,6 +63,14 @@ export const Wrap = styled((props) => <Card {...props} />)<WrapProps>`
             #f0b90b 91.42%
           );
         `;
+      case LIDO_MULTICHAIN_CHAINS['Mode Chain']:
+        return css`
+          background: linear-gradient(
+            54.14deg,
+            #626931 -22.38%,
+            #b4c740 91.42%
+          );
+        `;
       default:
         return css`
           background: linear-gradient(


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

 - Mode Network multichain fallback banner.
 - Move banner chain ids to IPFS.json

### Testing notes
Because we moved all multichain banner chainIDs to config, until this pr is merged into main(with updated config), no multichain banners will show on this code by default.
To enable banners:
``` ts
localStorage.setItem('mock-qa-helpers-show-lido-multichain-banners-on-testnet',true)
```
Override github request in browser with **IPFS.json from this branch**. Currently config has Mode chain for testnet and not for mainnet. If you want to test on staging environment you will have to modify override and add Mode chain id to `"1"."config"."multiChainBanner"` array

### Demo

<img width="554" alt="image" src="https://github.com/user-attachments/assets/03df663b-0a6f-4d0d-96a1-d35bac217791">

### Checklist:

- [x] Checked the changes locally.
