### PR TITLE
fix: not show an allowance is N/A

### DIFF
--- a/features/wsteth/unwrap/unwrap-form/unwrap-stats.tsx
+++ b/features/wsteth/unwrap/unwrap-form/unwrap-stats.tsx
@@ -74,7 +74,7 @@ export const UnwrapStats = () => {
       {isShowAllowance && (
         <AllowanceDataTableRow
           data-testid="allowance"
-          allowance={allowance || 0n}
+          allowance={allowance}
           isBlank={!isDappActiveOnL2}
           loading={isAllowanceLoading}
           token={TOKENS_TO_WRAP.wstETH}

--- a/features/wsteth/wrap/hooks/use-wrap-tx-on-l1-approve.ts
+++ b/features/wsteth/wrap/hooks/use-wrap-tx-on-l1-approve.ts
@@ -82,7 +82,9 @@ export const useWrapTxOnL1Approve = ({
       processApproveTx,
       needsApprove,
       allowance,
-      isAllowanceLoading,
+      // fix first loading when the wallet is autoconnecting
+      isAllowanceLoading:
+        isDappActiveOnL1 && (allowance == null || isAllowanceLoading),
       isApprovalNeededBeforeWrap,
       refetchAllowance,
       // There are 3 cases when we show the allowance on the wrap page:

--- a/shared/components/allowance-data-table-row/allowance-data-table-row.tsx
+++ b/shared/components/allowance-data-table-row/allowance-data-table-row.tsx
@@ -29,12 +29,15 @@ export const AllowanceDataTableRow = ({
   }, [allowance]);
   return (
     <DataTableRow title={title} {...rest}>
-      {isBlank ? (
+      {isBlank || allowance == null ? (
         '-'
       ) : isInfiniteAllowance ? (
         'Infinite'
       ) : (
-        <FormatToken amount={allowance} symbol={getTokenDisplayName(token)} />
+        <FormatToken
+          amount={allowance || 0n}
+          symbol={getTokenDisplayName(token)}
+        />
       )}
     </DataTableRow>
   );


### PR DESCRIPTION
### Description

fix: not show an allowance is N/A
fix(wrap): fix first loading when the wallet is autoconnecting

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
