### PR TITLE
Fix: staking with incorrect refs – rework getRefferalAddress

### DIFF
--- a/features/stake/stake-form/use-stake.ts
+++ b/features/stake/stake-form/use-stake.ts
@@ -50,9 +50,10 @@ export const useStake = ({ onConfirm, onRetry }: StakeOptions) => {
           throw new MockLimitReachedError('Stake limit reached');
         }
 
-        const referralAddress = referral
-          ? await getRefferalAddress(referral, stake.core.rpcProvider)
-          : config.STAKE_FALLBACK_REFERRAL_ADDRESS;
+        const referralAddress = await getRefferalAddress(
+          referral,
+          stake.core.rpcProvider,
+        );
 
         const onStakeTxConfirmed = async () => {
           const [, balance] = await Promise.all([

--- a/features/stake/stake-form/utils.ts
+++ b/features/stake/stake-form/utils.ts
@@ -1,21 +1,38 @@
 import { PublicClient, isAddress } from 'viem';
-import { getEnsAddress } from 'viem/ens';
+import { getEnsAddress, normalize } from 'viem/ens';
+import { config } from 'config';
 
 export const getRefferalAddress = async (
-  input: string,
+  input: string | null,
   provider: PublicClient,
 ): Promise<string> => {
   try {
-    if (isAddress(input)) return input;
-    const address = await getEnsAddress(provider, { name: input });
-    if (address) return address.toString();
-    return input;
-  } catch {
-    // noop
-  }
+    const fallback = config.STAKE_FALLBACK_REFERRAL_ADDRESS;
 
-  // if code gets here, ref is invalid and we need to throw error
-  throw new ReferralAddressError();
+    if (input) {
+      // The address is Ethereum address
+      if (isAddress(input)) return input;
+
+      // Not all ENS names end with .eth, so we can't detect ENS names easily.
+      // The address is a http[s] link, return fallback instead
+      if (/^https?:\/\//.test(input)) return fallback;
+      // Filter out *.lido.fi referrals, e.g. ref from blog.lido.fi
+      // Assuming, that no one uses the 'lido.fi' ENS name
+      if (input.endsWith('lido.fi')) return fallback;
+
+      // Trying to get ENS address takes some time, so it is called after another checks
+      const ensAddress = await getEnsAddress(provider, {
+        name: normalize(input),
+      });
+      if (ensAddress) return ensAddress.toString();
+    }
+
+    // the provided 'input' is not an Ethereum address, nor a ENS address, returning the fallback
+    return fallback;
+  } catch {
+    // something went wrong during getting the address
+    throw new ReferralAddressError();
+  }
 };
 
 export class ReferralAddressError extends Error {

--- a/features/stake/stake-form/utils.ts
+++ b/features/stake/stake-form/utils.ts
@@ -9,23 +9,23 @@ export const getRefferalAddress = async (
   try {
     const fallback = config.STAKE_FALLBACK_REFERRAL_ADDRESS;
 
-    if (input) {
-      // The address is Ethereum address
-      if (isAddress(input)) return input;
+    if (!input) return fallback;
 
-      // Not all ENS names end with .eth, so we can't detect ENS names easily.
-      // The address is a http[s] link, return fallback instead
-      if (/^https?:\/\//.test(input)) return fallback;
-      // Filter out *.lido.fi referrals, e.g. ref from blog.lido.fi
-      // Assuming, that no one uses the 'lido.fi' ENS name
-      if (input.endsWith('lido.fi')) return fallback;
+    // The address is Ethereum address
+    if (isAddress(input)) return input;
 
-      // Trying to get ENS address takes some time, so it is called after another checks
-      const ensAddress = await getEnsAddress(provider, {
-        name: normalize(input),
-      });
-      if (ensAddress) return ensAddress.toString();
-    }
+    // Not all ENS names end with .eth, so we can't detect ENS names easily.
+    // The address is a http[s] link, return fallback instead
+    if (/^https?:\/\//.test(input)) return fallback;
+    // Filter out *.lido.fi referrals, e.g. ref from blog.lido.fi
+    // Assuming, that no one uses the 'lido.fi' ENS name
+    if (input.endsWith('lido.fi')) return fallback;
+
+    // Trying to get ENS address takes some time, so it is called after another checks
+    const ensAddress = await getEnsAddress(provider, {
+      name: normalize(input),
+    });
+    if (ensAddress) return ensAddress.toString();
 
     // the provided 'input' is not an Ethereum address, nor a ENS address, returning the fallback
     return fallback;


### PR DESCRIPTION
### Description
Resolves SI-1817

Fixes the issue, when it is not possible to stake if some incorrect ref is provided.

### Testing notes
The logic of processing the provided ref address looks like this:
1. if the ref is an Ethereum address (0x...), then the ref is used as is
2. if the ref starts with 'http[s]://', then the ref is replaced with a fallback address
3. if the ref ends with 'lido.fi', then the ref is replaced with a fallback address
It is possible to pass ENS names as a ref. We assume that no one uses 'lido.fi' ENS name, because not all ENS names end with '.eth' and it is technically possible to have 'lido.fi' ENS name.
4. only in the end, after all other checks, we are trying to get ENS name using the provided ref. Because this request takes some time (5 seconds or so).

Checked with refs:
- `?ref=blog.lido.fi` – no ENS request, ignoring the ref
- `/?ref=https://test` – no ENS request, ignoring the ref
- `?ref=test.com` – we have to do a ENS request, because it is a possible ENS name. If the name is not resolved – ignore, return fallback.

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
