### PR TITLE
fix: make "you will receive" row always first

### DIFF
--- a/features/wsteth/unwrap/unwrap-form/unwrap-stats.tsx
+++ b/features/wsteth/unwrap/unwrap-form/unwrap-stats.tsx
@@ -24,14 +24,6 @@ export const UnwrapStats = () => {
   return (
     <DataTable>
       <DataTableRow
-        title="Max transaction cost"
-        data-testid="maxGasFee"
-        loading={isUnwrapTxCostLoading}
-      >
-        <FormatPrice amount={unwrapTxCostInUsd} />
-      </DataTableRow>
-      <DataTableRowStethByWsteth />
-      <DataTableRow
         title="You will receive"
         loading={isWillReceiveStETHLoading}
       >
@@ -43,6 +35,14 @@ export const UnwrapStats = () => {
           trimEllipsis
         />
       </DataTableRow>
+      <DataTableRow
+        title="Max transaction cost"
+        data-testid="maxGasFee"
+        loading={isUnwrapTxCostLoading}
+      >
+        <FormatPrice amount={unwrapTxCostInUsd} />
+      </DataTableRow>
+      <DataTableRowStethByWsteth />
     </DataTable>
   );
 };

--- a/features/wsteth/wrap/wrap-form/wrap-stats.tsx
+++ b/features/wsteth/wrap/wrap-form/wrap-stats.tsx
@@ -48,6 +48,18 @@ export const WrapFormStats = () => {
   return (
     <DataTable data-testid="wrapStats">
       <DataTableRow
+        title="You will receive"
+        loading={isWillReceiveWstethLoading}
+      >
+        <FormatToken
+          amount={willReceiveWsteth}
+          data-testid="youWillReceive"
+          fallback="-"
+          symbol="wstETH"
+          trimEllipsis
+        />
+      </DataTableRow>
+      <DataTableRow
         title="Max unlock cost"
         data-testid="maxUnlockFee"
         loading={isApproveCostLoading}
@@ -86,19 +98,6 @@ export const WrapFormStats = () => {
         loading={isApprovalLoading}
         token={TOKENS.STETH}
       />
-
-      <DataTableRow
-        title="You will receive"
-        loading={isWillReceiveWstethLoading}
-      >
-        <FormatToken
-          amount={willReceiveWsteth}
-          data-testid="youWillReceive"
-          fallback="-"
-          symbol="wstETH"
-          trimEllipsis
-        />
-      </DataTableRow>
     </DataTable>
   );
 };


### PR DESCRIPTION
### Description

Fixes "You will receive" position on stake/wrap inconsistency

<img src=https://github.com/user-attachments/assets/bc717e69-f7cb-470e-a0c4-901d53144937 width=400 />

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
