### PR TITLE
fix: sdk link in rewards page

### DIFF
--- a/features/rewards/components/errorBlocks/ErrorUnprocessable.tsx
+++ b/features/rewards/components/errorBlocks/ErrorUnprocessable.tsx
@@ -10,7 +10,7 @@ export const ErrorUnprocessable = () => (
         directly from Lido Subgraph using{' '}
         <Link
           href={
-            'https://lidofinance.github.io/lido-ethereum-sdk/methods/rewards/#get-rewards-from-subgraph'
+            'https://lidofinance.github.io/lido-ethereum-sdk/modules/rewards/#get-rewards-from-subgraph'
           }
         >
           Rewards Module from Lido Ethereum SDK


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

Updated link in rewards error to correctly point to sdk docs


### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
