### PR TITLE
[WIP] new page settings in IPFS.json

### DIFF
--- a/IPFS.json
+++ b/IPFS.json
@@ -36,6 +36,14 @@
       "multiChainBanner": [],
       "featureFlags": {
         "ledgerLiveL2": true
+      },
+      "pages": {
+        "/withdrawals": {
+          "deactivate": true
+        },
+        "/rewards": {
+          "deactivate": true
+        }
       }
     }
   }

--- a/config/external-config/index.ts
+++ b/config/external-config/index.ts
@@ -4,4 +4,5 @@ export type {
   Manifest,
   ManifestEntry,
   ExternalConfig,
+  ManifestConfigPage,
 } from './types';

--- a/config/external-config/types.ts
+++ b/config/external-config/types.ts
@@ -16,7 +16,15 @@ export type ManifestConfig = {
   featureFlags: {
     ledgerLiveL2?: boolean;
   };
+  pages?: {
+    [page in ManifestConfigPage]?: {
+      deactivate?: boolean;
+      sections?: [string, ...string[]];
+    };
+  };
 };
+
+export type ManifestConfigPage = '/' | '/wrap' | '/withdrawals' | '/rewards';
 
 export type ExternalConfig = Omit<ManifestEntry, 'config'> &
   ManifestConfig & {

--- a/config/external-config/utils.ts
+++ b/config/external-config/utils.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import type { Manifest, ManifestEntry } from './types';
+import { Manifest, ManifestConfig, ManifestEntry } from './types';
 import { getDexConfig } from 'features/withdrawals/request/withdrawal-rates';
 
 import FallbackLocalManifest from 'IPFS.json' assert { type: 'json' };
@@ -81,6 +81,7 @@ export const getBackwardCompatibleConfig = (
     ),
     featureFlags: { ...(config.featureFlags ?? {}) },
     multiChainBanner: config.multiChainBanner ?? [],
+    pages: config.pages ?? ({} as ManifestConfig['pages']),
   };
 };
 

--- a/consts/external-links.ts
+++ b/consts/external-links.ts
@@ -7,4 +7,6 @@ export const OPEN_OCEAN_REFERRAL_ADDRESS =
 
 // for dev and local testing you can set to 'http://localhost:3000/runtime/IPFS.json' and have file at /public/runtime/IPFS.json
 export const IPFS_MANIFEST_URL =
-  'https://raw.githubusercontent.com/lidofinance/ethereum-staking-widget/main/IPFS.json';
+  process.env.NODE_ENV === 'development'
+    ? 'http://localhost:3000/runtime/IPFS.json'
+    : 'https://raw.githubusercontent.com/lidofinance/ethereum-staking-widget/main/IPFS.json';

--- a/shared/components/layout/header/components/navigation/navigation.tsx
+++ b/shared/components/layout/header/components/navigation/navigation.tsx
@@ -1,4 +1,4 @@
-import { FC, memo } from 'react';
+import { FC, memo, useMemo } from 'react';
 import { Wallet, Stake, Wrap, Withdraw } from '@lidofinance/lido-ui';
 
 import {
@@ -9,12 +9,23 @@ import {
   REWARDS_PATH,
   getPathWithoutFirstSlash,
 } from 'consts/urls';
+import { useConfig } from 'config';
+import { ManifestConfigPage } from 'config/external-config';
 import { LocalLink } from 'shared/components/local-link';
 import { useRouterPath } from 'shared/hooks/use-router-path';
 
 import { Nav, NavLink } from './styles';
 
-const routes = [
+type PageRoute = {
+  name: string;
+  path: string;
+  icon: React.ReactNode;
+  exact?: boolean;
+  full_path?: string;
+  subPaths?: string[];
+};
+
+const routes: PageRoute[] = [
   {
     name: 'Stake',
     path: HOME_PATH,
@@ -39,8 +50,24 @@ const routes = [
     icon: <Wallet data-testid="navRewards" />,
   },
 ];
+
 export const Navigation: FC = memo(() => {
   const pathname = useRouterPath();
+  const {
+    externalConfig: { pages },
+  } = useConfig();
+
+  const availableRoutes = useMemo(() => {
+    if (!pages) return routes;
+
+    const paths = Object.keys(pages) as ManifestConfigPage[];
+    return routes.filter((route) => {
+      const path = paths.find((path) => route.path.includes(path));
+      if (!path) return true;
+      return !pages[path]?.deactivate;
+    });
+  }, [pages]);
+
   let pathnameWithoutQuery = pathname.split('?')[0];
   if (pathnameWithoutQuery[pathnameWithoutQuery.length - 1] === '/') {
     // Remove last '/'
@@ -49,7 +76,7 @@ export const Navigation: FC = memo(() => {
 
   return (
     <Nav>
-      {routes.map(({ name, path, subPaths, icon }) => {
+      {availableRoutes.map(({ name, path, subPaths, icon }) => {
         const isActive =
           pathnameWithoutQuery === getPathWithoutFirstSlash(path) ||
           (path.length > 1 && pathnameWithoutQuery.startsWith(path)) ||

--- a/shared/components/layout/layout.tsx
+++ b/shared/components/layout/layout.tsx
@@ -1,11 +1,15 @@
 import { ReactNode, FC, PropsWithChildren } from 'react';
 
 import { ContainerProps } from '@lidofinance/lido-ui';
+import { useRouter } from 'next/router';
+import { useRouterPath } from 'shared/hooks/use-router-path';
 
-import { config } from 'config';
+import { config, useConfig } from 'config';
+import { ManifestConfigPage } from 'config/external-config';
+import { HOME_PATH } from 'consts/urls';
 
+import { LayoutEffectSsrDelayed } from 'shared/components/layout-effect-ssr-delayed';
 import { IPFSInfoBox } from 'features/ipfs/ipfs-info-box';
-
 import { Header } from './header/header';
 import { Footer } from './footer/footer';
 import { Main } from './main/main';
@@ -24,10 +28,24 @@ type Props = {
 export const Layout: FC<PropsWithChildren<Props>> = (props) => {
   const { title, subtitle, containerSize } = props;
   const { children } = props;
+  const router = useRouter();
+  const path = useRouterPath();
+  const { pages } = useConfig().externalConfig;
+
+  const checkPathEffect = () => {
+    if (pages) {
+      const paths = Object.keys(pages) as ManifestConfigPage[];
+      const forbiddenPath = paths.find((pathKey) => path.includes(pathKey));
+      if (forbiddenPath && pages[forbiddenPath]?.deactivate) {
+        void router.push(HOME_PATH);
+      }
+    }
+  };
 
   return (
     <>
       <Header />
+      <LayoutEffectSsrDelayed effect={checkPathEffect} deps={[pages]} />
       <Main size={containerSize}>
         {config.ipfsMode && (
           <IPFSInfoBoxOnlyMobileAndPortableWrapper>


### PR DESCRIPTION
### Description

Added a new pages section in IPFS.json config section
Initial pages structure
```
  // Describe current pages
  type ManifestConfigPage = '/' | '/wrap' | '/withdrawals' | '/rewards';
  
  // IPFS.json structure
  pages?: {
    [page in ManifestConfigPage]?: {
      deactivate?: boolean;
      sections?: [string, ...string[]];
    };
  }
```
**deactivate** - describes page availability state, default `false` and page is shown
**sections** - describes which page's sections are available, default all sections are available

**Note**: current updates impact on Sepolia network

### Testing notes

For local testing, set default chain to `11155111`

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
