### PR TITLE
feat(ChainSwitcherTooltip): black bg for dark theme

### DIFF
--- a/shared/components/layout/header/components/chain-switcher/components/select-icon-tooltip/styles.tsx
+++ b/shared/components/layout/header/components/chain-switcher/components/select-icon-tooltip/styles.tsx
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import { ThemeName } from '@lidofinance/lido-ui';
 import { devicesHeaderMedia } from 'styles/global';
 
 interface TooltipProps {
@@ -29,7 +30,8 @@ export const SelectIconTooltipContent = styled.div<TooltipProps>`
   gap: 10px;
   padding: ${({ theme }) => theme.spaceMap.md}px
     ${({ theme }) => theme.spaceMap.md}px;
-  background-color: var(--lido-color-accent);
+  background-color: ${({ theme }) =>
+    theme.name === ThemeName.light ? 'var(--lido-color-accent)' : '#000000'};
   border-radius: ${({ theme }) => theme.borderRadiusesMap.sm}px;
 
   ${({ $showArrow }) =>
@@ -46,7 +48,10 @@ export const SelectIconTooltipContent = styled.div<TooltipProps>`
         transform: rotate(45deg);
         flex-shrink: 0;
         border-radius: 2px 0 0 0;
-        background: var(--lido-color-accent);
+        background-color: ${({ theme }) =>
+          theme.name === ThemeName.light
+            ? 'var(--lido-color-accent)'
+            : '#000000'};
 
         @media ${devicesHeaderMedia.mobile} {
           display: none;


### PR DESCRIPTION
### Description

Changed the background for dark theme in ChainSwitcherTooltip

### Demo

<img width="363" alt="image" src="https://github.com/user-attachments/assets/cc5162f2-d9f1-4482-8a8e-6d6a322c7290">


### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
