### PR TITLE
Transaction modal upper space improved

### DIFF
--- a/shared/transaction-modal/transaction-modal-content.tsx
+++ b/shared/transaction-modal/transaction-modal-content.tsx
@@ -1,14 +1,14 @@
 import { memo } from 'react';
 import styled from 'styled-components';
 import { Text } from '@lidofinance/lido-ui';
-import { devicesHeaderMedia } from 'styles/global';
 
 export const Wrap = styled.div`
   text-align: center;
-  margin-top: -46px;
+  margin-top: -34px;
 
-  @media ${devicesHeaderMedia.mobile} {
-    margin-top: -42px;
+  ${({ theme }) => theme.mediaQueries.md} {
+    margin-top: -26px;
+    padding-bottom: 12px;
   }
 `;
 

--- a/shared/transaction-modal/transaction-modal-content.tsx
+++ b/shared/transaction-modal/transaction-modal-content.tsx
@@ -1,9 +1,15 @@
 import { memo } from 'react';
 import styled from 'styled-components';
 import { Text } from '@lidofinance/lido-ui';
+import { devicesHeaderMedia } from 'styles/global';
 
 export const Wrap = styled.div`
   text-align: center;
+  margin-top: -46px;
+
+  @media ${devicesHeaderMedia.mobile} {
+    margin-top: -42px;
+  }
 `;
 
 export const Title = styled(Text).attrs({


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

A fix for a big padding on the top of the transaction modal.

### Demo

<img width="542" alt="image" src="https://github.com/user-attachments/assets/6ec893dc-75b8-48eb-a136-72a22bef4aa7" />

### Checklist:

- [x] Checked the changes locally.
