### PR TITLE
Fix/disable collect startup metrics on ipfs

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -46,7 +46,7 @@ declare module 'next/config' {
     publicRuntimeConfig: {
       basePath: string | undefined;
       developmentMode: boolean;
-      runMetrics: boolean;
+      collectMetrics: boolean;
     };
   };
 

--- a/global.d.ts
+++ b/global.d.ts
@@ -46,6 +46,7 @@ declare module 'next/config' {
     publicRuntimeConfig: {
       basePath: string | undefined;
       developmentMode: boolean;
+      runMetrics: boolean;
     };
   };
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,10 +7,7 @@ import { startupCheckRPCs } from './scripts/startup-checks/rpc.mjs';
 logEnvironmentVariables();
 buildDynamics();
 
-if (
-  process.env.RUN_STARTUP_CHECKS === 'true' &&
-  typeof window === 'undefined'
-) {
+if (process.env.RUN_STARTUP_CHECKS === 'true') {
   void startupCheckRPCs();
 }
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -179,6 +179,6 @@ export default withBundleAnalyzer({
   publicRuntimeConfig: {
     basePath,
     developmentMode,
-    runMetrics: process.env.RUN_METRICS === 'true',
+    collectMetrics: process.env.COLLECT_METRICS === 'true',
   },
 });

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -179,5 +179,6 @@ export default withBundleAnalyzer({
   publicRuntimeConfig: {
     basePath,
     developmentMode,
+    runMetrics: process.env.RUN_METRICS === 'true',
   },
 });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' next build",
     "build:analyze": "ANALYZE_BUNDLE=true yarn build",
     "build:ipfs": "IPFS_MODE=true yarn build && IPFS_MODE=true next export",
-    "start": "NODE_ENV=production RUN_METRICS=true RUN_STARTUP_CHECKS=true RUN_SECRET_ENV_LOGGING=true node -r next-logger --no-warnings=ExperimentalWarning server.mjs",
+    "start": "NODE_ENV=production COLLECT_METRICS=true RUN_STARTUP_CHECKS=true RUN_SECRET_ENV_LOGGING=true node -r next-logger --no-warnings=ExperimentalWarning server.mjs",
     "lint": "eslint --ext ts,tsx,js,mjs .",
     "lint:fix": "yarn lint --fix",
     "types": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' next build",
     "build:analyze": "ANALYZE_BUNDLE=true yarn build",
     "build:ipfs": "IPFS_MODE=true yarn build && IPFS_MODE=true next export",
-    "start": "NODE_ENV=production RUN_STARTUP_CHECKS=true node -r next-logger --no-warnings=ExperimentalWarning server.mjs",
+    "start": "NODE_ENV=production RUN_METRICS=true RUN_STARTUP_CHECKS=true RUN_SECRET_ENV_LOGGING=true node -r next-logger --no-warnings=ExperimentalWarning server.mjs",
     "lint": "eslint --ext ts,tsx,js,mjs .",
     "lint:fix": "yarn lint --fix",
     "types": "tsc --noEmit",

--- a/scripts/log-environment-variables.mjs
+++ b/scripts/log-environment-variables.mjs
@@ -80,5 +80,8 @@ export const logSecretEnvironmentVariables = () => {
 
 export const logEnvironmentVariables = () => {
   logOpenEnvironmentVariables();
-  logSecretEnvironmentVariables();
+
+  if (process.env.RUN_SECRET_ENV_LOGGING === 'true') {
+    logSecretEnvironmentVariables();
+  }
 };

--- a/utilsApi/metrics/startup-metrics.ts
+++ b/utilsApi/metrics/startup-metrics.ts
@@ -5,7 +5,7 @@ import buildInfoJson from 'build-info.json';
 import { openKeys } from 'scripts/log-environment-variables.mjs';
 import { getRPCChecks } from 'scripts/startup-checks/rpc.mjs';
 
-import { config, secretConfig } from 'config';
+import { config } from 'config';
 import { METRICS_PREFIX } from 'consts/metrics';
 
 import { StartupChecksRPCMetrics } from './startup-checks';
@@ -19,7 +19,7 @@ const collectStartupChecksRPCMetrics = async (
     // Await the promise if it's still in progress
     const rpcChecksResults = await getRPCChecks();
 
-    if (!rpcChecksResults && !secretConfig.developmentMode) {
+    if (!rpcChecksResults) {
       throw new Error(
         '[collectStartupChecksRPCMetrics] getRPCChecks resolved as "null"!',
       );

--- a/utilsApi/metrics/startup-metrics.ts
+++ b/utilsApi/metrics/startup-metrics.ts
@@ -61,7 +61,8 @@ export const collectStartupMetrics = async (
   registry: Registry,
 ): Promise<void> => {
   // conflicts with HMR
-  if (config.developmentMode) return;
+  if (config.developmentMode || config.ipfsMode) return;
+
   collectEnvInfoMetrics(registry);
 
   collectBuildInfoMetrics({

--- a/utilsApi/metrics/startup-metrics.ts
+++ b/utilsApi/metrics/startup-metrics.ts
@@ -60,8 +60,7 @@ const collectEnvInfoMetrics = (registry: Registry): void => {
 export const collectStartupMetrics = async (
   registry: Registry,
 ): Promise<void> => {
-  // conflicts with HMR
-  if (config.developmentMode || config.ipfsMode) return;
+  if (!config.runMetrics) return;
 
   collectEnvInfoMetrics(registry);
 

--- a/utilsApi/metrics/startup-metrics.ts
+++ b/utilsApi/metrics/startup-metrics.ts
@@ -60,7 +60,7 @@ const collectEnvInfoMetrics = (registry: Registry): void => {
 export const collectStartupMetrics = async (
   registry: Registry,
 ): Promise<void> => {
-  if (!config.runMetrics) return;
+  if (!config.collectMetrics) return;
 
   collectEnvInfoMetrics(registry);
 


### PR DESCRIPTION
### Description

refactor: some conditions for checks

fix: disable some checks for not "yarn build"

feat: add envs to "yarn start"
- RUN_METRICS
- RUN_STARTUP_CHECKS
- RUN_SECRET_ENV_LOGGING


### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
