### PR TITLE
Hotifx for the Safe transactions issue

### DIFF
--- a/modules/web3/web3-provider/web3-provider.tsx
+++ b/modules/web3/web3-provider/web3-provider.tsx
@@ -16,7 +16,10 @@ import {
   fallback,
   type Config,
 } from 'wagmi';
-import * as wagmiChains from 'wagmi/chains';
+import * as _wagmiChains from 'wagmi/chains';
+import { Chain } from 'wagmi/chains';
+
+import { unichain, unichainSepolia } from '@lidofinance/lido-ethereum-sdk';
 
 import { ReefKnotProvider, getDefaultConfig } from 'reef-knot/core-react';
 import {
@@ -36,19 +39,21 @@ import { walletMetricProps } from 'consts/matomo-wallets-events';
 import { SupportL1Chains } from './dapp-chain';
 import { useWeb3Transport } from './use-web3-transport';
 
-type ChainsList = [wagmiChains.Chain, ...wagmiChains.Chain[]];
+type ChainsList = [Chain, ...Chain[]];
 
 const WALLETS_PINNED: WalletIdsEthereum[] = [
   'binanceWallet',
   'browserExtension',
 ];
 
+const wagmiChains = { ..._wagmiChains, unichain, unichainSepolia };
+
 export const wagmiChainMap = Object.values(wagmiChains).reduce(
   (acc, chain) => {
     acc[chain.id] = chain;
     return acc;
   },
-  {} as Record<number, wagmiChains.Chain>,
+  {} as Record<number, Chain>,
 );
 
 type Web3ProviderContextValue = {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@lidofinance/api-rpc": "^0.48.0",
     "@lidofinance/eth-api-providers": "^0.48.0",
     "@lidofinance/eth-providers": "^0.48.0",
-    "@lidofinance/lido-ethereum-sdk": "4.2.0-alpha.2",
+    "@lidofinance/lido-ethereum-sdk": "4.3.0-alpha.2",
     "@lidofinance/lido-ui": "^3.26.0",
     "@lidofinance/next-api-wrapper": "^0.48.0",
     "@lidofinance/next-ip-rate-limit": "^0.48.0",
@@ -59,7 +59,7 @@
     "tiny-async-pool": "^1.2.0",
     "tiny-invariant": "^1.1.0",
     "uuid": "^8.3.2",
-    "viem": "2.23.1",
+    "viem": "2.22.23",
     "wagmi": "2.14.11"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2312,10 +2312,10 @@
   resolved "https://registry.yarnpkg.com/@lidofinance/eth-providers/-/eth-providers-0.48.0.tgz#217279cc8433968531283b985617b981d59a8393"
   integrity sha512-ItzIN9psHu8stf8MTAmNaXmKyaVnsYzQ10zdvdX6TM56TcFRlxidTnR5UVeOObtr1Bm/pz61GYCOZkUI6q3aAw==
 
-"@lidofinance/lido-ethereum-sdk@4.2.0-alpha.2":
-  version "4.2.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@lidofinance/lido-ethereum-sdk/-/lido-ethereum-sdk-4.2.0-alpha.2.tgz#d393a08a3898874550735398303f94786c85bc16"
-  integrity sha512-yX/bCBCyKizGgARQsJBLDyzF1PxsYuIF+2IYBAwFieyPYVmbMt3VeRfaJMIS8Eb8aNccQu0GVjC1/V5FD6Pvvg==
+"@lidofinance/lido-ethereum-sdk@4.3.0-alpha.2":
+  version "4.3.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@lidofinance/lido-ethereum-sdk/-/lido-ethereum-sdk-4.3.0-alpha.2.tgz#7d38bc6e296302393a6be9e26cb19b6090804b71"
+  integrity sha512-5lxrYLK2iYz8C+CRU206luOdHBCOWI5KVhcDFJbcIMuQvJ9BMxX5qk4YYDaF5/l4YTL8PzqMNz1WeTFhALkRvg==
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
     graphql "^16.8.1"
@@ -10844,10 +10844,10 @@ vary@^1:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
-viem@2.23.1:
-  version "2.23.1"
-  resolved "https://registry.yarnpkg.com/viem/-/viem-2.23.1.tgz#5fe527de258e33b2445af266698fd6575068112d"
-  integrity sha512-c5AyJCTA5LeNI/KCu++vkbqbh7irYjUSHxLIAHPKJ6IEcBNMt8+7sPG7gjMXpqVWnqPMzaW9CA2n+yUsKWttDA==
+viem@2.22.23:
+  version "2.22.23"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-2.22.23.tgz#59949d41fd5a22317bed2cf7ea8e85d74e63fedf"
+  integrity sha512-MheOu+joowphTCfCgdQ9BGU/z1IeHa6/ZIYNVc6KTwDklj671YS87cGv5kRCSU0vAfzN+5wjWyIffM8000KGkQ==
   dependencies:
     "@noble/curves" "1.8.1"
     "@noble/hashes" "1.7.1"


### PR DESCRIPTION
### Description
Resolves SI-1793

- downgrade viem to 2.22
- bump sdk to 4.3.0-alpha.2
- import Unichain from lido-ethereum-sdk instead of viem (temporary solution)

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
