### PR TITLE
fix: update Ledger Live error handling

### DIFF
--- a/utils/getErrorMessage.ts
+++ b/utils/getErrorMessage.ts
@@ -84,21 +84,10 @@ export const extractCodeFromError = (
       normalizedMessage.includes('rejected the request') ||
       normalizedMessage.includes('reject this request') ||
       normalizedMessage.includes('rejected methods') ||
-      normalizedMessage.includes('transaction declined')
+      normalizedMessage.includes('transaction declined') ||
+      normalizedMessage.includes('signed declined')
     )
       return 'ACTION_REJECTED';
-  }
-
-  // Ledger live errors
-  if (
-    'data' in error &&
-    typeof error.data === 'object' &&
-    Array.isArray(error.data) &&
-    typeof error.data['0'] === 'object' &&
-    typeof error.data['0'].message === 'string' &&
-    error.data['0'].message.toLowerCase().includes('rejected')
-  ) {
-    return 'ACTION_REJECTED';
   }
 
   if ('name' in error && typeof error.name == 'string') {


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

 - handle permit signing reject(due to user or blind signing off) for Ledger Live
 - no way to determine user or blind sign reject( but better than not enough ether for gas
 - should be resolved once Ledger deploys permits metadata for stETH and wstETH

### Demo
<img width="532" alt="image" src="https://github.com/user-attachments/assets/d90775b7-34ec-493b-af2c-a4b22e0a7126">

### Code review notes

<!--- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

<!--- List all possible edge cases and how to test them. -->

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
