### PR TITLE
reef-knot 7.1.0 (xdefi -> ctrl)

### DIFF
--- a/consts/matomo-wallets-events.ts
+++ b/consts/matomo-wallets-events.ts
@@ -30,7 +30,7 @@ const EVENTS_DATA_CONNECT_START: EventsData = {
   okx: ['OKX', 'okx'],
   trust: ['Trust', 'trust'],
   walletConnect: ['WalletConnect', 'walletconnect'],
-  xdefi: ['XDEFI', 'xdefi'],
+  ctrl: ['Ctrl', 'ctrl'],
 } as const;
 
 const EVENTS_DATA_CONNECT_SUCCESS: EventsData = {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "react-hook-form": "^7.45.2",
     "react-is": "^18.2.0",
     "react-transition-group": "^4.4.2",
-    "reef-knot": "7.0.1",
+    "reef-knot": "7.1.0",
     "styled-components": "^5.3.5",
     "tiny-async-pool": "^1.2.0",
     "tiny-invariant": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2882,16 +2882,16 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.24.tgz#58601079e11784d20f82d0585865bb42305c4df3"
   integrity sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ==
 
-"@reef-knot/connect-wallet-modal@7.0.1":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@reef-knot/connect-wallet-modal/-/connect-wallet-modal-7.0.1.tgz#6b7f5ea4b8507c213879acbf9b24713382c39666"
-  integrity sha512-86KymEMgDs+6bk/royoIFASd0HVfmvO6wkZ+QLfoRMVSRlT7XCXzvZ/aDhgQ+DQh4g5H4z3C0qaGSpUhp02VMA==
+"@reef-knot/connect-wallet-modal@7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@reef-knot/connect-wallet-modal/-/connect-wallet-modal-7.1.0.tgz#c99ac665fffbb126aeee75bac3803f2be3e27f5a"
+  integrity sha512-jYguoBtvYLOLvN2jJuwUzk0k0xTwzfrVV2mBoqYpx13tiRW7+hIuL6IGLT94cx10rwRTTWY6vwGFTGGIhHQhPQ==
   dependencies:
     "@ledgerhq/hw-app-eth" "^6.37.1"
     "@ledgerhq/hw-transport" "^6.31.0"
     "@ledgerhq/hw-transport-webhid" "^6.29.0"
     "@lidofinance/lido-ui" "^3.18.0"
-    "@reef-knot/wallets-list" "^4.0.0"
+    "@reef-knot/wallets-list" "^4.1.0"
     "@types/react" "18.2.45"
     "@types/react-dom" "18.2.17"
 
@@ -2978,6 +2978,11 @@
   resolved "https://registry.yarnpkg.com/@reef-knot/wallet-adapter-coinbase/-/wallet-adapter-coinbase-4.0.0.tgz#f60c2670810cdc6bee8ebfb1e869917d719ca60f"
   integrity sha512-UqJqTr6qBVhpQCWNckZaKaT3MZWJ/JQnbIJbg95+UODnq5U+TrwfE4M77WLQjTXCI0iL3GgqhL9/v4uvum2xHQ==
 
+"@reef-knot/wallet-adapter-ctrl@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@reef-knot/wallet-adapter-ctrl/-/wallet-adapter-ctrl-1.0.0.tgz#be2ab7996d5fcdf6546e719ff28c54e2615b0b7f"
+  integrity sha512-dhEh5AEOhBIaCYOyqGeKGFg85TcLJiUBi3Unn1YeMO0hxk1AVH2urzAlyEhH1Ve+chxJpfLVJIuW7n36RF0Nug==
+
 "@reef-knot/wallet-adapter-dapp-browser-injected@4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@reef-knot/wallet-adapter-dapp-browser-injected/-/wallet-adapter-dapp-browser-injected-4.0.0.tgz#fe5d9f483b13a9becb871ca325792787739e2181"
@@ -3028,11 +3033,6 @@
   resolved "https://registry.yarnpkg.com/@reef-knot/wallet-adapter-walletconnect/-/wallet-adapter-walletconnect-4.0.0.tgz#7aa49b8148c789a69af16655da9d486c3dceb4e2"
   integrity sha512-Vcxqw6l/gEeW1arxMQQVeJo0nmRFVCzfUy2/gBYSF/fFLr/z4/980ghGCpMWnH3xjG5dObZB330dSfClLVDo7w==
 
-"@reef-knot/wallet-adapter-xdefi@4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@reef-knot/wallet-adapter-xdefi/-/wallet-adapter-xdefi-4.0.0.tgz#9ce8720ea12c7c6b14379d4adae69107e8f41dab"
-  integrity sha512-C/MGlscHtUSn7bbWfyJki2EWJ4C7TxkGRjuuC5daX4/zkcJgVqOBHNB2wETKzLBbP4LhLx1Tx7MaQwbMexGRnQ==
-
 "@reef-knot/wallets-helpers@2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@reef-knot/wallets-helpers/-/wallets-helpers-2.1.1.tgz#1a493f37a23aa6a2a0a405fa36d60b4897ffe0b7"
@@ -3041,10 +3041,10 @@
     "@types/ua-parser-js" "0.7.39"
     ua-parser-js "1.0.37"
 
-"@reef-knot/wallets-list@4.0.0", "@reef-knot/wallets-list@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@reef-knot/wallets-list/-/wallets-list-4.0.0.tgz#00e1c1602acde0fffb6c23173a71e37285f2c9c8"
-  integrity sha512-Em4bwAx15hf4tGpHVG6Wg3BOlymVIt35zElpCe21bONZqqh6H9ylmqLexDZv87UnzRZ+Jnbic5pKvmYRGKsAqA==
+"@reef-knot/wallets-list@4.1.0", "@reef-knot/wallets-list@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@reef-knot/wallets-list/-/wallets-list-4.1.0.tgz#109dec1fe7be8d3485af48ed5ea0a2fe9394b28b"
+  integrity sha512-NrjwY0JAlGpFbNubjfEME/Y4GKU0aC77OytsZWyX5C291Zbesm5VEZO5zoV35TQQUeaCOdMO91x9CHqMnpNIfg==
   dependencies:
     "@reef-knot/wallet-adapter-ambire" "4.0.0"
     "@reef-knot/wallet-adapter-binance-wallet" "3.0.0"
@@ -3054,6 +3054,7 @@
     "@reef-knot/wallet-adapter-coin98" "4.0.0"
     "@reef-knot/wallet-adapter-coinbase" "4.0.0"
     "@reef-knot/wallet-adapter-coinbase-smart-wallet" "3.0.0"
+    "@reef-knot/wallet-adapter-ctrl" "1.0.0"
     "@reef-knot/wallet-adapter-dapp-browser-injected" "4.0.0"
     "@reef-knot/wallet-adapter-exodus" "4.0.0"
     "@reef-knot/wallet-adapter-imtoken" "4.0.0"
@@ -3064,7 +3065,6 @@
     "@reef-knot/wallet-adapter-safe" "4.0.0"
     "@reef-knot/wallet-adapter-trust" "4.0.0"
     "@reef-knot/wallet-adapter-walletconnect" "4.0.0"
-    "@reef-knot/wallet-adapter-xdefi" "4.0.0"
 
 "@reef-knot/web3-react@6.0.0":
   version "6.0.0"
@@ -9463,18 +9463,18 @@ redis-parser@^3.0.0:
   dependencies:
     redis-errors "^1.0.0"
 
-reef-knot@7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/reef-knot/-/reef-knot-7.0.1.tgz#b49700dc0e053e55087275b015779c18cb0e232e"
-  integrity sha512-isp9mWwCJ/2ncg3dIEMI9HstAMB25xKiscP36qo+T+6KmgFXyv1B+OcivTkXT4oKoxGe4aeU2pubrLoTexUTnA==
+reef-knot@7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/reef-knot/-/reef-knot-7.1.0.tgz#4bc09b66d5c5fa826c12c6a3e97c93866d867c48"
+  integrity sha512-bnB6MRcKaUwFSpYhQlE+98LoMm6PQN/MuFmv4j37MMoEF+gScn1HB+s9i6NPIdSEsZitPPk8l6AAAtAOxSPXJQ==
   dependencies:
-    "@reef-knot/connect-wallet-modal" "7.0.1"
+    "@reef-knot/connect-wallet-modal" "7.1.0"
     "@reef-knot/core-react" "6.0.0"
     "@reef-knot/ledger-connector" "4.2.0"
     "@reef-knot/types" "4.0.0"
     "@reef-knot/ui-react" "2.1.5"
     "@reef-knot/wallets-helpers" "2.1.1"
-    "@reef-knot/wallets-list" "4.0.0"
+    "@reef-knot/wallets-list" "4.1.0"
     "@reef-knot/web3-react" "6.0.0"
 
 reflect.getprototypeof@^1.0.4:
@@ -10023,7 +10023,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -10039,6 +10039,15 @@ string-width@^2.1.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.0, string-width@^5.1.2:
   version "5.1.2"
@@ -10105,7 +10114,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -10125,6 +10134,13 @@ strip-ansi@^5.1.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -11023,7 +11039,16 @@ winston@*:
     triple-beam "^1.3.0"
     winston-transport "^4.5.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@7.0.0, wrap-ansi@^6.2.0, wrap-ansi@^7.0.0, wrap-ansi@^8.0.1, wrap-ansi@^8.1.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@7.0.0, wrap-ansi@^6.2.0, wrap-ansi@^7.0.0, wrap-ansi@^8.0.1, wrap-ansi@^8.1.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
### Description
This update replaces XDEFI wallet with Ctrl (rebranding):
See https://github.com/lidofinance/reef-knot/pull/204

### Demo

![image](https://github.com/user-attachments/assets/1d7f0bbd-54cc-4ba1-a56a-d7cd0e1671a0)

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
