### PR TITLE
fix: add testnet chain names in 'wrong network' banner

### DIFF
--- a/features/wsteth/shared/wallet/wallet.tsx
+++ b/features/wsteth/shared/wallet/wallet.tsx
@@ -5,6 +5,8 @@ import { useConnectorInfo } from 'reef-knot/core-react';
 import { Divider, Text } from '@lidofinance/lido-ui';
 import { useSDK } from '@lido-sdk/react';
 
+import { config } from 'config';
+import { CHAINS } from 'consts/chains';
 import { FormatToken } from 'shared/formatters';
 import { TokenToWallet } from 'shared/components';
 import { useWstethBySteth, useStethByWsteth } from 'shared/hooks';
@@ -23,7 +25,7 @@ import {
   useStethBalance,
   useWstethBalance,
 } from 'shared/hooks/use-balance';
-import { OPTIMISM, ETHEREUM, useDappChain } from 'providers/dapp-chain';
+import { OPTIMISM, useDappChain } from 'providers/dapp-chain';
 import { capitalizeFirstLetter } from 'utils/capitalize-string';
 
 import { StyledCard } from './styles';
@@ -150,7 +152,11 @@ export const Wallet: WalletComponentType = memo((props) => {
   }
 
   if (isDappActive && !isMatchDappChainAndWalletChain(chainId)) {
-    const error = `Wrong network. Please switch to ${chainName === OPTIMISM ? capitalizeFirstLetter(OPTIMISM) : capitalizeFirstLetter(ETHEREUM)} in your wallet to wrap/unwrap.`;
+    const switchToOptimism =
+      config.supportedChains.indexOf(CHAINS.Optimism) > -1
+        ? capitalizeFirstLetter(OPTIMISM)
+        : 'Optimism Sepolia';
+    const error = `Wrong network. Please switch to ${chainName === OPTIMISM ? switchToOptimism : capitalizeFirstLetter(CHAINS[config.defaultChain])} in your wallet to wrap/unwrap.`;
     return <Fallback error={error} {...props} />;
   }
 


### PR DESCRIPTION
### Description

fix: add testnet chain names in 'wrong network' banner

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
