### PR TITLE
feat: pausedInfo for Sepolia

### DIFF
--- a/features/withdrawals/request/form/paused-info.tsx
+++ b/features/withdrawals/request/form/paused-info.tsx
@@ -1,4 +1,4 @@
-import { useAccount } from 'wagmi';
+import { useChainId } from 'wagmi';
 import { Link } from '@lidofinance/lido-ui';
 
 import { config } from 'config';
@@ -9,7 +9,7 @@ import { InfoBoxStyled } from 'features/withdrawals/shared';
 const LIDO_TWITTER_LINK = 'https://twitter.com/lidofinance';
 
 export const PausedInfo = () => {
-  const { chainId } = useAccount();
+  const chainId = useChainId();
 
   const docsSepoliaLink = `${config.docsOrigin}/deployed-contracts/sepolia/`;
 

--- a/features/withdrawals/request/form/paused-info.tsx
+++ b/features/withdrawals/request/form/paused-info.tsx
@@ -11,19 +11,16 @@ const LIDO_TWITTER_LINK = 'https://twitter.com/lidofinance';
 export const PausedInfo = () => {
   const { chainId } = useAccount();
 
-  let link = <Link href={LIDO_TWITTER_LINK}>see here</Link>;
-
-  if (chainId == CHAINS.Sepolia) {
-    link = (
-      <Link href={`${config.docsOrigin}/deployed-contracts/sepolia/`}>
-        see here
-      </Link>
-    );
-  }
+  const docsSepoliaLink = `${config.docsOrigin}/deployed-contracts/sepolia/`;
 
   return (
     <InfoBoxStyled>
-      Withdrawals are currently unavailable. For more information, {link}
+      Withdrawals are currently unavailable. For more information,{' '}
+      <Link
+        href={chainId == CHAINS.Sepolia ? docsSepoliaLink : LIDO_TWITTER_LINK}
+      >
+        see here
+      </Link>
     </InfoBoxStyled>
   );
 };

--- a/features/withdrawals/request/form/paused-info.tsx
+++ b/features/withdrawals/request/form/paused-info.tsx
@@ -1,13 +1,29 @@
-import { InfoBoxStyled } from 'features/withdrawals/shared';
+import { useAccount } from 'wagmi';
 import { Link } from '@lidofinance/lido-ui';
+
+import { config } from 'config';
+import { CHAINS } from 'consts/chains';
+
+import { InfoBoxStyled } from 'features/withdrawals/shared';
 
 const LIDO_TWITTER_LINK = 'https://twitter.com/lidofinance';
 
 export const PausedInfo = () => {
+  const { chainId } = useAccount();
+
+  let link = <Link href={LIDO_TWITTER_LINK}>see here</Link>;
+
+  if (chainId == CHAINS.Sepolia) {
+    link = (
+      <Link href={`${config.docsOrigin}/deployed-contracts/sepolia/`}>
+        see here
+      </Link>
+    );
+  }
+
   return (
     <InfoBoxStyled>
-      Withdrawals are currently unavailable. For more information,{' '}
-      <Link href={LIDO_TWITTER_LINK}>see here</Link>
+      Withdrawals are currently unavailable. For more information, {link}
     </InfoBoxStyled>
   );
 };


### PR DESCRIPTION
### Description

Changed the link for Sepolia

<img width="701" alt="image" src="https://github.com/user-attachments/assets/6b8ef4ce-1a7f-4f80-a54e-c3b8b1d9241d">

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
