### PR TITLE
fix: chains naming

### DIFF
--- a/modules/web3/web3-provider/dapp-chain.tsx
+++ b/modules/web3/web3-provider/dapp-chain.tsx
@@ -73,8 +73,13 @@ export const useDappChain = (): UseDappChainValue => {
         .map((chain) => (chain.testnet ? chain.name : 'Mainnet'));
 
       return (
-        chainType +
-        (chainNamesForType.length > 0 ? `(${chainNamesForType.join(',')})` : '')
+        // Ethereum example:
+        // - Ethereum(Mainnet,Hoodi,Sepolia,Holesky)
+        // - or
+        // - Ethereum
+        chainNamesForType.length > 1
+          ? `${chainType}(${chainNamesForType.join(',')})`
+          : chainType
       );
     };
 

--- a/shared/components/layout/header/components/chain-switcher/chain-switcher.tsx
+++ b/shared/components/layout/header/components/chain-switcher/chain-switcher.tsx
@@ -16,6 +16,12 @@ import {
 
 type IconsMapType = Record<number, ChainOption>;
 
+const overriddenChainNames: Record<number, string> = {
+  10: 'Optimism',
+  1868: 'Soneium',
+  130: 'Unichain',
+};
+
 export const ChainSwitcher: FC = () => {
   const { isDappActive, chainId, setChainId, supportedChainIds } =
     useDappStatus();
@@ -30,7 +36,7 @@ export const ChainSwitcher: FC = () => {
     () =>
       supportedChainIds.reduce((acc: IconsMapType, chainId: number) => {
         acc[chainId] = {
-          name: wagmiChainMap[chainId].name,
+          name: overriddenChainNames[chainId] ?? wagmiChainMap[chainId].name,
           iconComponent: CHAIN_ICONS_MAP.has(Number(chainId))
             ? createElement(
                 CHAIN_ICONS_MAP.get(Number(chainId)) as ComponentType,


### PR DESCRIPTION
### Description

Fixed display of chain names in the banner when the widget has test networks and hasn't

### Demo

```SUPPORTED_CHAINS=1,17000,560048,11155111,10,11155420,1868,1946,130,1301``` with all testnets
<img width="526" alt="Снимок экрана 2025-04-01 в 18 48 07" src="https://github.com/user-attachments/assets/9ffbf948-9246-49e3-b94d-3df73462432f" />

```SUPPORTED_CHAINS=1,10,1868``` without testnets
<img width="559" alt="Снимок экрана 2025-04-01 в 18 47 01" src="https://github.com/user-attachments/assets/8f0c073b-d22c-4a5e-b310-eb00e21ceb07" />

```SUPPORTED_CHAINS=1,10,11155111``` with ethereum sepolia testnets
<img width="548" alt="Снимок экрана 2025-04-01 в 18 43 43" src="https://github.com/user-attachments/assets/5bc5aa8c-00d5-46e8-b3fe-9b6d79578d99" />

names for mainnet chains in the chain switcher
<img width="267" alt="Снимок экрана 2025-04-01 в 19 11 48" src="https://github.com/user-attachments/assets/7153b2d2-3a63-4e95-96f1-fab99c7182a3" />





### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
