### PR TITLE
Feature/remove dependence on external services

### DIFF
--- a/consts/api.ts
+++ b/consts/api.ts
@@ -47,7 +47,7 @@ export const getEthApiPath = (
     | undefined,
 ) => {
   if (!config.ethAPIBasePath) {
-    return null;
+    return undefined;
   }
 
   let search = new URLSearchParams(params).toString();
@@ -55,7 +55,9 @@ export const getEthApiPath = (
   return config.ethAPIBasePath + endpoint + search;
 };
 
-export const getReplacementLink = (apiRoute: API_ROUTES): string | null => {
+export const getReplacementLink = (
+  apiRoute: API_ROUTES,
+): string | undefined => {
   switch (apiRoute) {
     case API_ROUTES.ETH_APR:
       return getEthApiPath(ETH_API_ROUTES.ETH_APR);

--- a/consts/api.ts
+++ b/consts/api.ts
@@ -46,12 +46,16 @@ export const getEthApiPath = (
     | URLSearchParams
     | undefined,
 ) => {
+  if (!config.ethAPIBasePath) {
+    return null;
+  }
+
   let search = new URLSearchParams(params).toString();
   search = search ? '?' + search : '';
   return config.ethAPIBasePath + endpoint + search;
 };
 
-export const getReplacementLink = (apiRoute: API_ROUTES): string => {
+export const getReplacementLink = (apiRoute: API_ROUTES): string | null => {
   switch (apiRoute) {
     case API_ROUTES.ETH_APR:
       return getEthApiPath(ETH_API_ROUTES.ETH_APR);

--- a/env-dynamics.mjs
+++ b/env-dynamics.mjs
@@ -112,8 +112,8 @@ export const wqAPIBasePath = process.env.WQ_API_BASE_PATH;
 /** @type string */
 
 /** @type string */
-export const widgetApiBasePathForIpfs =
-  process.env.WIDGET_API_BASE_PATH_FOR_IPFS;
-
-/** @type string */
 export const rewardsBackendBasePath = process.env.REWARDS_BACKEND_BASE_PATH;
+// for IPFS only
+
+/** @type boolean */
+export const isRewardsAvailable = ipfsMode ? !!rewardsBackendBasePath: !!process.env.REWARDS_BACKEND;

--- a/env-dynamics.mjs
+++ b/env-dynamics.mjs
@@ -114,6 +114,3 @@ export const wqAPIBasePath = process.env.WQ_API_BASE_PATH;
 /** @type string */
 export const rewardsBackendBasePath = process.env.REWARDS_BACKEND_BASE_PATH;
 // for IPFS only
-
-/** @type boolean */
-export const isRewardsAvailable = ipfsMode ? !!rewardsBackendBasePath: !!process.env.REWARDS_BACKEND;

--- a/features/ipfs/home-page-ipfs.tsx
+++ b/features/ipfs/home-page-ipfs.tsx
@@ -1,6 +1,7 @@
 import { FC, useMemo, useEffect } from 'react';
 import { useRouter } from 'next/router';
 
+import { config } from 'config';
 import {
   getPathWithoutFirstSlash,
   HOME_PATH,
@@ -32,7 +33,7 @@ const IPFS_ROUTABLE_PAGES = [
   // HOME_PATH not need here
   getPathWithoutFirstSlash(WRAP_PATH),
   getPathWithoutFirstSlash(WITHDRAWALS_PATH),
-  getPathWithoutFirstSlash(REWARDS_PATH),
+  config.isRewardsAvailable && getPathWithoutFirstSlash(REWARDS_PATH),
   getPathWithoutFirstSlash(REFERRAL_PATH),
   getPathWithoutFirstSlash(SETTINGS_PATH),
 ];
@@ -92,7 +93,11 @@ export const HomePageIpfs: FC = () => {
     }
 
     case getPathWithoutFirstSlash(REWARDS_PATH): {
-      spaPage = <RewardsPage />;
+      if (config.isRewardsAvailable) {
+        spaPage = <RewardsPage />;
+        break;
+      }
+      // skip this case (falls through to default)
       break;
     }
 

--- a/features/stake/lido-stats/lido-stats.tsx
+++ b/features/stake/lido-stats/lido-stats.tsx
@@ -30,13 +30,17 @@ export const LidoStats: FC = memo(() => {
     return getEtherscanTokenLink(chainId, stethAddress ?? '');
   }, [chainId, stethAddress]);
 
+  if (!lidoStats.data) {
+    return null;
+  }
+
   const showApr = !config.ipfsMode || isStatItemAvailable(lidoApr.apr);
   const showTotalStaked =
-    !config.ipfsMode || isStatItemAvailable(lidoStats.data.totalStaked);
+    !config.ipfsMode || isStatItemAvailable(lidoStats.data?.totalStaked);
   const showStakers =
-    !config.ipfsMode || isStatItemAvailable(lidoStats.data.stakers);
+    !config.ipfsMode || isStatItemAvailable(lidoStats.data?.stakers);
   const showMarketCap =
-    !config.ipfsMode || isStatItemAvailable(lidoStats.data.marketCap);
+    !config.ipfsMode || isStatItemAvailable(lidoStats.data?.marketCap);
 
   if (!showApr && !showTotalStaked && !showStakers && !showMarketCap) {
     return null;

--- a/features/stake/swap-discount-banner/integrations.tsx
+++ b/features/stake/swap-discount-banner/integrations.tsx
@@ -42,8 +42,9 @@ const STAKE_SWAP_INTEGRATION_CONFIG: StakeSwapDiscountIntegrationMap = {
   'one-inch': {
     title: '1inch',
     async getRate() {
-      const { rate } = await getOneInchRate({ token: LIDO_TOKENS.eth });
-      return rate;
+      const result = await getOneInchRate({ token: LIDO_TOKENS.eth });
+      // a fallback value of 1 is acceptable for devnet
+      return result?.rate ?? 1;
     },
     BannerText({ discountPercent }) {
       return (

--- a/features/withdrawals/hooks/contract/useWithdrawalsData.ts
+++ b/features/withdrawals/hooks/contract/useWithdrawalsData.ts
@@ -75,8 +75,7 @@ export const useWithdrawalRequests = () => {
         }
       });
 
-      const wqRequests: { finalizationAt: string; id: string | undefined }[] =
-        [];
+      let wqRequests: { finalizationAt: string; id: string | undefined }[] = [];
 
       try {
         const requests =
@@ -85,15 +84,12 @@ export const useWithdrawalRequests = () => {
             getCustomApiUrl,
           });
 
-        for (const request of requests) {
-          if (!request || !request.requestInfo) continue;
-          const modifiedResult = {
+        wqRequests = requests
+          .filter((request) => request?.requestInfo)
+          .map((request) => ({
             id: request.requestInfo.requestId,
             finalizationAt: request.requestInfo.finalizationAt,
-          };
-
-          wqRequests.push(modifiedResult);
-        }
+          }));
       } catch (e) {
         console.warn(
           `[useWithdrawalData] Failed to fetch request time for requests ids: ${pendingRequestsIds}. Details:`,

--- a/features/withdrawals/hooks/useWaitingTime.ts
+++ b/features/withdrawals/hooks/useWaitingTime.ts
@@ -4,6 +4,7 @@ import { config } from 'config';
 import { STRATEGY_EAGER } from 'consts/react-query-strategies';
 
 import { useWithdrawals } from 'features/withdrawals/contexts/withdrawals-context';
+import { getCustomApiUrl } from 'features/withdrawals/utils/get-custom-api-url';
 import { useDebouncedValue } from 'shared/hooks';
 
 import { useLidoSDK } from 'modules/web3';
@@ -37,7 +38,7 @@ export const useWaitingTime = (
     queryFn: async () => {
       return await withdraw.waitingTime.getWithdrawalWaitingTimeByAmount({
         amount: BigInt(debouncedAmount),
-        getCustomApiUrl: (defaultUrl) => defaultUrl ?? '',
+        getCustomApiUrl,
       });
     },
     ...STRATEGY_EAGER,

--- a/features/withdrawals/hooks/useWaitingTime.ts
+++ b/features/withdrawals/hooks/useWaitingTime.ts
@@ -35,12 +35,11 @@ export const useWaitingTime = (
   const { data, error, isLoading, isFetching } = useQuery<RequestTimeV2Dto>({
     queryKey: ['waiting-time', debouncedAmount],
     enabled: !!config.wqAPIBasePath,
-    queryFn: async () => {
-      return await withdraw.waitingTime.getWithdrawalWaitingTimeByAmount({
+    queryFn: () =>
+      withdraw.waitingTime.getWithdrawalWaitingTimeByAmount({
         amount: BigInt(debouncedAmount),
         getCustomApiUrl,
-      });
-    },
+      }),
     ...STRATEGY_EAGER,
     retry: (failureCount, e) => {
       if (e && e instanceof FetcherError && e.status === 400) {

--- a/features/withdrawals/hooks/useWaitingTime.ts
+++ b/features/withdrawals/hooks/useWaitingTime.ts
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import { config } from 'config';
@@ -8,8 +7,6 @@ import { useWithdrawals } from 'features/withdrawals/contexts/withdrawals-contex
 import { useDebouncedValue } from 'shared/hooks';
 
 import { useLidoSDK } from 'modules/web3';
-import { encodeURLQuery } from 'utils/encodeURLQuery';
-import { standardFetcher } from 'utils/standardFetcher';
 import { FetcherError } from 'utils/fetcherError';
 
 const DEFAULT_DAYS_VALUE = 5;
@@ -34,35 +31,14 @@ export const useWaitingTime = (
   const { withdraw } = useLidoSDK();
   const debouncedAmount = useDebouncedValue(amount, 1000);
 
-  const url = useMemo(() => {
-    if (!config.wqAPIBasePath) return null;
-
-    const basePath = config.wqAPIBasePath;
-    const params = encodeURLQuery({ amount: debouncedAmount });
-    const queryString = params ? `?${params}` : '';
-    return `${basePath}/v2/request-time/calculate${queryString}`;
-  }, [debouncedAmount]);
-
   const { data, error, isLoading, isFetching } = useQuery<RequestTimeV2Dto>({
     queryKey: ['waiting-time', debouncedAmount],
+    enabled: !!config.wqAPIBasePath,
     queryFn: async () => {
-      try {
-        if (!url) {
-          throw new Error('Missing URL for fetching a waiting-time');
-        }
-
-        return await standardFetcher<RequestTimeV2Dto>(url, {
-          headers: {
-            'Content-Type': 'application/json',
-            'WQ-Request-Source': 'widget',
-          },
-        });
-      } catch (error) {
-        // Fallback from SDK
-        return await withdraw.waitingTime.getWithdrawalWaitingTimeByAmount({
-          amount: BigInt(debouncedAmount),
-        });
-      }
+      return await withdraw.waitingTime.getWithdrawalWaitingTimeByAmount({
+        amount: BigInt(debouncedAmount),
+        getCustomApiUrl: (defaultUrl) => defaultUrl ?? '',
+      });
     },
     ...STRATEGY_EAGER,
     retry: (failureCount, e) => {

--- a/features/withdrawals/request/withdrawal-rates/integrations.ts
+++ b/features/withdrawals/request/withdrawal-rates/integrations.ts
@@ -109,12 +109,11 @@ const getParaSwapWithdrawalRate: GetRateType = async ({ amount, token }) => {
 };
 
 const getOneInchWithdrawalRate: GetRateType = async (params) => {
+  const fallback = { rate: null, toReceive: null };
+
   try {
     if (params.amount > 0n) {
-      const result = await getOneInchRate(params);
-      if (result) {
-        return result;
-      }
+      return (await getOneInchRate(params)) ?? fallback;
     }
   } catch (e) {
     console.warn(
@@ -122,10 +121,8 @@ const getOneInchWithdrawalRate: GetRateType = async (params) => {
       e,
     );
   }
-  return {
-    rate: null,
-    toReceive: null,
-  };
+
+  return fallback;
 };
 
 const getBebopWithdrawalRate: GetRateType = async ({ amount, token }) => {

--- a/features/withdrawals/request/withdrawal-rates/integrations.ts
+++ b/features/withdrawals/request/withdrawal-rates/integrations.ts
@@ -112,7 +112,9 @@ const getOneInchWithdrawalRate: GetRateType = async (params) => {
   try {
     if (params.amount > 0n) {
       const result = await getOneInchRate(params);
-      return result;
+      if (result) {
+        return result;
+      }
     }
   } catch (e) {
     console.warn(

--- a/features/withdrawals/utils/get-custom-api-url.ts
+++ b/features/withdrawals/utils/get-custom-api-url.ts
@@ -1,0 +1,17 @@
+// TODO
+// import { WqApiCustomUrlGetter } from '@lidofinance/lido-ethereum-sdk/withdraw';
+import { CHAINS } from '@lidofinance/lido-ethereum-sdk';
+export type WqApiCustomUrlGetter = (
+  defaultUrl: string | null,
+  chainId: CHAINS,
+) => string;
+
+import { config } from 'config';
+
+export const getCustomApiUrl: WqApiCustomUrlGetter = (defaultUrl, chainId) => {
+  if (chainId === config.defaultChain) {
+    return config.wqAPIBasePath ?? '';
+  }
+
+  return defaultUrl ?? '';
+};

--- a/global.d.ts
+++ b/global.d.ts
@@ -24,6 +24,7 @@ declare module 'next/config' {
       basePath: string | undefined;
       developmentMode: boolean;
       devnetOverrides: Record<string, string>;
+      isRewardsAvailable: boolean;
 
       defaultChain: string;
       rpcUrls_1: string | undefined;
@@ -51,6 +52,7 @@ declare module 'next/config' {
       basePath: string | undefined;
       developmentMode: boolean;
       devnetOverrides: Record<string, string>;
+      isRewardsAvailable: boolean;
       collectMetrics: boolean;
     };
   };

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -17,6 +17,8 @@ const basePath = process.env.BASE_PATH;
 const developmentMode = process.env.NODE_ENV === 'development';
 const isIPFSMode = process.env.IPFS_MODE === 'true';
 
+const isRewardsAvailable = isIPFSMode ? !!process.env.REWARDS_BACKEND_BASE_PATH : !!process.env.REWARDS_BACKEND;
+
 const devnetOverrides =
   (process.env.DEVNET_OVERRIDES || '')
     .split(',')
@@ -162,6 +164,7 @@ export default withBundleAnalyzer({
     basePath,
     developmentMode,
     devnetOverrides,
+    isRewardsAvailable,
 
     // ETH rpcs
     defaultChain: process.env.DEFAULT_CHAIN,
@@ -195,6 +198,7 @@ export default withBundleAnalyzer({
     basePath,
     developmentMode,
     devnetOverrides,
+    isRewardsAvailable,
     collectMetrics: process.env.COLLECT_METRICS === 'true',
   },
 });

--- a/pages/api/rewards.ts
+++ b/pages/api/rewards.ts
@@ -23,7 +23,7 @@ if (!secretConfig.rewardsBackendAPI) {
     '[createCachedProxy] Skipped setup: secretConfig.rewardsBackendAPI is null',
   );
   handler = (_: NextApiRequest, res: NextApiResponse) => {
-    res.status(204).end();
+    res.status(404).end();
   };
 } else {
   handler = createCachedProxy({

--- a/pages/api/rewards.ts
+++ b/pages/api/rewards.ts
@@ -1,3 +1,4 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import {
   wrapRequest as wrapNextRequest,
   cacheControl,
@@ -21,7 +22,7 @@ if (!secretConfig.rewardsBackendAPI) {
   console.error(
     '[createCachedProxy] Skipped setup: secretConfig.rewardsBackendAPI is null',
   );
-  handler = (_req, res) => {
+  handler = (_: NextApiRequest, res: NextApiResponse) => {
     res.status(204).end();
   };
 } else {

--- a/pages/rewards.tsx
+++ b/pages/rewards.tsx
@@ -1,6 +1,7 @@
 import { FC } from 'react';
 import Head from 'next/head';
 
+import { secretConfig } from 'config';
 import { TopCard, RewardsList } from 'features/rewards/features';
 import RewardsHistoryProvider from 'providers/rewardsHistory';
 
@@ -32,6 +33,10 @@ const Rewards: FC = () => {
   );
 };
 
-export const getStaticProps = getDefaultStaticProps('/rewards');
+export const getStaticProps = getDefaultStaticProps('/rewards', async () => {
+  if (!secretConfig.rewardsBackendAPI) return { notFound: true };
+
+  return { props: {} };
+});
 
 export default Rewards;

--- a/pages/rewards.tsx
+++ b/pages/rewards.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react';
 import Head from 'next/head';
 
-import { secretConfig } from 'config';
+import { config } from 'config';
 import { TopCard, RewardsList } from 'features/rewards/features';
 import RewardsHistoryProvider from 'providers/rewardsHistory';
 
@@ -34,7 +34,7 @@ const Rewards: FC = () => {
 };
 
 export const getStaticProps = getDefaultStaticProps('/rewards', async () => {
-  if (!secretConfig.rewardsBackendAPI) return { notFound: true };
+  if (!config.isRewardsAvailable) return { notFound: true };
 
   return { props: {} };
 });

--- a/shared/banners/curve/curve.tsx
+++ b/shared/banners/curve/curve.tsx
@@ -23,6 +23,10 @@ export const Curve: FC = () => {
 
   const { data, isLoading } = useCurve();
 
+  if (!data) {
+    return null;
+  }
+
   const apr = data?.data.totalApr.toFixed(2) ?? DATA_UNAVAILABLE;
   const value = isLoading ? <InlineLoader /> : apr;
 

--- a/shared/banners/curve/useCurve.ts
+++ b/shared/banners/curve/useCurve.ts
@@ -10,7 +10,13 @@ export const useCurve = (): UseQueryResult<CurveResponse> => {
 
   return useQuery<CurveResponse>({
     queryKey: ['curve-apr', url],
-    queryFn: () => standardFetcher<CurveResponse>(url),
+    enabled: !!url,
+    queryFn: () => {
+      if (!url) {
+        throw new Error('Missing URL for curve APR request');
+      }
+      return standardFetcher<CurveResponse>(url);
+    },
     ...STRATEGY_LAZY,
   });
 };

--- a/shared/banners/curve/useCurve.ts
+++ b/shared/banners/curve/useCurve.ts
@@ -1,3 +1,4 @@
+import invariant from 'tiny-invariant';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import { ETH_API_ROUTES, getEthApiPath } from 'consts/api';
 import { STRATEGY_LAZY } from 'consts/react-query-strategies';
@@ -12,9 +13,7 @@ export const useCurve = (): UseQueryResult<CurveResponse> => {
     queryKey: ['curve-apr', url],
     enabled: !!url,
     queryFn: () => {
-      if (!url) {
-        throw new Error('Missing URL for curve APR request');
-      }
+      invariant(url, 'Missing URL for curve APR request');
       return standardFetcher<CurveResponse>(url);
     },
     ...STRATEGY_LAZY,

--- a/shared/components/layout/header/components/navigation/navigation.tsx
+++ b/shared/components/layout/header/components/navigation/navigation.tsx
@@ -23,7 +23,7 @@ type PageRoute = {
   exact?: boolean;
   full_path?: string;
   subPaths?: string[];
-  shouldDisable?: boolean;
+  isDisabled?: boolean;
 };
 
 const routesAll: PageRoute[] = [
@@ -49,11 +49,11 @@ const routesAll: PageRoute[] = [
     name: 'Rewards',
     path: REWARDS_PATH,
     icon: <Wallet data-testid="navRewards" />,
-    shouldDisable: !config.isRewardsAvailable,
+    isDisabled: !config.isRewardsAvailable,
   },
 ];
 
-const routes: PageRoute[] = routesAll.filter((route) => !route.shouldDisable);
+const routes: PageRoute[] = routesAll.filter((route) => !route.isDisabled);
 
 export const Navigation: FC = memo(() => {
   const pathname = useRouterPath();

--- a/shared/components/layout/header/components/navigation/navigation.tsx
+++ b/shared/components/layout/header/components/navigation/navigation.tsx
@@ -9,7 +9,7 @@ import {
   REWARDS_PATH,
   getPathWithoutFirstSlash,
 } from 'consts/urls';
-import { useConfig } from 'config';
+import { config, useConfig } from 'config';
 import { ManifestConfigPage } from 'config/external-config';
 import { LocalLink } from 'shared/components/local-link';
 import { useRouterPath } from 'shared/hooks/use-router-path';
@@ -23,9 +23,10 @@ type PageRoute = {
   exact?: boolean;
   full_path?: string;
   subPaths?: string[];
+  shouldDisable?: boolean;
 };
 
-const routes: PageRoute[] = [
+const routesAll: PageRoute[] = [
   {
     name: 'Stake',
     path: HOME_PATH,
@@ -48,8 +49,11 @@ const routes: PageRoute[] = [
     name: 'Rewards',
     path: REWARDS_PATH,
     icon: <Wallet data-testid="navRewards" />,
+    shouldDisable: !config.isRewardsAvailable,
   },
 ];
+
+const routes: PageRoute[] = routesAll.filter((route) => !route.shouldDisable);
 
 export const Navigation: FC = memo(() => {
   const pathname = useRouterPath();

--- a/shared/hooks/useLidoApr.ts
+++ b/shared/hooks/useLidoApr.ts
@@ -34,7 +34,7 @@ export const useLidoApr = (): UseLidoAprResult => {
     queryFn: async () => {
       try {
         if (!url) {
-          throw new Error('Missing URL for fetching SMA APR');
+          throw new Error('Missing URL for fetching the SMA APR');
         }
 
         return await standardFetcher<SMA_APR_RESPONSE>(url);

--- a/shared/hooks/useLidoApr.ts
+++ b/shared/hooks/useLidoApr.ts
@@ -1,3 +1,5 @@
+import invariant from 'tiny-invariant';
+
 import { CHAINS } from '@lidofinance/lido-ethereum-sdk/common';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
@@ -33,10 +35,7 @@ export const useLidoApr = (): UseLidoAprResult => {
     ...STRATEGY_LAZY,
     queryFn: async () => {
       try {
-        if (!url) {
-          throw new Error('Missing URL for fetching the SMA APR');
-        }
-
+        invariant(url, 'Missing URL for fetching the SMA APR');
         return await standardFetcher<SMA_APR_RESPONSE>(url);
       } catch (error) {
         // Fallback from SDK

--- a/shared/hooks/useLidoApr.ts
+++ b/shared/hooks/useLidoApr.ts
@@ -33,6 +33,10 @@ export const useLidoApr = (): UseLidoAprResult => {
     ...STRATEGY_LAZY,
     queryFn: async () => {
       try {
+        if (!url) {
+          throw new Error('Missing URL for fetching SMA APR');
+        }
+
         return await standardFetcher<SMA_APR_RESPONSE>(url);
       } catch (error) {
         // Fallback from SDK

--- a/shared/hooks/useLidoStats.ts
+++ b/shared/hooks/useLidoStats.ts
@@ -1,3 +1,4 @@
+import invariant from 'tiny-invariant';
 import { useQuery } from '@tanstack/react-query';
 
 import { ETH_API_ROUTES, getEthApiPath } from 'consts/api';
@@ -19,7 +20,7 @@ type QueryResponseData = {
 };
 
 export const useLidoStats = (): {
-  data?: QueryResponseData | null;
+  data?: QueryResponseData;
   isLoading: boolean;
 } => {
   const url = getEthApiPath(ETH_API_ROUTES.STETH_STATS);
@@ -27,21 +28,16 @@ export const useLidoStats = (): {
   const { data, isLoading } = useQuery<
     RequestResponseData | undefined,
     Error,
-    QueryResponseData | null
+    QueryResponseData | undefined
   >({
     queryKey: ['lido-stats', url],
     enabled: !!url,
     queryFn: () => {
-      if (!url) {
-        throw new Error('Missing URL for curve LidoStats request');
-      }
+      invariant(url, 'Missing URL for LidoStats request');
       return standardFetcher<RequestResponseData>(url);
     },
     select: (rawData) => {
-      if (!rawData) {
-        return null;
-      }
-
+      invariant(rawData, 'Failed to fetch LidoStats');
       return {
         totalStaked: rawData?.totalStaked
           ? `${Number(rawData.totalStaked).toLocaleString('en-US')} ETH`

--- a/shared/hooks/useLidoStats.ts
+++ b/shared/hooks/useLidoStats.ts
@@ -43,7 +43,7 @@ export const useLidoStats = (): {
           ? `${Number(rawData.totalStaked).toLocaleString('en-US')} ETH`
           : DATA_UNAVAILABLE,
         stakers: rawData?.uniqueAnytimeHolders
-          ? String(rawData.uniqueAnytimeHolders)
+          ? Number(rawData.uniqueAnytimeHolders).toLocaleString('en-US')
           : DATA_UNAVAILABLE,
         marketCap: rawData?.marketCap
           ? `$${Math.round(rawData.marketCap).toLocaleString('en-US')}`

--- a/shared/hooks/useLidoStats.ts
+++ b/shared/hooks/useLidoStats.ts
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import { ETH_API_ROUTES, getEthApiPath } from 'consts/api';
@@ -6,42 +5,57 @@ import { DATA_UNAVAILABLE } from 'consts/text';
 import { STRATEGY_LAZY } from 'consts/react-query-strategies';
 import { standardFetcher } from 'utils/standardFetcher';
 
-type ResponseData = {
+type RequestResponseData = {
   uniqueAnytimeHolders: string;
   uniqueHolders: string;
   totalStaked: string;
   marketCap: number;
 };
 
+type QueryResponseData = {
+  totalStaked: string;
+  stakers: string;
+  marketCap: string;
+};
+
 export const useLidoStats = (): {
-  data: {
-    totalStaked: string;
-    stakers: string;
-    marketCap: string;
-  };
+  data?: QueryResponseData | null;
   isLoading: boolean;
 } => {
   const url = getEthApiPath(ETH_API_ROUTES.STETH_STATS);
 
-  const { data: rawData, isLoading } = useQuery<ResponseData>({
+  const { data, isLoading } = useQuery<
+    RequestResponseData | undefined,
+    Error,
+    QueryResponseData | null
+  >({
     queryKey: ['lido-stats', url],
-    queryFn: () => standardFetcher<ResponseData>(url),
+    enabled: !!url,
+    queryFn: () => {
+      if (!url) {
+        throw new Error('Missing URL for curve LidoStats request');
+      }
+      return standardFetcher<RequestResponseData>(url);
+    },
+    select: (rawData) => {
+      if (!rawData) {
+        return null;
+      }
+
+      return {
+        totalStaked: rawData?.totalStaked
+          ? `${Number(rawData.totalStaked).toLocaleString('en-US')} ETH`
+          : DATA_UNAVAILABLE,
+        stakers: rawData?.uniqueAnytimeHolders
+          ? String(rawData.uniqueAnytimeHolders)
+          : DATA_UNAVAILABLE,
+        marketCap: rawData?.marketCap
+          ? `$${Math.round(rawData.marketCap).toLocaleString('en-US')}`
+          : DATA_UNAVAILABLE,
+      };
+    },
     ...STRATEGY_LAZY,
   });
-
-  const data = useMemo(() => {
-    return {
-      totalStaked: rawData?.totalStaked
-        ? `${Number(rawData.totalStaked).toLocaleString('en-US')} ETH`
-        : DATA_UNAVAILABLE,
-      stakers: rawData?.uniqueAnytimeHolders
-        ? String(rawData.uniqueAnytimeHolders)
-        : DATA_UNAVAILABLE,
-      marketCap: rawData?.marketCap
-        ? `$${Math.round(rawData.marketCap).toLocaleString('en-US')}`
-        : DATA_UNAVAILABLE,
-    };
-  }, [rawData]);
 
   return {
     data,

--- a/utils/get-one-inch-rate.ts
+++ b/utils/get-one-inch-rate.ts
@@ -7,13 +7,21 @@ type GetOneInchRateParams = {
   amount?: bigint;
 };
 
-export const getOneInchRate = async ({
-  token,
-  amount,
-}: GetOneInchRateParams) => {
-  const params = new URLSearchParams({ token });
-  if (amount) params.append('amount', amount.toString());
-  const url = getEthApiPath(ETH_API_ROUTES.SWAP_ONE_INCH, params);
+export const getOneInchRate = async (params: GetOneInchRateParams | null) => {
+  if (!params) {
+    return null;
+  }
+
+  const { token, amount } = params;
+
+  const urlParams = new URLSearchParams({ token });
+  if (amount) urlParams.append('amount', amount.toString());
+  const url = getEthApiPath(ETH_API_ROUTES.SWAP_ONE_INCH, urlParams);
+
+  if (!url) {
+    return null;
+  }
+
   const data = await standardFetcher<{
     rate: number;
     toReceive: string;

--- a/utilsApi/cached-proxy.ts
+++ b/utilsApi/cached-proxy.ts
@@ -96,7 +96,7 @@ export const createEthApiProxy = ({
   if (!proxyUrl) {
     console.error('[createEthApiProxy] Skipped setup: EthApiPath is null');
     return (_req, res) => {
-      res.status(204).end();
+      res.status(404).end();
     };
   }
 

--- a/utilsApi/cached-proxy.ts
+++ b/utilsApi/cached-proxy.ts
@@ -91,11 +91,20 @@ export const createEthApiProxy = ({
   ignoreParams,
   transformData,
 }: EthApiProxyOptions): API => {
+  const proxyUrl = getEthApiPath(endpoint);
+
+  if (!proxyUrl) {
+    console.error('[createEthApiProxy] Skipped setup: EthApiPath is null');
+    return (_req, res) => {
+      res.status(204).end();
+    };
+  }
+
   return createCachedProxy({
     cacheTTL,
     ignoreParams,
     transformData,
-    proxyUrl: getEthApiPath(endpoint),
+    proxyUrl,
     metricsHost: config.ethAPIBasePath,
     timeout: 5000,
   });

--- a/utilsApi/get-default-static-props.ts
+++ b/utilsApi/get-default-static-props.ts
@@ -51,6 +51,11 @@ export const getDefaultStaticProps = <
         ...result,
         props: { ...base.props, ...customProps },
       };
+
+      // Fix error: `redirect` and `notFound` can not both be returned from getStaticProps at the same time.
+      if ('notFound' in result && 'redirect' in result) {
+        delete (result as any).notFound;
+      }
     }
 
     /// metrics

--- a/utilsApi/nextApiWrappers.ts
+++ b/utilsApi/nextApiWrappers.ts
@@ -253,7 +253,7 @@ export const nextDefaultErrorHandler =
   };
 
 type sunsetByArgs = {
-  replacementLink?: string | null;
+  replacementLink?: string;
   sunsetTimestamp: number;
 };
 

--- a/utilsApi/nextApiWrappers.ts
+++ b/utilsApi/nextApiWrappers.ts
@@ -253,7 +253,7 @@ export const nextDefaultErrorHandler =
   };
 
 type sunsetByArgs = {
-  replacementLink?: string;
+  replacementLink?: string | null;
   sunsetTimestamp: number;
 };
 


### PR DESCRIPTION
### Description

The service no longer depends on ENV:
- `WQ_API_BASE_PATH` — uses the SDK as a fallback and hides the stats block
- `REWARDS_BACKEND_BASE_PATH` (IPFS version) — uses the SDK and hides the rewards page
- `REWARDS_BACKEND` (infrastructure version) — uses the SDK and hides the rewards page
- `WQ_API_BASE_PATH` — uses the SDK as a fallback

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
