### PR TITLE
Change cf-ipfs.com gateway with dweb.link

### DIFF
--- a/features/ipfs/security-status-banner/use-remote-version.ts
+++ b/features/ipfs/security-status-banner/use-remote-version.ts
@@ -49,7 +49,7 @@ export const useRemoteVersion = () => {
       if (data?.cid) {
         return {
           cid: data.cid,
-          link: `https://${data.cid}.ipfs.cf-ipfs.com`,
+          link: `https://${data.cid}.ipfs.dweb.link`,
           leastSafeVersion: data.leastSafeVersion,
         };
       }


### PR DESCRIPTION
### Description

cf-ipfs.com gateway doesn't work.
dweb.link looks okay according to https://ipfs.github.io/public-gateway-checker/, the link will be:
https://bafybeiecvujvs74xvxgpwctmbfkcucazyaudmwuiw4wfv6ys7uio7o376u.ipfs.dweb.link/

### Checklist:

- [ ] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
