### PR TITLE
feat: modify rpc startup check

### DIFF
--- a/scripts/startup-checks/rpc.mjs
+++ b/scripts/startup-checks/rpc.mjs
@@ -36,8 +36,7 @@ const checkRPC = async (url, chainId) => {
       console.info(`[checkRPC] [chainId=${chainId}] RPC ${domain} is working`);
       return { domain, chainId, success: true };
     } else {
-      console.error(`[checkRPC] [chainId=${chainId}] Expected chainId ${chainId}, but got ${chainIdClient}`);
-      return { domain, chainId, success: false };
+      throw new Error(`Expected chainId ${chainId}, but got ${chainIdClient}`)
     }
   } catch (err) {
     console.error(`[checkRPC] [chainId=${chainId}] Error checking RPC ${domain}: ${err.message}`);

--- a/scripts/startup-checks/rpc.mjs
+++ b/scripts/startup-checks/rpc.mjs
@@ -37,7 +37,7 @@ const checkRPC = async (url, chainId) => {
       return { domain, chainId, success: true };
     } else {
       console.error(`[checkRPC] [chainId=${chainId}] Expected chainId ${chainId}, but got ${chainIdClient}`);
-      return { domain, chainId, success: true };
+      return { domain, chainId, success: false };
     }
   } catch (err) {
     console.error(`[checkRPC] [chainId=${chainId}] Error checking RPC ${domain}: ${err.message}`);

--- a/scripts/startup-checks/rpc.mjs
+++ b/scripts/startup-checks/rpc.mjs
@@ -117,8 +117,7 @@ export const startupCheckRPCs = async () => {
         const rpcUrls = getRPCUrls(chainId);
 
         if (!rpcUrls?.length) {
-          console.warn(`[startupCheckRPCs] No RPC URLs found for chain ${chainId}`);
-          continue;
+          throw new Error(`[startupCheckRPCs] No RPC URLs found for chain ${chainId}`);
         }
 
         const chainCheckResults = await Promise.all(

--- a/scripts/startup-checks/rpc.mjs
+++ b/scripts/startup-checks/rpc.mjs
@@ -4,30 +4,16 @@ import { getChainId } from 'viem/actions';
 export const BROKEN_URL = 'BROKEN_URL';
 export const RPC_TIMEOUT_MS = 10_000;
 export const MAX_RETRY_COUNT = 3;
-export const RETRY_WAIT_TIME_MS = 10_000;
 
 // Safely initialize a global variable
 const globalStartupRPCChecks = globalThis.__startupRPCChecks || {
   promise: null,
-  // A 'item of results' is obj '{ domain, chainId, success }'
-  results: [],
 };
 globalThis.__startupRPCChecks = globalStartupRPCChecks;
-
-// Utility
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-
-// Utility
-const timeoutPromise = (ms, message) =>
-  new Promise((_, reject) => setTimeout(() => reject(new Error(message)), ms));
 
 const getRPCUrls = (chainId) => {
   const rpcUrls = process.env[`EL_RPC_URLS_${chainId}`]?.split(',');
   return rpcUrls?.filter((url) => url);
-};
-
-const pushRPCCheckResult = (domain, chainId, success) => {
-  globalStartupRPCChecks.results.push({ domain, chainId, success });
 };
 
 const checkRPC = async (url, chainId) => {
@@ -36,62 +22,27 @@ const checkRPC = async (url, chainId) => {
     domain = new URL(url).hostname;
   } catch {
     console.error(`[checkRPC] Invalid URL: ${url}`);
-    pushRPCCheckResult(BROKEN_URL, chainId, false);
-    return false;
+    return { domain: BROKEN_URL, chainId, success: false };
   }
 
   try {
     const client = createClient({
-      transport: http(url, { retryCount: 0, timeout: RPC_TIMEOUT_MS }),
+      transport: http(url, { retryCount: MAX_RETRY_COUNT, timeout: RPC_TIMEOUT_MS }),
     });
 
     const chainIdClient = await getChainId(client);
 
     if (chainIdClient === chainId) {
-      pushRPCCheckResult(domain, chainId, true);
-      console.info(`[checkRPC] RPC ${domain} is working`);
-      return true;
+      console.info(`[checkRPC] [chainId=${chainId}] RPC ${domain} is working`);
+      return { domain, chainId, success: true };
     } else {
-      throw new Error(`[checkRPC] Expected chainId ${chainId}, but got ${chainId}`);
+      console.error(`[checkRPC] [chainId=${chainId}] Expected chainId ${chainId}, but got ${chainIdClient}`);
+      return { domain, chainId, success: true };
     }
   } catch (err) {
-    console.error(`[checkRPC] Error checking RPC ${domain}: ${err.message}`);
-    return false;
+    console.error(`[checkRPC] [chainId=${chainId}] Error checking RPC ${domain}: ${err.message}`);
+    return { domain, chainId, success: false };
   }
-};
-
-const checkRPCWithRetries = async (url, chainId) => {
-  const domain = new URL(url).hostname;
-
-  for (let attempt = 1; attempt <= MAX_RETRY_COUNT; attempt++) {
-    try {
-      console.info(`[checkRPCWithRetries] Attempt ${attempt} for RPC ${domain}`);
-
-      const result = await Promise.race([
-        checkRPC(url, chainId),
-        timeoutPromise(RPC_TIMEOUT_MS, `[checkRPCWithRetries] RPC ${domain} timed out`),
-      ]);
-
-      if (!result) {
-        throw new Error('[checkRPCWithRetries] Promise(checkRPC) returned false!');
-      }
-
-      // Stop checking for ${url} with success (a success is set in the 'checkRPC' function)
-      return true;
-    } catch (err) {
-      console.error(`[checkRPCWithRetries] Error on attempt ${attempt} for RPC ${domain}: ${err.message}`);
-
-      if (attempt === MAX_RETRY_COUNT) {
-        console.error(`[checkRPCWithRetries] Failed after ${MAX_RETRY_COUNT} attempts for ${domain}`);
-        pushRPCCheckResult(domain, chainId, false);
-      } else {
-        console.info(`[checkRPCWithRetries] Retrying in ${RETRY_WAIT_TIME_MS} ms...`);
-        await sleep(RETRY_WAIT_TIME_MS);
-      }
-    }
-  }
-
-  return false;
 };
 
 export const getRPCChecks = () => globalStartupRPCChecks.promise;
@@ -113,23 +64,24 @@ export const startupCheckRPCs = async () => {
         throw new Error('[startupCheckRPCs] No supported chains found!');
       }
 
+      const results = [];
+
       for (const chainId of supportedChains) {
         const rpcUrls = getRPCUrls(chainId);
-
         if (!rpcUrls?.length) {
-          throw new Error(`[startupCheckRPCs] No RPC URLs found for chain ${chainId}`);
+          throw new Error(`[startupCheckRPCs] [chainId=${chainId}] No RPC URLs found!`);
         }
 
         const chainCheckResults = await Promise.all(
-          rpcUrls.map((url) => checkRPCWithRetries(url, chainId))
+          rpcUrls.map((url) => checkRPC(url, chainId))
         );
-        const brokenRPCCount = chainCheckResults.filter((success) => !success).length;
+        results.push(...chainCheckResults);
 
-        console.info(`[startupCheckRPCs] [chainId=${chainId}] Working RPCs: ${chainCheckResults.length - brokenRPCCount}`);
-        console.info(`[startupCheckRPCs] [chainId=${chainId}] Broken RPCs: ${brokenRPCCount}`);
+        const brokenRPCCount = chainCheckResults.filter((result) => !result.success).length;
+        console.info(`[startupCheckRPCs] [chainId=${chainId}] Working/Total RPCs: ${chainCheckResults.length - brokenRPCCount}/${chainCheckResults.length}`);
       }
 
-      return globalStartupRPCChecks.results;
+      return results;
     } catch (err) {
       console.error('[startupCheckRPCs] Error during RPC checks:', err);
       return null;

--- a/utilsApi/metrics/startup-checks.ts
+++ b/utilsApi/metrics/startup-checks.ts
@@ -2,7 +2,7 @@ import { Gauge, Registry } from 'prom-client';
 import { METRICS_PREFIX, METRIC_NAMES } from 'consts/metrics';
 
 export class StartupChecksRPCMetrics {
-  requestStatusGauge: Gauge<'rpc_domain' | 'success'>;
+  requestStatusGauge: Gauge<'rpc_domain' | 'chain_id'>;
 
   constructor(public registry: Registry) {
     this.requestStatusGauge = this.requestStatusGaugeInit();
@@ -15,7 +15,7 @@ export class StartupChecksRPCMetrics {
     return new Gauge({
       name: requestsCounterName,
       help: 'The total number of RPC checks after the app started.',
-      labelNames: ['rpc_domain'],
+      labelNames: ['rpc_domain', 'chain_id'],
       registers: [this.registry],
     });
   }

--- a/utilsApi/metrics/startup-metrics.ts
+++ b/utilsApi/metrics/startup-metrics.ts
@@ -25,17 +25,19 @@ const collectStartupChecksRPCMetrics = async (
       );
     }
 
-    rpcChecksResults.forEach((_check: { domain: string; success: boolean }) => {
-      rpcMetrics.requestStatusGauge
-        .labels(_check.domain)
-        .set(Number(+!_check.success));
-    });
+    rpcChecksResults.forEach(
+      (_check: { domain: string; chainId: number; success: boolean }) => {
+        rpcMetrics.requestStatusGauge
+          .labels({ rpc_domain: _check.domain, chain_id: _check.chainId })
+          .set(Number(+!_check.success));
+      },
+    );
   } catch (error) {
     console.error(
       `[collectStartupChecksRPCMetrics] Error collecting RPC metrics: ${error}`,
     );
     rpcMetrics.requestStatusGauge
-      .labels('BROKEN_URL') // false as string
+      .labels({ rpc_domain: 'BROKEN_URL' }) // false as string, chainId is not important here
       .inc(1);
   }
 };


### PR DESCRIPTION
### Description

Add a chainId to startup checks rpc

Added checks for all supported chain in startup checks rpc

### Code review notes

Stop app if no RPC URLs found for chain

### Demo

In logs you will see:
```
...
{..."msg":"[startupCheckRPCs] [chainId=17000] Working RPCs: 2"}
{..."msg":"[startupCheckRPCs] [chainId=11155111] Broken RPCs: 0"}
...
{..."msg":"[startupCheckRPCs] [chainId=11155111] Working RPCs: 1"}
{..."msg":"[startupCheckRPCs] [chainId=11155111] Broken RPCs: 0"}
...
{..."msg":"[startupCheckRPCs] [chainId=11155420] Working RPCs: 1"}
{..."msg":"[startupCheckRPCs] [chainId=11155420] Broken RPCs: 1"}
...
```

In metrics you will see:
```
# success RPCs example
eth_stake_widget_ui_startup_checks_rpc_failed{rpc_domain="<domain1_here>",chain_id="17000"} 0
eth_stake_widget_ui_startup_checks_rpc_failed{rpc_domain="<domain2_here>",chain_id="17000"} 0
eth_stake_widget_ui_startup_checks_rpc_failed{rpc_domain="<domain3_here>",chain_id="11155111"} 0
eth_stake_widget_ui_startup_checks_rpc_failed{rpc_domain="<domain4_here>",chain_id="11155420"} 0
# failed RPC example
eth_stake_widget_ui_startup_checks_rpc_failed{rpc_domain="<domain5_here>",chain_id="11155420"} 1
```

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
