### PR TITLE
refactor: split the SDK provider to 2 providers (L1 and L2) 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY package.json yarn.lock ./
 
 RUN yarn install --frozen-lockfile --non-interactive --ignore-scripts && yarn cache clean
 COPY . .
-RUN NODE_NO_BUILD_DYNAMICS=true yarn typechain && yarn build
+RUN NODE_NO_BUILD_DYNAMICS=true yarn build
 # public/runtime is used to inject runtime vars; it should exist and user node should have write access there for it
 RUN rm -rf /app/public/runtime && mkdir /app/public/runtime && chown node /app/public/runtime
 

--- a/features/wsteth/unwrap/hooks/use-unwrap-form-processing.ts
+++ b/features/wsteth/unwrap/hooks/use-unwrap-form-processing.ts
@@ -5,7 +5,7 @@ import invariant from 'tiny-invariant';
 
 import { TransactionCallbackStage } from '@lidofinance/lido-ethereum-sdk/core';
 
-import { useLidoSDK, useDappStatus } from 'modules/web3';
+import { useDappStatus, useLidoSDK, useLidoSDKL2 } from 'modules/web3';
 
 import type { UnwrapFormInputType } from '../unwrap-form-context';
 import { useUnwrapTxOnL2Approve } from './use-unwrap-tx-on-l2-approve';
@@ -26,7 +26,8 @@ export const useUnwrapFormProcessor = ({
 }: UseUnwrapFormProcessorArgs) => {
   const { isDappActiveOnL2, address } = useDappStatus();
   const { txModalStages } = useTxModalStagesUnwrap();
-  const { l2, stETH, wrap, isL2 } = useLidoSDK();
+  const { stETH, wrap } = useLidoSDK();
+  const { l2, isL2 } = useLidoSDKL2();
 
   const {
     isApprovalNeededBeforeUnwrap: isApprovalNeededBeforeUnwrapOnL2,

--- a/features/wsteth/unwrap/hooks/use-unwrap-gas-limit.ts
+++ b/features/wsteth/unwrap/hooks/use-unwrap-gas-limit.ts
@@ -2,16 +2,22 @@ import { useQuery } from '@tanstack/react-query';
 import { config } from 'config';
 import { UNWRAP_GAS_LIMIT, UNWRAP_L2_GAS_LIMIT } from 'consts/tx';
 import { STRATEGY_LAZY } from 'consts/react-query-strategies';
-import { useLidoSDK, useDappStatus, ESTIMATE_AMOUNT } from 'modules/web3';
+import {
+  useLidoSDK,
+  useDappStatus,
+  ESTIMATE_AMOUNT,
+  useLidoSDKL2,
+} from 'modules/web3';
 
 export const useUnwrapGasLimit = () => {
-  const { isDappActiveOnL2 } = useDappStatus();
-  const { l2, isL2, wrap, core } = useLidoSDK();
+  const { chainId, isDappActiveOnL2 } = useDappStatus();
+  const { wrap } = useLidoSDK();
+  const { l2, isL2 } = useLidoSDKL2();
 
   const fallback = isDappActiveOnL2 ? UNWRAP_L2_GAS_LIMIT : UNWRAP_GAS_LIMIT;
 
   const { data } = useQuery<bigint>({
-    queryKey: ['unwrap-gas-limit', isDappActiveOnL2, core.chainId],
+    queryKey: ['unwrap-gas-limit', isDappActiveOnL2, chainId],
     ...STRATEGY_LAZY,
     queryFn: async () => {
       try {

--- a/features/wsteth/unwrap/hooks/use-unwrap-tx-on-l2-approve.ts
+++ b/features/wsteth/unwrap/hooks/use-unwrap-tx-on-l2-approve.ts
@@ -3,7 +3,7 @@ import { useMemo, useCallback } from 'react';
 import { LIDO_L2_CONTRACT_ADDRESSES } from '@lidofinance/lido-ethereum-sdk/common';
 import { TransactionCallbackStage } from '@lidofinance/lido-ethereum-sdk/core';
 
-import { useLidoSDK, useDappStatus, useAllowance } from 'modules/web3';
+import { useLidoSDKL2, useDappStatus, useAllowance } from 'modules/web3';
 
 import { useTxModalWrap } from '../../wrap/hooks/use-tx-modal-stages-wrap';
 import { TOKENS_TO_WRAP } from '../../shared/types';
@@ -14,7 +14,7 @@ type UseUnwrapTxApproveArgs = {
 
 export const useUnwrapTxOnL2Approve = ({ amount }: UseUnwrapTxApproveArgs) => {
   const { isDappActiveOnL2, isChainTypeOnL2, address } = useDappStatus();
-  const { core, l2 } = useLidoSDK();
+  const { l2, core } = useLidoSDKL2();
   const { txModalStages } = useTxModalWrap();
 
   const staticTokenAddress = LIDO_L2_CONTRACT_ADDRESSES[core.chainId]?.wsteth;

--- a/features/wsteth/wrap/hooks/use-approve-gas-limit.tsx
+++ b/features/wsteth/wrap/hooks/use-approve-gas-limit.tsx
@@ -6,18 +6,24 @@ import {
 } from 'consts/tx';
 import { STRATEGY_LAZY } from 'consts/react-query-strategies';
 
-import { useLidoSDK, useDappStatus, ESTIMATE_AMOUNT } from 'modules/web3';
+import {
+  useLidoSDK,
+  useLidoSDKL2,
+  useDappStatus,
+  ESTIMATE_AMOUNT,
+} from 'modules/web3';
 
 export const useApproveGasLimit = () => {
-  const { isDappActiveOnL2 } = useDappStatus();
-  const { l2, stETH, isL2, wstETH, core } = useLidoSDK();
+  const { chainId, isDappActiveOnL2 } = useDappStatus();
+  const { stETH, wstETH } = useLidoSDK();
+  const { l2, isL2 } = useLidoSDKL2();
 
   const fallback = isDappActiveOnL2
     ? STETH_L2_APPROVE_GAS_LIMIT
     : WSTETH_APPROVE_GAS_LIMIT;
 
   const { data } = useQuery<bigint | undefined>({
-    queryKey: ['approve-wrap-gas-limit', isDappActiveOnL2, core.chainId],
+    queryKey: ['approve-wrap-gas-limit', isDappActiveOnL2, chainId],
     ...STRATEGY_LAZY,
     queryFn: async () => {
       try {

--- a/features/wsteth/wrap/hooks/use-wrap-form-processing.ts
+++ b/features/wsteth/wrap/hooks/use-wrap-form-processing.ts
@@ -6,7 +6,7 @@ import { TransactionCallbackStage } from '@lidofinance/lido-ethereum-sdk/core';
 
 import { config } from 'config';
 import { MockLimitReachedError } from 'features/stake/stake-form/utils';
-import { useDappStatus, useLidoSDK } from 'modules/web3';
+import { useDappStatus, useLidoSDK, useLidoSDKL2 } from 'modules/web3';
 
 import type {
   WrapFormApprovalData,
@@ -27,7 +27,8 @@ export const useWrapFormProcessor = ({
   onRetry,
 }: UseWrapFormProcessorArgs) => {
   const { isDappActiveOnL2, address } = useDappStatus();
-  const { l2, wrap, wstETH } = useLidoSDK();
+  const { wrap, wstETH } = useLidoSDK();
+  const { l2 } = useLidoSDKL2();
   const { txModalStages } = useTxModalWrap();
 
   const {

--- a/features/wsteth/wrap/hooks/use-wrap-form-validation-context.ts
+++ b/features/wsteth/wrap/hooks/use-wrap-form-validation-context.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useDappStatus, useLidoSDK } from 'modules/web3';
+import { useDappStatus, useLidoSDKL2 } from 'modules/web3';
 import { useAwaiter } from 'shared/hooks/use-awaiter';
 
 import type {
@@ -15,8 +15,8 @@ type UseWrapFormValidationContextArgs = {
 export const useWrapFormValidationContext = ({
   networkData,
 }: UseWrapFormValidationContextArgs): WrapFormValidationContext => {
-  const { isL2 } = useLidoSDK();
   const { isDappActive } = useDappStatus();
+  const { isL2 } = useLidoSDKL2();
 
   const {
     stakeLimitInfo,

--- a/features/wsteth/wrap/hooks/use-wrap-gas-limit.ts
+++ b/features/wsteth/wrap/hooks/use-wrap-gas-limit.ts
@@ -9,7 +9,12 @@ import {
   WRAP_L2_GAS_LIMIT,
 } from 'consts/tx';
 import { applyGasLimitRatio } from 'utils/apply-gas-limit-ratio';
-import { useDappStatus, useLidoSDK, ESTIMATE_AMOUNT } from 'modules/web3';
+import {
+  useDappStatus,
+  useLidoSDK,
+  useLidoSDKL2,
+  ESTIMATE_AMOUNT,
+} from 'modules/web3';
 
 const fetchGasLimitETH = async (isL2: boolean, wrap: LidoSDKWrap) => {
   if (isL2) return 0n;
@@ -53,8 +58,9 @@ const fetchGasLimitStETH = async (
 };
 
 export const useWrapGasLimit = () => {
-  const { isDappActiveOnL2 } = useDappStatus();
-  const { l2, isL2, wrap, core } = useLidoSDK();
+  const { chainId, isDappActiveOnL2 } = useDappStatus();
+  const { wrap } = useLidoSDK();
+  const { l2, isL2 } = useLidoSDKL2();
 
   const wrapFallback = isDappActiveOnL2 ? WRAP_L2_GAS_LIMIT : WRAP_GAS_LIMIT;
 
@@ -62,7 +68,7 @@ export const useWrapGasLimit = () => {
     gasLimitETH: bigint;
     gasLimitStETH: bigint;
   }>({
-    queryKey: ['wrap-gas-limit', core.chainId, isL2],
+    queryKey: ['wrap-gas-limit', chainId, isL2],
     ...STRATEGY_EAGER,
     queryFn: async () => {
       const [gasLimitETH, gasLimitStETH] = await Promise.all([

--- a/modules/web3/hooks/use-balance.ts
+++ b/modules/web3/hooks/use-balance.ts
@@ -9,10 +9,8 @@ import {
   useAccount,
 } from 'wagmi';
 
-import { useLidoSDK } from 'modules/web3';
+import { useDappStatus, useLidoSDK, useLidoSDKL2 } from 'modules/web3';
 import { config } from 'config';
-
-import { useDappStatus } from './use-dapp-status';
 
 import type { Address, WatchContractEventOnLogsFn } from 'viem';
 import type { GetBalanceData } from 'wagmi/query';
@@ -233,13 +231,15 @@ export const useStethBalance = ({
   account,
   shouldSubscribeToUpdates = true,
 }: UseBalanceProps = {}) => {
-  const { core, l2, stETH, isL2 } = useLidoSDK();
+  const { chainId } = useDappStatus();
+  const { stETH } = useLidoSDK();
+  const { l2, isL2 } = useLidoSDKL2();
   const { isSupportedChain, address } = useDappStatus();
 
   const mergedAccount = account ?? address;
 
   const { data: contract, isLoading } = useQuery({
-    queryKey: ['steth-contract', core.chainId, isL2],
+    queryKey: ['steth-contract', chainId, isL2],
     enabled: !!mergedAccount && isSupportedChain,
 
     staleTime: Infinity,
@@ -265,19 +265,15 @@ export const useWstethBalance = ({
 }: UseBalanceProps = {}) => {
   const { isSupportedChain, address } = useDappStatus();
   const mergedAccount = account ?? address;
-  const {
-    core: lidoSDKCore,
-    l2: lidoSDKL2,
-    wstETH: lidoSDKwstETH,
-    isL2,
-  } = useLidoSDK();
+  const { chainId } = useDappStatus();
+  const { wstETH } = useLidoSDK();
+  const { l2, isL2 } = useLidoSDKL2();
 
   const { data: contract, isLoading } = useQuery({
-    queryKey: ['wsteth-contract', lidoSDKCore.chainId, isL2],
+    queryKey: ['wsteth-contract', chainId, isL2],
     enabled: !!mergedAccount && isSupportedChain,
     staleTime: Infinity,
-    queryFn: () =>
-      isL2 ? lidoSDKL2.wsteth.getContract() : lidoSDKwstETH.getContract(),
+    queryFn: () => (isL2 ? l2.wsteth.getContract() : wstETH.getContract()),
   });
 
   const balanceData = useTokenBalance(

--- a/modules/web3/hooks/use-contract-address.ts
+++ b/modules/web3/hooks/use-contract-address.ts
@@ -7,12 +7,13 @@ import type {
 import { LIDO_L2_CONTRACT_ADDRESSES } from '@lidofinance/lido-ethereum-sdk/common';
 
 import { STRATEGY_CONSTANT } from 'consts/react-query-strategies';
-import { useLidoSDK } from 'modules/web3';
+import { useLidoSDK, useLidoSDKL2 } from 'modules/web3';
 
 export const useContractAddress = (
   contractName: LIDO_CONTRACT_NAMES | LIDO_L2_CONTRACT_NAMES,
 ) => {
-  const { isL2, core } = useLidoSDK();
+  const { core } = useLidoSDK();
+  const { isL2 } = useLidoSDKL2();
 
   return useQuery<Address | null>({
     queryKey: ['use-contract-address', core.chainId, isL2, contractName],

--- a/modules/web3/hooks/use-stETH-by-wstETH.ts
+++ b/modules/web3/hooks/use-stETH-by-wstETH.ts
@@ -1,8 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
-import { useLidoSDK } from 'modules/web3';
+import { useDappStatus, useLidoSDK, useLidoSDKL2 } from 'modules/web3';
 
 export const useStETHByWstETH = (wsteth?: bigint | null) => {
-  const { isL2, l2, wrap, chainId } = useLidoSDK();
+  const { chainId } = useDappStatus();
+  const { wrap } = useLidoSDK();
+  const { l2, isL2 } = useLidoSDKL2();
 
   return useQuery({
     queryKey: ['use-steth-by-wsteth', wsteth?.toString(), isL2, chainId],

--- a/modules/web3/hooks/use-steth-contract-address.ts
+++ b/modules/web3/hooks/use-steth-contract-address.ts
@@ -1,8 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
-import { useLidoSDK } from 'modules/web3';
+import { useLidoSDK, useLidoSDKL2 } from 'modules/web3';
 
 export const useStETHContractAddress = () => {
-  const { stETH, l2, isL2 } = useLidoSDK();
+  const { stETH } = useLidoSDK();
+  const { l2, isL2 } = useLidoSDKL2();
 
   return useQuery({
     queryKey: ['use-steth-contract-address', isL2, l2.steth, stETH],

--- a/modules/web3/hooks/use-wstETH-by-stETH.ts
+++ b/modules/web3/hooks/use-wstETH-by-stETH.ts
@@ -1,8 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
-import { useLidoSDK } from 'modules/web3';
+import { useLidoSDK, useLidoSDKL2 } from 'modules/web3';
 
 export const useWstethBySteth = (steth?: bigint | null) => {
-  const { isL2, l2, wrap, chainId } = useLidoSDK();
+  const { wrap, chainId } = useLidoSDK();
+  const { l2, isL2 } = useLidoSDKL2();
 
   return useQuery({
     queryKey: ['use-wsteth-by-steth', steth?.toString(), isL2, chainId],

--- a/modules/web3/hooks/use-wsteth-contract-address.ts
+++ b/modules/web3/hooks/use-wsteth-contract-address.ts
@@ -1,8 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
-import { useLidoSDK } from 'modules/web3';
+import { useLidoSDK, useLidoSDKL2 } from 'modules/web3';
 
 export const useWstETHContractAddress = () => {
-  const { wstETH, l2, isL2 } = useLidoSDK();
+  const { wstETH } = useLidoSDK();
+  const { l2, isL2 } = useLidoSDKL2();
 
   return useQuery({
     queryKey: ['use-wsteth-contract-address', isL2, l2.wsteth, wstETH],

--- a/modules/web3/index.ts
+++ b/modules/web3/index.ts
@@ -5,6 +5,7 @@ export {
   Web3Provider,
   useWagmiMainnetOnlyConfig,
   useLidoSDK,
+  useLidoSDKL2,
   SupportL2Chains,
   DAPP_CHAIN_TYPE,
 } from './web3-provider';

--- a/modules/web3/web3-provider/dapp-chain.tsx
+++ b/modules/web3/web3-provider/dapp-chain.tsx
@@ -7,6 +7,7 @@ import React, {
 } from 'react';
 import invariant from 'tiny-invariant';
 import { LidoSDKProvider } from './lido-sdk';
+import { LidoSDKL2Provider } from './lido-sdk-l2';
 
 import { CHAINS, isSDKSupportedL2Chain } from 'consts/chains';
 import { useAccount } from 'wagmi';
@@ -167,7 +168,7 @@ export const SupportL2Chains: React.FC<React.PropsWithChildren> = ({
         [chainType, walletChainId],
       )}
     >
-      <LidoSDKProvider>{children}</LidoSDKProvider>
+      <LidoSDKL2Provider>{children}</LidoSDKL2Provider>
     </DappChainContext.Provider>
   );
 };
@@ -191,6 +192,22 @@ export const SupportL1Chains: React.FC<React.PropsWithChildren> = ({
   children,
 }) => (
   <DappChainContext.Provider value={onlyL1ChainsValue}>
-    <LidoSDKProvider>{children}</LidoSDKProvider>
+    <LidoSDKProvider>
+      {/*
+        Note that LidoSDKL2Provider will actually be used inside SupportL2Chains.
+        But why is there a LidoSDKL2Provider here too?
+
+        We have common hooks that use both useLidoSDK (L1) and useLidoSDKL2 hooks.
+        In fact, this is needed so that common hooks do not fail with the invariant
+        when calling useLidoSDKL2 from LidoSDKL2Provider.
+
+        Inside this LidoSDKL2Provider there will be a chainID from L1,
+        but this will not cause an error until you try to perform any operation with the wrong network
+        (you can use isL2 to avoid this).
+
+        For React, nesting the same providers into each other is an acceptable situation.
+      */}
+      <LidoSDKL2Provider>{children}</LidoSDKL2Provider>
+    </LidoSDKProvider>
   </DappChainContext.Provider>
 );

--- a/modules/web3/web3-provider/index.ts
+++ b/modules/web3/web3-provider/index.ts
@@ -1,3 +1,4 @@
 export { Web3Provider, useWagmiMainnetOnlyConfig } from './web3-provider';
 export { useLidoSDK } from './lido-sdk';
+export { useLidoSDKL2 } from './lido-sdk-l2';
 export { SupportL2Chains, DAPP_CHAIN_TYPE } from './dapp-chain';

--- a/modules/web3/web3-provider/lido-sdk-l2.tsx
+++ b/modules/web3/web3-provider/lido-sdk-l2.tsx
@@ -1,0 +1,53 @@
+import { createContext, useContext, useMemo } from 'react';
+import invariant from 'tiny-invariant';
+import { usePublicClient, useWalletClient } from 'wagmi';
+
+import { LIDO_L2_CONTRACT_ADDRESSES } from '@lidofinance/lido-ethereum-sdk/common';
+import { CHAINS, LidoSDKCore } from '@lidofinance/lido-ethereum-sdk/core';
+import { LidoSDKL2 } from '@lidofinance/lido-ethereum-sdk/l2';
+
+import { useDappChain } from './dapp-chain';
+
+type LidoSDKL2ContextValue = {
+  chainId: CHAINS;
+  core: LidoSDKCore;
+  l2: LidoSDKL2;
+  isL2: boolean;
+};
+
+const LidoSDKL2Context = createContext<LidoSDKL2ContextValue | null>(null);
+LidoSDKL2Context.displayName = 'LidoSDKL2Context';
+
+export const useLidoSDKL2 = () => {
+  const value = useContext(LidoSDKL2Context);
+  invariant(value, 'useLidoSDKL2 was used outside of LidoSDKL2Provider');
+  return value;
+};
+
+export const LidoSDKL2Provider = ({ children }: React.PropsWithChildren) => {
+  const { chainId } = useDappChain();
+  const { data: walletClient } = useWalletClient({ chainId });
+  const publicClient = usePublicClient({ chainId });
+
+  const contextValue = useMemo(() => {
+    // @ts-expect-error: typing (viem + LidoSDK)
+    const core = new LidoSDKCore({
+      chainId,
+      logMode: 'none',
+      rpcProvider: publicClient,
+      web3Provider: walletClient,
+    });
+
+    return {
+      chainId: core.chainId,
+      core,
+      l2: new LidoSDKL2({ core }),
+      isL2: !!LIDO_L2_CONTRACT_ADDRESSES[chainId as CHAINS],
+    };
+  }, [chainId, publicClient, walletClient]);
+  return (
+    <LidoSDKL2Context.Provider value={contextValue}>
+      {children}
+    </LidoSDKL2Context.Provider>
+  );
+};

--- a/modules/web3/web3-provider/lido-sdk.tsx
+++ b/modules/web3/web3-provider/lido-sdk.tsx
@@ -8,14 +8,12 @@ import {
   useWalletClient,
 } from 'wagmi';
 
-import { LIDO_L2_CONTRACT_ADDRESSES } from '@lidofinance/lido-ethereum-sdk/common';
 import { LidoSDKStake } from '@lidofinance/lido-ethereum-sdk/stake';
 import { CHAINS, LidoSDKCore } from '@lidofinance/lido-ethereum-sdk/core';
 import {
   LidoSDKstETH,
   LidoSDKwstETH,
 } from '@lidofinance/lido-ethereum-sdk/erc20';
-import { LidoSDKL2 } from '@lidofinance/lido-ethereum-sdk/l2';
 import { LidoSDKWrap } from '@lidofinance/lido-ethereum-sdk/wrap';
 import { LidoSDKWithdraw } from '@lidofinance/lido-ethereum-sdk/withdraw';
 import { LidoSDKStatistics } from '@lidofinance/lido-ethereum-sdk/statistics';
@@ -25,16 +23,14 @@ import { useTokenTransferSubscription } from 'modules/web3/hooks/use-balance';
 import { useDappChain } from './dapp-chain';
 
 type LidoSDKContextValue = {
+  chainId: CHAINS;
   core: LidoSDKCore;
   stake: LidoSDKStake;
   stETH: LidoSDKstETH;
   wstETH: LidoSDKwstETH;
-  l2: LidoSDKL2;
   wrap: LidoSDKWrap;
   withdraw: LidoSDKWithdraw;
   statistics: LidoSDKStatistics;
-  chainId: CHAINS;
-  isL2: boolean;
   subscribeToTokenUpdates: ReturnType<typeof useTokenTransferSubscription>;
 };
 
@@ -87,21 +83,19 @@ export const LidoSDKProvider = ({ children }: React.PropsWithChildren) => {
     const wstETH = new LidoSDKwstETH({ core });
     const wrap = new LidoSDKWrap({ core });
     const withdraw = new LidoSDKWithdraw({ core });
-    const l2 = new LidoSDKL2({ core });
     const statistics = new LidoSDKStatistics({ core });
 
     return {
+      chainId: core.chainId,
       core,
       stake,
       stETH,
       wstETH,
       wrap,
       withdraw,
-      l2,
       statistics,
-      chainId: core.chainId,
-      isL2: !!LIDO_L2_CONTRACT_ADDRESSES[chainId as CHAINS],
       subscribeToTokenUpdates: subscribe,
+      // the L2 module you can to find in the 'modules/web3/web3-provider/lido-sdk-l2.tsx'
     };
   }, [chainId, publicClient, subscribe, walletClient]);
   return (

--- a/shared/hooks/use-token-address.ts
+++ b/shared/hooks/use-token-address.ts
@@ -10,11 +10,12 @@ import { LidoSDKCore } from '@lidofinance/lido-ethereum-sdk/core';
 import { useQuery } from '@tanstack/react-query';
 
 import { STRATEGY_CONSTANT } from 'consts/react-query-strategies';
-import { useLidoSDK } from 'modules/web3';
+import { useDappStatus, useLidoSDK, useLidoSDKL2 } from 'modules/web3';
 
 const fetchTokenAddress = async (
   token: string,
   core: LidoSDKCore,
+  chainId: CHAINS,
   isL2: boolean,
 ): Promise<Address> => {
   if (isL2) {
@@ -34,13 +35,15 @@ const fetchTokenAddress = async (
 };
 
 export const useTokenAddress = (token: string): Address | undefined => {
-  const { core, isL2 } = useLidoSDK();
+  const { chainId } = useDappStatus();
+  const { core } = useLidoSDK();
+  const { isL2 } = useLidoSDKL2();
 
   const { data: address } = useQuery({
-    queryKey: ['tokenAddress', token, core, isL2],
+    queryKey: ['tokenAddress', token, core, chainId, isL2],
     enabled: !!token,
     ...STRATEGY_CONSTANT,
-    queryFn: () => fetchTokenAddress(token, core, isL2),
+    queryFn: () => fetchTokenAddress(token, core, chainId, isL2),
   });
 
   return address;

--- a/shared/hooks/useStakingLimitInfo.ts
+++ b/shared/hooks/useStakingLimitInfo.ts
@@ -4,7 +4,7 @@ import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import { config } from 'config';
 import { STRATEGY_LAZY } from 'consts/react-query-strategies';
 import { LIMIT_LEVEL } from 'types';
-import { useLidoSDK } from 'modules/web3';
+import { useLidoSDK, useLidoSDKL2 } from 'modules/web3';
 
 export type StakeLimitFullInfo = {
   isStakingPaused: boolean;
@@ -39,7 +39,8 @@ const getLimitLevel = (maxLimit: bigint, currentLimit: bigint) => {
 };
 
 export const useStakingLimitInfo = (): UseQueryResult<StakeLimitFullInfo> => {
-  const { isL2, stake } = useLidoSDK();
+  const { stake } = useLidoSDK();
+  const { isL2 } = useLidoSDKL2();
 
   const enabled = !!stake.core && !!stake.core.chainId && !isL2;
 


### PR DESCRIPTION
### Description

Split the SDK provider to 2 providers (L1 and L2)

### Code review notes

...

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
