### PR TITLE
fix: increase AA tx timeout

### DIFF
--- a/config/groups/web3.ts
+++ b/config/groups/web3.ts
@@ -5,7 +5,7 @@ export const PROVIDER_BATCH_TIME = 150;
 // max batch
 export const PROVIDER_MAX_BATCH = 20;
 // AA transaction polling timeout(ms)
-export const AA_TX_POLLING_TIMEOUT = 60_000;
+export const AA_TX_POLLING_TIMEOUT = 180_000; // 3 minutes
 
 // account for gas estimation
 // will always have:


### PR DESCRIPTION
### Description

Increased AA_TX_POLLING_TIMEOUT to 3 minutes. This constant defines how long dapp awaits for AA action to be confirmed. 3 minutes is enough for most TXs to get confirmed and only timeout if erroneous wallet forgets about this tx.

### Demo

<!--- If thee are visual changes, attach a link to a specific section on preview stand / add screenshots / record a [loom](https://www.loom.com/). -->

### Code review notes

<!--- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

<!--- List all possible edge cases and how to test them. -->

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
