### PR TITLE
feat: optimism in Ledger Hardware text

### DIFF
--- a/features/wsteth/shared/wallet/wallet.tsx
+++ b/features/wsteth/shared/wallet/wallet.tsx
@@ -31,6 +31,7 @@ import { StyledCard } from './styles';
 import { useStETHByWstETHOnL2 } from 'shared/hooks/use-stETH-by-wstETH-on-l2';
 import { useWstETHByStETHOnL2 } from 'shared/hooks/use-wstETH-by-stETH-on-l2';
 import { useIsLedgerLive } from 'shared/hooks/useIsLedgerLive';
+import { useIsLedgerHardware } from '../../../../shared/hooks/useIsLedgerHardware';
 
 const WalletComponent: WalletComponentType = (props) => {
   const { account } = useSDK();
@@ -141,6 +142,7 @@ const WalletComponent: WalletComponentType = (props) => {
 
 export const Wallet: WalletComponentType = memo((props) => {
   const isLedgerLive = useIsLedgerLive();
+  const isLedgerHardware = useIsLedgerHardware();
   const { featureFlags } = useConfig().externalConfig;
   const { chainId } = useAccount();
   const { isDappActive, isDappActiveOnL2 } = useDappStatus();
@@ -149,6 +151,16 @@ export const Wallet: WalletComponentType = memo((props) => {
 
   if (!featureFlags.ledgerLiveL2 && isLedgerLive && chainName === OPTIMISM) {
     const error = `Optimism is currently not supported in Ledger Live.`;
+    return <Fallback error={error} {...props} />;
+  }
+
+  // Most likely Optimism support in LL and LH will arrive at the same time
+  if (
+    !featureFlags.ledgerLiveL2 &&
+    isLedgerHardware &&
+    chainName === OPTIMISM
+  ) {
+    const error = `Optimism is currently not supported in Ledger Hardware.`;
     return <Fallback error={error} {...props} />;
   }
 

--- a/features/wsteth/shared/wallet/wallet.tsx
+++ b/features/wsteth/shared/wallet/wallet.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import { useAccount } from 'wagmi';
+import { useConnectorInfo } from 'reef-knot/core-react';
 
 import { Divider, Text } from '@lidofinance/lido-ui';
 import { useSDK } from '@lido-sdk/react';
@@ -31,7 +32,6 @@ import { StyledCard } from './styles';
 import { useStETHByWstETHOnL2 } from 'shared/hooks/use-stETH-by-wstETH-on-l2';
 import { useWstETHByStETHOnL2 } from 'shared/hooks/use-wstETH-by-stETH-on-l2';
 import { useIsLedgerLive } from 'shared/hooks/useIsLedgerLive';
-import { useIsLedgerHardware } from '../../../../shared/hooks/useIsLedgerHardware';
 
 const WalletComponent: WalletComponentType = (props) => {
   const { account } = useSDK();
@@ -142,7 +142,7 @@ const WalletComponent: WalletComponentType = (props) => {
 
 export const Wallet: WalletComponentType = memo((props) => {
   const isLedgerLive = useIsLedgerLive();
-  const isLedgerHardware = useIsLedgerHardware();
+  const { isLedger: isLedgerHardware } = useConnectorInfo();
   const { featureFlags } = useConfig().externalConfig;
   const { chainId } = useAccount();
   const { isDappActive, isDappActiveOnL2 } = useDappStatus();

--- a/features/wsteth/shared/wallet/wallet.tsx
+++ b/features/wsteth/shared/wallet/wallet.tsx
@@ -154,12 +154,7 @@ export const Wallet: WalletComponentType = memo((props) => {
     return <Fallback error={error} {...props} />;
   }
 
-  // Most likely Optimism support in LL and LH will arrive at the same time
-  if (
-    !featureFlags.ledgerLiveL2 &&
-    isLedgerHardware &&
-    chainName === OPTIMISM
-  ) {
+  if (isLedgerHardware && chainName === OPTIMISM) {
     const error = `Optimism is currently not supported in Ledger Hardware.`;
     return <Fallback error={error} {...props} />;
   }

--- a/shared/hooks/useIsLedgerHardware.ts
+++ b/shared/hooks/useIsLedgerHardware.ts
@@ -1,7 +1,0 @@
-import { useConnectorInfo } from 'reef-knot/core-react';
-
-export const useIsLedgerHardware = () => {
-  const { isLedger } = useConnectorInfo();
-
-  return isLedger;
-};

--- a/shared/hooks/useIsLedgerHardware.ts
+++ b/shared/hooks/useIsLedgerHardware.ts
@@ -1,0 +1,7 @@
+import { useConnectorInfo } from 'reef-knot/core-react';
+
+export const useIsLedgerHardware = () => {
+  const { isLedger } = useConnectorInfo();
+
+  return isLedger;
+};


### PR DESCRIPTION
### Description

Added text 'Optimism is currently not supported in Ledger Hardware.'

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
