### PR TITLE
fix: initial claim state

### DIFF
--- a/features/withdrawals/claim/claim-form-context/claim-form-context.tsx
+++ b/features/withdrawals/claim/claim-form-context/claim-form-context.tsx
@@ -80,16 +80,23 @@ export const ClaimFormProvider: FC<PropsWithChildren> = ({ children }) => {
     if (!data || isSubmitting) return;
 
     // for regular updates generate new list but keep user input
-    const oldValues = getValues('requests');
-    const checkedIds = new Set(
-      oldValues?.filter((req) => req.checked).map((req) => req.token_id),
+    const prevCheckState = getValues('requests')?.reduce(
+      (res, req) => ({
+        ...res,
+        [req.token_id]: req.checked,
+      }),
+      {} as Record<string, boolean>,
     );
+
     const newRequests = generateDefaultValues(
       data,
       defaultSelectedRequestCount,
     ).requests.map((request) => ({
       ...request,
-      checked: request.status.isFinalized && checkedIds.has(request.token_id),
+      checked:
+        prevCheckState?.[request.token_id] !== undefined
+          ? prevCheckState?.[request.token_id]
+          : request.status.isFinalized,
     }));
 
     setValue('requests', newRequests, {


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

A problem fixed that has been occurring when the user connects the wallet on the Claim page without browser cache, after connection the claim list of requests to be displayed without the checked checkboxes

### Testing notes

Steps to reproduce:
1. Open claim page
2. Reload the page to clear the browser cache
3. Connect wallet
4. Wait the claim list to be loaded

### Checklist:

- [x] Checked the changes locally.
