### PR TITLE
refactor: l2 tech debt improvement

### DIFF
--- a/features/wsteth/unwrap/hooks/use-unwrap-tx-on-l2-approve.ts
+++ b/features/wsteth/unwrap/hooks/use-unwrap-tx-on-l2-approve.ts
@@ -2,7 +2,12 @@ import { useMemo, useCallback } from 'react';
 import type { BigNumber } from 'ethers';
 
 import { runWithTransactionLogger } from 'utils';
-import { useLidoSDK, useDappStatus, useAllowance } from 'modules/web3';
+import {
+  useLidoSDK,
+  useDappStatus,
+  useAllowance,
+  DAPP_CHAIN_TYPE,
+} from 'modules/web3';
 
 import { LIDO_L2_CONTRACT_ADDRESSES } from '@lidofinance/lido-ethereum-sdk/common';
 import { TransactionCallbackStage } from '@lidofinance/lido-ethereum-sdk/core';
@@ -12,7 +17,7 @@ type UseUnwrapTxApproveArgs = {
 };
 
 export const useUnwrapTxOnL2Approve = ({ amount }: UseUnwrapTxApproveArgs) => {
-  const { isDappActiveOnL2, address } = useDappStatus();
+  const { isDappActiveOnL2, chainType, address } = useDappStatus();
   const { core, l2 } = useLidoSDK();
 
   const staticTokenAddress = LIDO_L2_CONTRACT_ADDRESSES[core.chainId]?.wsteth;
@@ -60,15 +65,18 @@ export const useUnwrapTxOnL2Approve = ({ amount }: UseUnwrapTxApproveArgs) => {
       allowance,
       isApprovalNeededBeforeUnwrap,
       isAllowanceLoading,
-      isShowAllowance: isDappActiveOnL2,
+      // todo
+      isShowAllowance:
+        isDappActiveOnL2 || chainType === DAPP_CHAIN_TYPE.Optimism,
     }),
     [
       processApproveTx,
       refetchAllowance,
-      isAllowanceLoading,
       allowance,
       isApprovalNeededBeforeUnwrap,
+      isAllowanceLoading,
       isDappActiveOnL2,
+      chainType,
     ],
   );
 };

--- a/features/wsteth/unwrap/hooks/use-unwrap-tx-on-l2-approve.ts
+++ b/features/wsteth/unwrap/hooks/use-unwrap-tx-on-l2-approve.ts
@@ -2,12 +2,7 @@ import { useMemo, useCallback } from 'react';
 import type { BigNumber } from 'ethers';
 
 import { runWithTransactionLogger } from 'utils';
-import {
-  useLidoSDK,
-  useDappStatus,
-  useAllowance,
-  DAPP_CHAIN_TYPE,
-} from 'modules/web3';
+import { useLidoSDK, useDappStatus, useAllowance } from 'modules/web3';
 
 import { LIDO_L2_CONTRACT_ADDRESSES } from '@lidofinance/lido-ethereum-sdk/common';
 import { TransactionCallbackStage } from '@lidofinance/lido-ethereum-sdk/core';
@@ -17,7 +12,7 @@ type UseUnwrapTxApproveArgs = {
 };
 
 export const useUnwrapTxOnL2Approve = ({ amount }: UseUnwrapTxApproveArgs) => {
-  const { isDappActiveOnL2, chainType, address } = useDappStatus();
+  const { isDappActiveOnL2, isChainTypeOnL2, address } = useDappStatus();
   const { core, l2 } = useLidoSDK();
 
   const staticTokenAddress = LIDO_L2_CONTRACT_ADDRESSES[core.chainId]?.wsteth;
@@ -65,9 +60,7 @@ export const useUnwrapTxOnL2Approve = ({ amount }: UseUnwrapTxApproveArgs) => {
       allowance,
       isApprovalNeededBeforeUnwrap,
       isAllowanceLoading,
-      // todo
-      isShowAllowance:
-        isDappActiveOnL2 || chainType === DAPP_CHAIN_TYPE.Optimism,
+      isShowAllowance: isDappActiveOnL2 || isChainTypeOnL2,
     }),
     [
       processApproveTx,
@@ -76,7 +69,7 @@ export const useUnwrapTxOnL2Approve = ({ amount }: UseUnwrapTxApproveArgs) => {
       isApprovalNeededBeforeUnwrap,
       isAllowanceLoading,
       isDappActiveOnL2,
-      chainType,
+      isChainTypeOnL2,
     ],
   );
 };

--- a/features/wsteth/unwrap/hooks/use-unwrap-tx-on-l2-approve.ts
+++ b/features/wsteth/unwrap/hooks/use-unwrap-tx-on-l2-approve.ts
@@ -60,6 +60,9 @@ export const useUnwrapTxOnL2Approve = ({ amount }: UseUnwrapTxApproveArgs) => {
       allowance,
       isApprovalNeededBeforeUnwrap,
       isAllowanceLoading,
+      // There are 2 cases when we show the allowance on the unwrap page:
+      // 1. any Optimism supported chain and chain switcher is Optimism (isDappActiveOnL2)
+      // 2. or any ETH supported chain, but chain switcher is Optimism (isChainTypeOnL2)
       isShowAllowance: isDappActiveOnL2 || isChainTypeOnL2,
     }),
     [

--- a/features/wsteth/unwrap/hooks/use-unwrap-tx-on-l2-approve.ts
+++ b/features/wsteth/unwrap/hooks/use-unwrap-tx-on-l2-approve.ts
@@ -61,8 +61,8 @@ export const useUnwrapTxOnL2Approve = ({ amount }: UseUnwrapTxApproveArgs) => {
       isApprovalNeededBeforeUnwrap,
       isAllowanceLoading,
       // There are 2 cases when we show the allowance on the unwrap page:
-      // 1. any Optimism supported chain and chain switcher is Optimism (isDappActiveOnL2)
-      // 2. or any ETH supported chain, but chain switcher is Optimism (isChainTypeOnL2)
+      // 1. wallet chain is any Optimism supported chain and chain switcher is Optimism (isDappActiveOnL2)
+      // 2. or wallet chain is any ETH supported chain, but chain switcher is Optimism (isChainTypeOnL2)
       isShowAllowance: isDappActiveOnL2 || isChainTypeOnL2,
     }),
     [

--- a/features/wsteth/unwrap/unwrap-form/unwrap-stats.tsx
+++ b/features/wsteth/unwrap/unwrap-form/unwrap-stats.tsx
@@ -16,22 +16,21 @@ import { useUnwrapFormData, UnwrapFormInputType } from '../unwrap-form-context';
 import { useApproveGasLimit } from 'features/wsteth/wrap/hooks/use-approve-gas-limit';
 
 export const UnwrapStats = () => {
-  const { isDappActiveOnL2, isChainTypeMatched, chainTypeChainId } =
-    useDappStatus();
+  const { isDappActiveOnL2, chainTypeChainId } = useDappStatus();
   const { allowance, isAllowanceLoading, isShowAllowance } =
     useUnwrapFormData();
   const amount = useWatch<UnwrapFormInputType, 'amount'>({ name: 'amount' });
 
-  // This is used to get the TX price if the wallet chain id and header toggle network don't match
-  const chainIdForce = !isChainTypeMatched ? chainTypeChainId : undefined;
-
   const unwrapGasLimit = useUnwrapGasLimit();
   // The 'unwrapGasLimit' difference between the networks is insignificant
   // and can be neglected in the '!isChainTypeMatched' case
+  //
+  // Using the chainTypeChainId (chainId from the chain switcher) for TX calculation (and below for 'approveTxCostInUsd'),
+  // because the statistics here are shown for the chain from the chain switcher
   const {
     txCostUsd: unwrapTxCostInUsd,
     initialLoading: isUnwrapTxCostLoading,
-  } = useTxCostInUsd(unwrapGasLimit, chainIdForce);
+  } = useTxCostInUsd(unwrapGasLimit, chainTypeChainId);
 
   const approveGasLimit = useApproveGasLimit();
   // The 'approveGasLimit' difference between the networks is insignificant
@@ -39,7 +38,7 @@ export const UnwrapStats = () => {
   const {
     txCostUsd: approveTxCostInUsd,
     initialLoading: isApproveCostLoading,
-  } = useTxCostInUsd(approveGasLimit, chainIdForce);
+  } = useTxCostInUsd(approveGasLimit, chainTypeChainId);
 
   const { data: willReceiveStETH, initialLoading: isWillReceiveStETHLoading } =
     useDebouncedStethByWsteth(amount, isDappActiveOnL2);

--- a/features/wsteth/unwrap/unwrap-form/unwrap-stats.tsx
+++ b/features/wsteth/unwrap/unwrap-form/unwrap-stats.tsx
@@ -16,21 +16,30 @@ import { useUnwrapFormData, UnwrapFormInputType } from '../unwrap-form-context';
 import { useApproveGasLimit } from 'features/wsteth/wrap/hooks/use-approve-gas-limit';
 
 export const UnwrapStats = () => {
-  const { isWalletConnected, isDappActiveOnL2, isDappActive } = useDappStatus();
+  const { isDappActiveOnL2, isChainTypeMatched, chainTypeChainId } =
+    useDappStatus();
   const { allowance, isAllowanceLoading, isShowAllowance } =
     useUnwrapFormData();
   const amount = useWatch<UnwrapFormInputType, 'amount'>({ name: 'amount' });
+
+  // This is used to get the TX price if the wallet chain id and header toggle network don't match
+  const chainIdForce = !isChainTypeMatched ? chainTypeChainId : undefined;
+
   const unwrapGasLimit = useUnwrapGasLimit();
+  // The 'unwrapGasLimit' difference between the networks is insignificant
+  // and can be neglected in the '!isChainTypeMatched' case
   const {
     txCostUsd: unwrapTxCostInUsd,
     initialLoading: isUnwrapTxCostLoading,
-  } = useTxCostInUsd(unwrapGasLimit);
+  } = useTxCostInUsd(unwrapGasLimit, chainIdForce);
 
   const approveGasLimit = useApproveGasLimit();
+  // The 'approveGasLimit' difference between the networks is insignificant
+  // and can be neglected in the '!isChainTypeMatched' case
   const {
     txCostUsd: approveTxCostInUsd,
     initialLoading: isApproveCostLoading,
-  } = useTxCostInUsd(approveGasLimit);
+  } = useTxCostInUsd(approveGasLimit, chainIdForce);
 
   const { data: willReceiveStETH, initialLoading: isWillReceiveStETHLoading } =
     useDebouncedStethByWsteth(amount, isDappActiveOnL2);
@@ -54,11 +63,7 @@ export const UnwrapStats = () => {
         data-testid="maxGasFee"
         loading={isUnwrapTxCostLoading}
       >
-        {isWalletConnected && !isDappActive ? (
-          '-'
-        ) : (
-          <FormatPrice amount={unwrapTxCostInUsd} />
-        )}
+        <FormatPrice amount={unwrapTxCostInUsd} />
       </DataTableRow>
       {isShowAllowance && (
         <DataTableRow
@@ -66,11 +71,7 @@ export const UnwrapStats = () => {
           data-testid="maxUnlockFee"
           loading={isApproveCostLoading}
         >
-          {isWalletConnected && !isDappActive ? (
-            '-'
-          ) : (
-            <FormatPrice amount={approveTxCostInUsd} />
-          )}
+          <FormatPrice amount={approveTxCostInUsd} />
         </DataTableRow>
       )}
       <DataTableRowStethByWsteth />

--- a/features/wsteth/wrap/hooks/use-wrap-tx-on-l1-approve.ts
+++ b/features/wsteth/wrap/hooks/use-wrap-tx-on-l1-approve.ts
@@ -6,7 +6,7 @@ import { useSDK } from '@lido-sdk/react';
 
 import { TokensWrappable, TOKENS_TO_WRAP } from 'features/wsteth/shared/types';
 import { useApproveOnL1 } from 'shared/hooks/useApproveOnL1';
-import { DAPP_CHAIN_TYPE, useDappStatus } from 'modules/web3';
+import { useDappStatus } from 'modules/web3';
 
 type UseWrapTxApproveArgs = {
   amount: BigNumber;
@@ -17,7 +17,8 @@ export const useWrapTxOnL1Approve = ({
   amount,
   token,
 }: UseWrapTxApproveArgs) => {
-  const { isWalletConnected, isDappActiveOnL1, chainType } = useDappStatus();
+  const { isWalletConnected, isDappActiveOnL1, isChainTypeOnL2 } =
+    useDappStatus();
   const { chainId } = useSDK();
 
   const [stethTokenAddress, wstethTokenAddress] = useMemo(
@@ -51,11 +52,8 @@ export const useWrapTxOnL1Approve = ({
       isApprovalLoading,
       isApprovalNeededBeforeWrap,
       refetchAllowance,
-      // todo
       isShowAllowance:
-        !isWalletConnected ||
-        isDappActiveOnL1 ||
-        chainType === DAPP_CHAIN_TYPE.Ethereum,
+        !isWalletConnected || isDappActiveOnL1 || !isChainTypeOnL2,
     }),
     [
       processApproveTx,
@@ -66,7 +64,7 @@ export const useWrapTxOnL1Approve = ({
       refetchAllowance,
       isWalletConnected,
       isDappActiveOnL1,
-      chainType,
+      isChainTypeOnL2,
     ],
   );
 };

--- a/features/wsteth/wrap/hooks/use-wrap-tx-on-l1-approve.ts
+++ b/features/wsteth/wrap/hooks/use-wrap-tx-on-l1-approve.ts
@@ -6,7 +6,7 @@ import { useSDK } from '@lido-sdk/react';
 
 import { TokensWrappable, TOKENS_TO_WRAP } from 'features/wsteth/shared/types';
 import { useApproveOnL1 } from 'shared/hooks/useApproveOnL1';
-import { useDappStatus } from 'modules/web3';
+import { DAPP_CHAIN_TYPE, useDappStatus } from 'modules/web3';
 
 type UseWrapTxApproveArgs = {
   amount: BigNumber;
@@ -17,7 +17,7 @@ export const useWrapTxOnL1Approve = ({
   amount,
   token,
 }: UseWrapTxApproveArgs) => {
-  const { isDappActiveOnL1 } = useDappStatus();
+  const { isWalletConnected, isDappActiveOnL1, chainType } = useDappStatus();
   const { chainId } = useSDK();
 
   const [stethTokenAddress, wstethTokenAddress] = useMemo(
@@ -51,16 +51,22 @@ export const useWrapTxOnL1Approve = ({
       isApprovalLoading,
       isApprovalNeededBeforeWrap,
       refetchAllowance,
-      isShowAllowance: isDappActiveOnL1,
+      // todo
+      isShowAllowance:
+        !isWalletConnected ||
+        isDappActiveOnL1 ||
+        chainType === DAPP_CHAIN_TYPE.Ethereum,
     }),
     [
-      allowance,
-      isApprovalNeededBeforeWrap,
-      needsApprove,
-      isApprovalLoading,
       processApproveTx,
+      needsApprove,
+      allowance,
+      isApprovalLoading,
+      isApprovalNeededBeforeWrap,
       refetchAllowance,
+      isWalletConnected,
       isDappActiveOnL1,
+      chainType,
     ],
   );
 };

--- a/features/wsteth/wrap/hooks/use-wrap-tx-on-l1-approve.ts
+++ b/features/wsteth/wrap/hooks/use-wrap-tx-on-l1-approve.ts
@@ -54,8 +54,8 @@ export const useWrapTxOnL1Approve = ({
       refetchAllowance,
       // There are 3 cases when we show the allowance on the wrap page:
       // 1. is wallet not connected (!isWalletConnected)
-      // 2. or any ETH supported chain and chain switcher is ETH (isDappActiveOnL1)
-      // 3. or any Optimism supported chain, but chain switcher is ETH (!isChainTypeOnL2)
+      // 2. or wallet chain is any ETH supported chain and chain switcher is ETH (isDappActiveOnL1)
+      // 3. or wallet chain is any Optimism supported chain, but chain switcher is ETH (!isChainTypeOnL2)
       isShowAllowance:
         !isWalletConnected || isDappActiveOnL1 || !isChainTypeOnL2,
     }),

--- a/features/wsteth/wrap/hooks/use-wrap-tx-on-l1-approve.ts
+++ b/features/wsteth/wrap/hooks/use-wrap-tx-on-l1-approve.ts
@@ -52,6 +52,10 @@ export const useWrapTxOnL1Approve = ({
       isApprovalLoading,
       isApprovalNeededBeforeWrap,
       refetchAllowance,
+      // There are 3 cases when we show the allowance on the wrap page:
+      // 1. is wallet not connected (!isWalletConnected)
+      // 2. or any ETH supported chain and chain switcher is ETH (isDappActiveOnL1)
+      // 3. or any Optimism supported chain, but chain switcher is ETH (!isChainTypeOnL2)
       isShowAllowance:
         !isWalletConnected || isDappActiveOnL1 || !isChainTypeOnL2,
     }),

--- a/features/wsteth/wrap/wrap-form/wrap-stats.tsx
+++ b/features/wsteth/wrap/wrap-form/wrap-stats.tsx
@@ -112,7 +112,7 @@ export const WrapFormStats = () => {
           DATA_UNAVAILABLE
         )}
       </DataTableRow>
-      {(!isDappActive || isShowAllowance) && (
+      {isShowAllowance && (
         <AllowanceDataTableRow
           data-testid="allowance"
           allowance={allowance}

--- a/features/wsteth/wrap/wrap-form/wrap-stats.tsx
+++ b/features/wsteth/wrap/wrap-form/wrap-stats.tsx
@@ -18,12 +18,7 @@ import { useWrapFormData, WrapFormInputType } from '../wrap-form-context';
 const oneSteth = parseEther('1');
 
 export const WrapFormStats = () => {
-  const {
-    isDappActive,
-    isDappActiveOnL2,
-    isChainTypeMatched,
-    chainTypeChainId,
-  } = useDappStatus();
+  const { isDappActive, isDappActiveOnL2, chainTypeChainId } = useDappStatus();
   const { allowance, isShowAllowance, wrapGasLimit, isApprovalLoading } =
     useWrapFormData();
 
@@ -49,21 +44,21 @@ export const WrapFormStats = () => {
     initialLoading: oneWstethConvertedLoading,
   } = isDappActiveOnL2 ? wstETHByStETHOnL2 : wstethBySteth;
 
-  // This is used to get the TX price if the wallet chain id and header toggle network don't match
-  const chainIdForce = !isChainTypeMatched ? chainTypeChainId : undefined;
-
   // The 'approveGasLimit' difference between the networks is insignificant
   // and can be neglected in the '!isChainTypeMatched' case
+  //
+  // Using the chainTypeChainId (chainId from the chain switcher) for TX calculation (and below for 'wrapTxCostInUsd'),
+  // because the statistics here are shown for the chain from the chain switcher
   const approveGasLimit = useApproveGasLimit();
   const {
     txCostUsd: approveTxCostInUsd,
     initialLoading: isApproveCostLoading,
-  } = useTxCostInUsd(approveGasLimit, chainIdForce);
+  } = useTxCostInUsd(approveGasLimit, chainTypeChainId);
 
   // The 'wrapGasLimit' difference between the networks is insignificant
   // and can be neglected in the '!isChainTypeMatched' case
   const { txCostUsd: wrapTxCostInUsd, initialLoading: isWrapCostLoading } =
-    useTxCostInUsd(wrapGasLimit, chainIdForce);
+    useTxCostInUsd(wrapGasLimit, chainTypeChainId);
 
   return (
     <DataTable data-testid="wrapStats">

--- a/features/wsteth/wrap/wrap-form/wrap-stats.tsx
+++ b/features/wsteth/wrap/wrap-form/wrap-stats.tsx
@@ -44,6 +44,7 @@ export const WrapFormStats = () => {
     isDappActiveOnL2 ? oneSteth : undefined,
   );
 
+  // TODO: remove isDappActiveOnL2
   const {
     data: oneWstethConverted,
     initialLoading: oneWstethConvertedLoading,

--- a/features/wsteth/wrap/wrap-form/wrap-stats.tsx
+++ b/features/wsteth/wrap/wrap-form/wrap-stats.tsx
@@ -44,20 +44,22 @@ export const WrapFormStats = () => {
     isDappActiveOnL2 ? oneSteth : undefined,
   );
 
-  // TODO: remove isDappActiveOnL2
   const {
     data: oneWstethConverted,
     initialLoading: oneWstethConvertedLoading,
   } = isDappActiveOnL2 ? wstETHByStETHOnL2 : wstethBySteth;
 
+  // This is used to get the TX price if the wallet chain id and header toggle network don't match
+  const chainIdForce = !isChainTypeMatched ? chainTypeChainId : undefined;
+
+  // The 'approveGasLimit' difference between the networks is insignificant
+  // and can be neglected in the '!isChainTypeMatched' case
   const approveGasLimit = useApproveGasLimit();
   const {
     txCostUsd: approveTxCostInUsd,
     initialLoading: isApproveCostLoading,
-  } = useTxCostInUsd(approveGasLimit);
+  } = useTxCostInUsd(approveGasLimit, chainIdForce);
 
-  // This is used to get the TX price if the wallet chain id and header toggle network don't match
-  const chainIdForce = !isChainTypeMatched ? chainTypeChainId : undefined;
   // The 'wrapGasLimit' difference between the networks is insignificant
   // and can be neglected in the '!isChainTypeMatched' case
   const { txCostUsd: wrapTxCostInUsd, initialLoading: isWrapCostLoading } =

--- a/modules/web3/hooks/use-max-gas-price.ts
+++ b/modules/web3/hooks/use-max-gas-price.ts
@@ -22,13 +22,13 @@ const feeHistoryToMaxFee = ({
   return BigNumber.from(maxFeePerGas);
 };
 
-export const useMaxGasPrice = (chainIdForce?: number) => {
-  const { chainId } = useDappStatus();
+export const useMaxGasPrice = (chainId?: number) => {
+  const { chainId: dappChainId } = useDappStatus();
 
   const { data, isLoading, error, isFetching, refetch } = useFeeHistory({
     blockCount: 5,
     blockTag: 'pending',
-    chainId: chainIdForce || chainId,
+    chainId: chainId || dappChainId,
     rewardPercentiles: REWARD_PERCENTILES,
     query: {
       select: feeHistoryToMaxFee,

--- a/modules/web3/hooks/use-max-gas-price.ts
+++ b/modules/web3/hooks/use-max-gas-price.ts
@@ -22,13 +22,13 @@ const feeHistoryToMaxFee = ({
   return BigNumber.from(maxFeePerGas);
 };
 
-export const useMaxGasPrice = () => {
+export const useMaxGasPrice = (chainIdForce?: number) => {
   const { chainId } = useDappStatus();
 
   const { data, isLoading, error, isFetching, refetch } = useFeeHistory({
     blockCount: 5,
     blockTag: 'pending',
-    chainId,
+    chainId: chainIdForce || chainId,
     rewardPercentiles: REWARD_PERCENTILES,
     query: {
       select: feeHistoryToMaxFee,

--- a/modules/web3/web3-provider/dapp-chain.tsx
+++ b/modules/web3/web3-provider/dapp-chain.tsx
@@ -59,7 +59,7 @@ const getChainTypeByChainId = (chainId?: number): DAPP_CHAIN_TYPE | null => {
 
 const getChainIdByChainType = (
   chainType: DAPP_CHAIN_TYPE,
-  supportedChainIds,
+  supportedChainIds: number[],
 ): number | null => {
   switch (chainType) {
     // At the current stage of the widget we don't care what ID is returned:

--- a/modules/web3/web3-provider/dapp-chain.tsx
+++ b/modules/web3/web3-provider/dapp-chain.tsx
@@ -26,7 +26,11 @@ type DappChainContextValue = {
 };
 
 type UseDappChainValue = {
+  // Current DApp chain ID (may not match with chainType)
   chainId: number;
+  // Chain ID by current chainType
+  chainTypeChainId: number;
+
   isSupportedChain: boolean;
   supportedChainTypes: DAPP_CHAIN_TYPE[];
   supportedChainLabels: string[];
@@ -51,6 +55,28 @@ const getChainTypeByChainId = (chainId?: number): DAPP_CHAIN_TYPE | null => {
     return DAPP_CHAIN_TYPE.Optimism;
   }
   return null;
+};
+
+const getChainIdByChainType = (
+  chainType: DAPP_CHAIN_TYPE,
+  supportedChainIds,
+): number | null => {
+  switch (chainType) {
+    case DAPP_CHAIN_TYPE.Ethereum:
+      return (
+        Array.from(ETHEREUM_CHAINS).find((id) =>
+          supportedChainIds.includes(id),
+        ) ?? null
+      );
+    case DAPP_CHAIN_TYPE.Optimism:
+      return (
+        Array.from(OPTIMISM_CHAINS).find((id) =>
+          supportedChainIds.includes(id),
+        ) ?? null
+      );
+    default:
+      return null;
+  }
 };
 
 export const useDappChain = (): UseDappChainValue => {
@@ -83,11 +109,16 @@ export const useDappChain = (): UseDappChainValue => {
       );
     });
 
+    const chainTypeChainId =
+      getChainIdByChainType(context.chainType, context.supportedChainIds) ||
+      config.defaultChain;
+
     return {
       ...context,
       chainId: context.supportedChainIds.includes(dappChain)
         ? dappChain
         : config.defaultChain,
+      chainTypeChainId,
       isSupportedChain: walletChain
         ? context.supportedChainIds.includes(walletChain)
         : true,

--- a/modules/web3/web3-provider/dapp-chain.tsx
+++ b/modules/web3/web3-provider/dapp-chain.tsx
@@ -137,12 +137,11 @@ export const SupportL2Chains: React.FC<React.PropsWithChildren> = ({
   children,
 }) => {
   const { chainId: walletChainId, isConnected } = useAccount();
+  const wagmiConfig = useConfig();
   const [chainType, setChainType] = useState<DAPP_CHAIN_TYPE>(
     DAPP_CHAIN_TYPE.Ethereum,
   );
 
-  // Reset the chainType after disconnect
-  const wagmiConfig = useConfig();
   useEffect(() => {
     if (isConnected && walletChainId) {
       const newChainType = getChainTypeByChainId(walletChainId);
@@ -151,6 +150,7 @@ export const SupportL2Chains: React.FC<React.PropsWithChildren> = ({
       return () => {
         // protecs from side effect double run
         if (!wagmiConfig.state.current) {
+          // Reset the chainType after disconnect
           setChainType(DAPP_CHAIN_TYPE.Ethereum);
         }
       };

--- a/modules/web3/web3-provider/dapp-chain.tsx
+++ b/modules/web3/web3-provider/dapp-chain.tsx
@@ -89,7 +89,7 @@ export const useDappChain = (): UseDappChainValue => {
   invariant(context, 'useDappChain was used outside of DappChainProvider');
 
   const { chainId: dappChain } = useLidoSDK();
-  const { chainId: walletChain } = useAccount();
+  const { chainId: walletChain, isConnected } = useAccount();
 
   return useMemo(() => {
     const supportedChainTypes = context.supportedChainIds
@@ -114,9 +114,13 @@ export const useDappChain = (): UseDappChainValue => {
       );
     });
 
-    const chainTypeChainId =
-      getChainIdByChainType(context.chainType, context.supportedChainIds) ||
-      config.defaultChain;
+    // The check (is isConnected) is needed for the case when the wallet was disconnected:
+    // - the Ethereum in wallet or Optimism in wallet,
+    // - the Optimism in the chain switcher (important)
+    const chainTypeChainId = isConnected
+      ? getChainIdByChainType(context.chainType, context.supportedChainIds) ??
+        config.defaultChain
+      : config.defaultChain;
 
     return {
       ...context,
@@ -130,7 +134,7 @@ export const useDappChain = (): UseDappChainValue => {
       supportedChainTypes,
       supportedChainLabels,
     };
-  }, [context, dappChain, walletChain]);
+  }, [context, dappChain, isConnected, walletChain]);
 };
 
 export const SupportL2Chains: React.FC<React.PropsWithChildren> = ({
@@ -163,6 +167,9 @@ export const SupportL2Chains: React.FC<React.PropsWithChildren> = ({
           // At the moment a simple check is enough for us,
           // however in the future we will either rethink this flag
           // or use an array or Set (for example with L2_DAPP_CHAINS_TYPE)
+          //
+          // The check (is isConnected) is needed for the case when the wallet was disconnected
+          // with the Optimism in the chain switcher
           isChainTypeOnL2: isConnected
             ? chainType === DAPP_CHAIN_TYPE.Optimism
             : false,

--- a/modules/web3/web3-provider/dapp-chain.tsx
+++ b/modules/web3/web3-provider/dapp-chain.tsx
@@ -23,6 +23,7 @@ type DappChainContextValue = {
   setChainType: React.Dispatch<React.SetStateAction<DAPP_CHAIN_TYPE>>;
   supportedChainIds: number[];
   isChainTypeMatched: boolean;
+  isChainTypeOnL2: boolean;
 };
 
 type UseDappChainValue = {
@@ -135,7 +136,7 @@ export const useDappChain = (): UseDappChainValue => {
 export const SupportL2Chains: React.FC<React.PropsWithChildren> = ({
   children,
 }) => {
-  const { chainId: walletChainId } = useAccount();
+  const { chainId: walletChainId, isConnected } = useAccount();
   const [chainType, setChainType] = useState<DAPP_CHAIN_TYPE>(
     DAPP_CHAIN_TYPE.Ethereum,
   );
@@ -159,8 +160,14 @@ export const SupportL2Chains: React.FC<React.PropsWithChildren> = ({
           supportedChainIds: config.supportedChains,
           isChainTypeMatched:
             chainType === getChainTypeByChainId(walletChainId),
+          // At the moment a simple check is enough for us,
+          // however in the future we will either rethink this flag
+          // or use an array or Set (for example with L2_DAPP_CHAINS_TYPE)
+          isChainTypeOnL2: isConnected
+            ? chainType === DAPP_CHAIN_TYPE.Optimism
+            : false,
         }),
-        [chainType, walletChainId],
+        [chainType, walletChainId, isConnected],
       )}
     >
       {children}
@@ -175,6 +182,7 @@ const onlyL1ChainsValue = {
     (chain) => !isSDKSupportedL2Chain(chain),
   ),
   isChainTypeMatched: true,
+  isChainTypeOnL2: false,
   setChainType: () => {},
 };
 

--- a/modules/web3/web3-provider/dapp-chain.tsx
+++ b/modules/web3/web3-provider/dapp-chain.tsx
@@ -62,6 +62,10 @@ const getChainIdByChainType = (
   supportedChainIds,
 ): number | null => {
   switch (chainType) {
+    // At the current stage of the widget we don't care what ID is returned:
+    // - 'chainTypeChainId' is only used for statistics;
+    // - on the prod environment, the function display of 'chainType' to 'chainId' will be 1 to 1 (bijective mapping).
+
     case DAPP_CHAIN_TYPE.Ethereum:
       return (
         Array.from(ETHEREUM_CHAINS).find((id) =>

--- a/modules/web3/web3-provider/dapp-chain.tsx
+++ b/modules/web3/web3-provider/dapp-chain.tsx
@@ -64,7 +64,7 @@ const getChainIdByChainType = (
   switch (chainType) {
     // At the current stage of the widget we don't care what ID is returned:
     // - 'chainTypeChainId' is only used for statistics;
-    // - on the prod environment, the function display of 'chainType' to 'chainId' will be 1 to 1 (bijective mapping).
+    // - on the prod environment, the function map of 'chainType' to 'chainId' will be 1 to 1 (bijective mapping).
 
     case DAPP_CHAIN_TYPE.Ethereum:
       return (

--- a/modules/web3/web3-provider/dapp-chain.tsx
+++ b/modules/web3/web3-provider/dapp-chain.tsx
@@ -144,7 +144,10 @@ export const SupportL2Chains: React.FC<React.PropsWithChildren> = ({
   // Reset the chainType after disconnect
   const wagmiConfig = useConfig();
   useEffect(() => {
-    if (isConnected) {
+    if (isConnected && walletChainId) {
+      const newChainType = getChainTypeByChainId(walletChainId);
+      if (newChainType) setChainType(newChainType);
+
       return () => {
         // protecs from side effect double run
         if (!wagmiConfig.state.current) {
@@ -153,17 +156,7 @@ export const SupportL2Chains: React.FC<React.PropsWithChildren> = ({
       };
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isConnected, setChainType]);
-
-  useEffect(() => {
-    if (!walletChainId) return;
-
-    const newChainType = getChainTypeByChainId(walletChainId);
-
-    if (!newChainType) return;
-
-    setChainType(newChainType);
-  }, [walletChainId]);
+  }, [walletChainId, isConnected, setChainType]);
 
   return (
     <DappChainContext.Provider

--- a/shared/components/allowance-data-table-row/allowance-data-table-row.tsx
+++ b/shared/components/allowance-data-table-row/allowance-data-table-row.tsx
@@ -1,4 +1,4 @@
-import { MaxUint256 } from '@ethersproject/constants';
+import { MaxUint256, Zero } from '@ethersproject/constants';
 import { TOKENS } from '@lido-sdk/constants';
 import { DataTableRow } from '@lidofinance/lido-ui';
 import { BigNumber } from 'ethers';
@@ -30,10 +30,7 @@ export const AllowanceDataTableRow = ({
   return (
     <DataTableRow title={title} {...rest}>
       {isBlank ? (
-        <FormatToken
-          amount={BigNumber.from('0')}
-          symbol={getTokenDisplayName(token)}
-        />
+        <FormatToken amount={Zero} symbol={getTokenDisplayName(token)} />
       ) : isInfiniteAllowance ? (
         'Infinite'
       ) : (

--- a/shared/components/allowance-data-table-row/allowance-data-table-row.tsx
+++ b/shared/components/allowance-data-table-row/allowance-data-table-row.tsx
@@ -30,7 +30,10 @@ export const AllowanceDataTableRow = ({
   return (
     <DataTableRow title={title} {...rest}>
       {isBlank ? (
-        '-'
+        <FormatToken
+          amount={BigNumber.from('0')}
+          symbol={getTokenDisplayName(token)}
+        />
       ) : isInfiniteAllowance ? (
         'Infinite'
       ) : (

--- a/shared/components/data-table-row-steth-by-wsteth/data-table-row-steth-by-wsteth.tsx
+++ b/shared/components/data-table-row-steth-by-wsteth/data-table-row-steth-by-wsteth.tsx
@@ -24,7 +24,6 @@ export const DataTableRowStethByWsteth = ({
     isDappActiveOnL2 ? OneWsteth : undefined,
   );
 
-  // TODO: remove isDappActiveOnL2
   const { data, initialLoading } = isDappActiveOnL2
     ? stETHByWstETHOnL2
     : stethByWsteth;

--- a/shared/components/data-table-row-steth-by-wsteth/data-table-row-steth-by-wsteth.tsx
+++ b/shared/components/data-table-row-steth-by-wsteth/data-table-row-steth-by-wsteth.tsx
@@ -16,7 +16,7 @@ type DataTableRowStethByWstethProps = {
 export const DataTableRowStethByWsteth = ({
   toSymbol = 'stETH',
 }: DataTableRowStethByWstethProps) => {
-  const { isWalletConnected, isDappActiveOnL2, isDappActive } = useDappStatus();
+  const { isDappActiveOnL2 } = useDappStatus();
   const stethByWsteth = useStethByWsteth(
     !isDappActiveOnL2 ? OneWsteth : undefined,
   );
@@ -24,6 +24,7 @@ export const DataTableRowStethByWsteth = ({
     isDappActiveOnL2 ? OneWsteth : undefined,
   );
 
+  // TODO: remove isDappActiveOnL2
   const { data, initialLoading } = isDappActiveOnL2
     ? stETHByWstETHOnL2
     : stethByWsteth;
@@ -34,9 +35,7 @@ export const DataTableRowStethByWsteth = ({
       title="Exchange rate"
       loading={initialLoading}
     >
-      {isWalletConnected && !isDappActive ? (
-        '-'
-      ) : data ? (
+      {data ? (
         <>
           1 wstETH =
           <FormatToken

--- a/shared/components/layout/header/components/chain-switcher/chain-switcher.tsx
+++ b/shared/components/layout/header/components/chain-switcher/chain-switcher.tsx
@@ -5,7 +5,12 @@ import { useDappStatus } from 'modules/web3';
 import { useClickOutside } from './hooks/use-click-outside';
 import { ChainSwitcherOptions } from './components/chain-switcher-options/chain-switcher-options';
 import { SelectIconTooltip } from './components/select-icon-tooltip/select-icon-tooltip';
-import { ChainSwitcherStyled, IconStyle, ArrowStyle } from './styles';
+import {
+  ChainSwitcherWrapperStyled,
+  ChainSwitcherStyled,
+  IconStyle,
+  ArrowStyle,
+} from './styles';
 
 import { ReactComponent as OptimismLogo } from 'assets/icons/chain-toggler/optimism.svg';
 import { ReactComponent as EthereumMainnetLogo } from 'assets/icons/chain-toggler/mainnet.svg';
@@ -26,7 +31,7 @@ export const ChainSwitcher: FC = () => {
   useClickOutside(selectRef, () => setOpened(false));
 
   return (
-    <>
+    <ChainSwitcherWrapperStyled>
       <ChainSwitcherStyled
         ref={selectRef}
         $disabled={!isChainTypeUnlocked}
@@ -54,6 +59,6 @@ export const ChainSwitcher: FC = () => {
           )}
         </>
       )}
-    </>
+    </ChainSwitcherWrapperStyled>
   );
 };

--- a/shared/components/layout/header/components/chain-switcher/components/chain-switcher-options/chain-switcher-options.tsx
+++ b/shared/components/layout/header/components/chain-switcher/components/chain-switcher-options/chain-switcher-options.tsx
@@ -1,0 +1,34 @@
+import { FC, ReactNode } from 'react';
+import { DAPP_CHAIN_TYPE } from 'modules/web3';
+
+import { PopoverWrapperStyled, PopupStyled, OptionStyled } from './styles';
+
+interface ChainSwitcherOptionsProps {
+  currentChainType: DAPP_CHAIN_TYPE;
+  onSelect: (chainType: DAPP_CHAIN_TYPE) => void;
+  opened: boolean;
+  options: Record<DAPP_CHAIN_TYPE, ReactNode>;
+}
+
+export const ChainSwitcherOptions: FC<ChainSwitcherOptionsProps> = ({
+  currentChainType,
+  onSelect,
+  opened,
+  options,
+}) => (
+  // We need the 'PopoverWrapperStyled' for block any events as if you had set 'pointer-events: none' on the body
+  // while the 'PopupStyled' is opened
+  <PopoverWrapperStyled $backdrop={opened}>
+    <PopupStyled $opened={opened}>
+      {Object.entries(options).map(([chainType, icon]) => (
+        <OptionStyled
+          key={chainType}
+          onClick={() => onSelect(chainType as DAPP_CHAIN_TYPE)}
+          $active={chainType === currentChainType}
+        >
+          {icon} <span>{chainType}</span>
+        </OptionStyled>
+      ))}
+    </PopupStyled>
+  </PopoverWrapperStyled>
+);

--- a/shared/components/layout/header/components/chain-switcher/components/chain-switcher-options/styles.tsx
+++ b/shared/components/layout/header/components/chain-switcher/components/chain-switcher-options/styles.tsx
@@ -1,0 +1,127 @@
+import styled, { css } from 'styled-components';
+
+export const PopoverWrapperStyled = styled.div<{ $backdrop: boolean }>`
+  position: absolute;
+  z-index: 200;
+  top: 0;
+  left: 0;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: ${({ $backdrop }) => ($backdrop ? '100%' : '0px')};
+`;
+
+type PopupMenuProps = {
+  $opened: boolean;
+};
+
+const visibleCSS = css`
+  opacity: 1;
+
+  &[data-placement] {
+    transform: translate(0, 0);
+  }
+`;
+
+const hiddenCSS = css`
+  opacity: 0;
+
+  &[data-placement^='top'] {
+    transform: translateY(6px);
+  }
+  &[data-placement^='right'] {
+    transform: translateX(-6px);
+  }
+  &[data-placement^='bottom'] {
+    transform: translateY(-6px);
+  }
+  &[data-placement^='left'] {
+    transform: translateX(6px);
+  }
+`;
+
+export const PopupStyled = styled.div<PopupMenuProps>`
+  min-width: 115px;
+  z-index: 201;
+
+  position: absolute;
+  top: 48px;
+
+  overflow: auto;
+  overflow-x: hidden;
+  box-sizing: border-box;
+
+  margin: 0;
+  padding: 0;
+
+  background: var(--lido-color-foreground);
+  font-size: ${({ theme }) => theme.fontSizesMap.xs}px;
+  line-height: 1.5em;
+  font-weight: 400;
+
+  border-radius: ${({ theme }) => theme.borderRadiusesMap.lg}px;
+  box-shadow: ${({ theme }) => theme.boxShadows.xs}
+    var(--lido-color-shadowLight);
+
+  transition: opacity 150ms ease;
+  transition-property: opacity, transform;
+
+  ${({ $opened }) => ($opened ? visibleCSS : hiddenCSS)};
+`;
+
+type PopupMenuOptionProps = {
+  $active: boolean;
+};
+
+export const OptionStyled = styled.div<PopupMenuOptionProps>`
+  display: flex;
+  align-items: center;
+
+  width: 100%;
+  height: 44px;
+
+  padding: 0 8px;
+  margin: 0;
+  box-sizing: border-box;
+
+  text-align: left;
+  color: var(--lido-color-text);
+  transition: opacity 100ms;
+  cursor: pointer;
+
+  // Fix the highlight by click
+  -webkit-tap-highlight-color: transparent;
+  outline: none;
+
+  // Backgrounds
+  background: var(--lido-color-controlBg);
+
+  ${({ theme, $active }) =>
+    theme.name === 'dark'
+      ? css`
+          background: ${$active && '#34343D'};
+        `
+      : css`
+          background: ${$active && '#000A3D08'};
+        `}
+
+  &:not(:disabled):hover {
+    ${({ theme }) =>
+      theme.name === 'dark'
+        ? css`
+            background: #34343d;
+          `
+        : css`
+            background: #000a3d08;
+          `}
+  }
+
+  // Option.Text
+  & > span {
+    margin-left: 8px;
+
+    font-weight: 400;
+    font-size: 12px;
+    color: #7a8aa0;
+  }
+`;

--- a/shared/components/layout/header/components/chain-switcher/components/select-icon-tooltip/styles.tsx
+++ b/shared/components/layout/header/components/chain-switcher/components/select-icon-tooltip/styles.tsx
@@ -11,6 +11,7 @@ export const SelectIconTooltipWrapper = styled.div`
   left: 0;
   top: calc(100% + 16px);
   width: 244px;
+  z-index: 100;
 
   @media ${devicesHeaderMedia.mobile} {
     position: fixed;
@@ -19,7 +20,6 @@ export const SelectIconTooltipWrapper = styled.div`
     right: 20px;
     top: unset;
     width: auto;
-    z-index: 5000;
   }
 `;
 

--- a/shared/components/layout/header/components/chain-switcher/hooks/use-click-outside.ts
+++ b/shared/components/layout/header/components/chain-switcher/hooks/use-click-outside.ts
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+
+export const useClickOutside = (
+  ref: React.RefObject<HTMLElement>,
+  onClickOutside: () => void,
+) => {
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent | TouchEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        onClickOutside();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('touchstart', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('touchstart', handleClickOutside);
+    };
+  }, [ref, onClickOutside]);
+};

--- a/shared/components/layout/header/components/chain-switcher/styles.tsx
+++ b/shared/components/layout/header/components/chain-switcher/styles.tsx
@@ -1,36 +1,171 @@
 import styled, { css } from 'styled-components';
-import { SelectIcon } from '@lidofinance/lido-ui';
 
-export const SelectIconWrapper = styled.div`
+type SelectProps = {
+  $disabled: boolean;
+};
+
+export const SelectStyled = styled.div<SelectProps>`
+  display: inline-flex;
+  flex-grow: 1;
+  align-items: center;
+  justify-content: space-between;
+
   position: relative;
-`;
+  overflow: ${({ $disabled }) => ($disabled ? 'hidden' : 'visible')};
+  box-sizing: border-box;
 
-export const SelectIconStyled = styled(SelectIcon)`
-  overflow: ${({ disabled }) => (disabled ? 'hidden' : 'visible')};
-  width: ${({ disabled }) => (disabled ? '44px' : '68px')};
+  width: ${({ $disabled }) => ($disabled ? '44px' : '68px')};
   height: 44px;
+  margin-right: 12px;
+  padding: 9px 8px;
 
-  cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
-
-  &:not(:disabled):hover {
-    & > span {
-      ${({ theme, disabled }) =>
-        theme.name === 'dark'
-          ? css`
-              background: ${!disabled && '#34343D'};
-            `
-          : css`
-              background: ${!disabled && '#000A3D08'};
-            `}
-    }
-  }
-
-  & > span {
-    border: 0;
-    padding-left: 8px;
-    padding-right: 14px;
-  }
+  font-weight: 400;
+  font-size: 14px;
+  color: var(--lido-color-text);
 
   border-radius: 10px;
-  margin-right: 12px;
+  transition: border-color 100ms;
+
+  cursor: ${({ $disabled }) => ($disabled ? 'default' : 'pointer')};
+
+  background: var(--lido-color-controlBg);
+
+  &:not(:disabled):hover {
+    ${({ theme, $disabled }) =>
+      theme.name === 'dark'
+        ? css`
+            background: ${!$disabled && '#34343D'};
+          `
+        : css`
+            background: ${!$disabled && '#000A3D08'};
+          `}
+  }
+`;
+
+export const SelectIconStyle = styled.span`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  align-self: stretch;
+  justify-self: stretch;
+`;
+
+type SelectArrowProps = {
+  $opened: boolean;
+};
+
+export const SelectArrowStyle = styled.div<SelectArrowProps>`
+  border: 3px solid currentColor;
+  border-bottom-width: 0;
+  border-left-color: transparent;
+  border-right-color: transparent;
+
+  color: var(--lido-color-text);
+  margin-right: 6px;
+
+  transform: rotate(${({ $opened }) => ($opened ? 180 : 0)}deg);
+  transition: transform ${({ theme }) => theme.duration.norm} ease;
+`;
+
+type PopupMenuProps = {
+  $opened: boolean;
+};
+
+const visibleCSS = css`
+  opacity: 1;
+
+  &[data-placement] {
+    transform: translate(0, 0);
+  }
+`;
+
+const hiddenCSS = css`
+  opacity: 0;
+
+  &[data-placement^='top'] {
+    transform: translateY(6px);
+  }
+  &[data-placement^='right'] {
+    transform: translateX(-6px);
+  }
+  &[data-placement^='bottom'] {
+    transform: translateY(-6px);
+  }
+  &[data-placement^='left'] {
+    transform: translateX(6px);
+  }
+`;
+
+export const PopupMenuStyled = styled.div<PopupMenuProps>`
+  min-width: 146px;
+  z-index: 200;
+
+  position: absolute;
+  top: 48px;
+
+  overflow: auto;
+  overflow-x: hidden;
+  box-sizing: border-box;
+
+  margin: 0;
+  padding: 0;
+
+  background: var(--lido-color-foreground);
+  color: var(--lido-color-text);
+  font-size: ${({ theme }) => theme.fontSizesMap.xs}px;
+  line-height: 1.5em;
+  font-weight: 400;
+
+  border-radius: ${({ theme }) => theme.borderRadiusesMap.lg}px;
+  box-shadow: ${({ theme }) => theme.boxShadows.xs}
+    var(--lido-color-shadowLight);
+
+  transition: opacity 150ms ease;
+  transition-property: opacity, transform;
+
+  ${({ $opened }) => ($opened ? visibleCSS : hiddenCSS)};
+`;
+
+type PopupMenuOptionProps = {
+  $active: boolean;
+};
+
+export const PopupMenuOptionStyled = styled.div<PopupMenuOptionProps>`
+  display: flex;
+  align-items: center;
+
+  width: 100%;
+  height: 44px;
+  
+  padding: 0 15px;
+  margin: 0;
+  box-sizing: border-box;
+
+  text-align: left;
+  color: var(--lido-color-text);
+  
+  transition: opacity 100ms;
+
+  cursor: pointer;
+  
+  background: var(--lido-color-controlBg);
+
+  ${({ theme, $active }) =>
+    theme.name === 'dark'
+      ? css`
+          background: ${$active && '#34343D'};
+        `
+      : css`
+          background: ${$active && '#000A3D08'};
+        `}
+  
+  &:not(:disabled):hover {
+    ${({ theme }) =>
+      theme.name === 'dark'
+        ? css`
+            background: #34343d;
+          `
+        : css`
+            background: #000a3d08;
+          `}
 `;

--- a/shared/components/layout/header/components/chain-switcher/styles.tsx
+++ b/shared/components/layout/header/components/chain-switcher/styles.tsx
@@ -1,5 +1,9 @@
 import styled, { css } from 'styled-components';
 
+export const ChainSwitcherWrapperStyled = styled.div`
+  position: relative;
+`;
+
 export const ChainSwitcherStyled = styled.div<{ $disabled: boolean }>`
   display: inline-flex;
   flex-grow: 1;

--- a/shared/components/layout/header/components/chain-switcher/styles.tsx
+++ b/shared/components/layout/header/components/chain-switcher/styles.tsx
@@ -1,10 +1,6 @@
 import styled, { css } from 'styled-components';
 
-type SelectProps = {
-  $disabled: boolean;
-};
-
-export const SelectStyled = styled.div<SelectProps>`
+export const ChainSwitcherStyled = styled.div<{ $disabled: boolean }>`
   display: inline-flex;
   flex-grow: 1;
   align-items: center;
@@ -25,8 +21,11 @@ export const SelectStyled = styled.div<SelectProps>`
 
   border-radius: 10px;
   transition: border-color 100ms;
+  cursor: ${({ $disabled }) => ($disabled ? 'not-allowed' : 'pointer')};
 
-  cursor: ${({ $disabled }) => ($disabled ? 'default' : 'pointer')};
+  // Fix the highlight by click
+  -webkit-tap-highlight-color: transparent;
+  outline: none;
 
   background: var(--lido-color-controlBg);
 
@@ -42,7 +41,7 @@ export const SelectStyled = styled.div<SelectProps>`
   }
 `;
 
-export const SelectIconStyle = styled.span`
+export const IconStyle = styled.span`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -50,122 +49,14 @@ export const SelectIconStyle = styled.span`
   justify-self: stretch;
 `;
 
-type SelectArrowProps = {
-  $opened: boolean;
-};
-
-export const SelectArrowStyle = styled.div<SelectArrowProps>`
-  border: 3px solid currentColor;
+export const ArrowStyle = styled.div<{ $opened: boolean }>`
+  border: 3px solid #7a8aa0;
   border-bottom-width: 0;
   border-left-color: transparent;
   border-right-color: transparent;
 
-  color: var(--lido-color-text);
   margin-right: 6px;
 
   transform: rotate(${({ $opened }) => ($opened ? 180 : 0)}deg);
   transition: transform ${({ theme }) => theme.duration.norm} ease;
-`;
-
-type PopupMenuProps = {
-  $opened: boolean;
-};
-
-const visibleCSS = css`
-  opacity: 1;
-
-  &[data-placement] {
-    transform: translate(0, 0);
-  }
-`;
-
-const hiddenCSS = css`
-  opacity: 0;
-
-  &[data-placement^='top'] {
-    transform: translateY(6px);
-  }
-  &[data-placement^='right'] {
-    transform: translateX(-6px);
-  }
-  &[data-placement^='bottom'] {
-    transform: translateY(-6px);
-  }
-  &[data-placement^='left'] {
-    transform: translateX(6px);
-  }
-`;
-
-export const PopupMenuStyled = styled.div<PopupMenuProps>`
-  min-width: 146px;
-  z-index: 200;
-
-  position: absolute;
-  top: 48px;
-
-  overflow: auto;
-  overflow-x: hidden;
-  box-sizing: border-box;
-
-  margin: 0;
-  padding: 0;
-
-  background: var(--lido-color-foreground);
-  color: var(--lido-color-text);
-  font-size: ${({ theme }) => theme.fontSizesMap.xs}px;
-  line-height: 1.5em;
-  font-weight: 400;
-
-  border-radius: ${({ theme }) => theme.borderRadiusesMap.lg}px;
-  box-shadow: ${({ theme }) => theme.boxShadows.xs}
-    var(--lido-color-shadowLight);
-
-  transition: opacity 150ms ease;
-  transition-property: opacity, transform;
-
-  ${({ $opened }) => ($opened ? visibleCSS : hiddenCSS)};
-`;
-
-type PopupMenuOptionProps = {
-  $active: boolean;
-};
-
-export const PopupMenuOptionStyled = styled.div<PopupMenuOptionProps>`
-  display: flex;
-  align-items: center;
-
-  width: 100%;
-  height: 44px;
-  
-  padding: 0 15px;
-  margin: 0;
-  box-sizing: border-box;
-
-  text-align: left;
-  color: var(--lido-color-text);
-  
-  transition: opacity 100ms;
-
-  cursor: pointer;
-  
-  background: var(--lido-color-controlBg);
-
-  ${({ theme, $active }) =>
-    theme.name === 'dark'
-      ? css`
-          background: ${$active && '#34343D'};
-        `
-      : css`
-          background: ${$active && '#000A3D08'};
-        `}
-  
-  &:not(:disabled):hover {
-    ${({ theme }) =>
-      theme.name === 'dark'
-        ? css`
-            background: #34343d;
-          `
-        : css`
-            background: #000a3d08;
-          `}
 `;

--- a/shared/hooks/txCost.ts
+++ b/shared/hooks/txCost.ts
@@ -3,8 +3,9 @@ import { useMemo } from 'react';
 import { useMaxGasPrice } from 'modules/web3';
 import { useEthUsd } from './use-eth-usd';
 
-export const useTxCostInUsd = (gasLimit?: BigNumber) => {
-  const { maxGasPrice, ...gasSwr } = useMaxGasPrice();
+export const useTxCostInUsd = (gasLimit?: BigNumber, chainIdForce?: number) => {
+  const { maxGasPrice, ...gasSwr } = useMaxGasPrice(chainIdForce);
+
   const ethAmount = useMemo(
     () => (maxGasPrice && gasLimit ? maxGasPrice.mul(gasLimit) : undefined),
     [gasLimit, maxGasPrice],


### PR DESCRIPTION
### Description

refactor: remake the ChainSwitcher to own code

**if the ChainType not matched:**
- refactor: show the allowance any way (also not connected wallet)
- refactor(wrap): show the 'stats'
- refactor(unwrap): show the 'stats'

### Demo

**remake the ChainSwitcher to own code**
<img width="384" alt="image" src="https://github.com/user-attachments/assets/c4654f95-9fbd-4c2a-947b-5b87167122f2">

<img width="330" alt="image" src="https://github.com/user-attachments/assets/0658975f-ac69-4935-8fcd-3e0f0c05655a">


---

**Wallet is any supported ETH chain, widget switcher on Optimism type (tx for Optimism)**
<img width="769" alt="image" src="https://github.com/user-attachments/assets/0ab9a1b6-8500-4353-bab6-617e770a773a">

<img width="757" alt="image" src="https://github.com/user-attachments/assets/1ecb3bf1-fd08-46b0-b42b-438a719b3985">

---

**Wallet is any supported Optimism chain, widget switcher on ETH type (tx for ETH)**
<img width="716" alt="image" src="https://github.com/user-attachments/assets/9e278b0d-65f8-43dc-acbb-a725d4fd0233">

<img width="739" alt="image" src="https://github.com/user-attachments/assets/c870d077-a36c-4862-9dd2-fe21fe824ea6">

---
**Wallet is not connected**
<img width="876" alt="image" src="https://github.com/user-attachments/assets/014f7866-30b0-4759-a969-fdaafddb8543">

<img width="884" alt="image" src="https://github.com/user-attachments/assets/4b70297c-bf00-45f9-805d-2af6c7ddf412">






### Code review notes

Based on the https://github.com/lidofinance/ethereum-staking-widget/pull/510

See the 'chainTypeChainId' and the 'isChainTypeOnL2' in the 'useDappChain'

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
