### PR TITLE
Add feature flag: disableSendCalls

### DIFF
--- a/IPFS.json
+++ b/IPFS.json
@@ -8,7 +8,9 @@
         324, 10, 42161, 137, 8453, 5000, 59144, 534352, 56, 34443, 48900, 1868,
         130, 1135
       ],
-      "featureFlags": {}
+      "featureFlags": {
+        "disableSendCalls": false
+      }
     }
   },
   "5": {
@@ -56,7 +58,8 @@
       "enabledWithdrawalDexes": ["one-inch", "paraswap", "bebop"],
       "multiChainBanner": [],
       "featureFlags": {
-        "ledgerLiveL2": true
+        "ledgerLiveL2": true,
+        "disableSendCalls": false
       }
     }
   }

--- a/config/external-config/types.ts
+++ b/config/external-config/types.ts
@@ -15,6 +15,7 @@ export type ManifestConfig = {
   multiChainBanner: number[];
   featureFlags: {
     ledgerLiveL2?: boolean;
+    disableSendCalls?: boolean;
   };
   pages?: {
     [page in ManifestConfigPage]?: {

--- a/modules/web3/hooks/use-aa.ts
+++ b/modules/web3/hooks/use-aa.ts
@@ -9,7 +9,7 @@ import { TransactionCallbackStage } from '@lidofinance/lido-ethereum-sdk';
 
 import { useDappStatus } from './use-dapp-status';
 import { useLidoSDK, useLidoSDKL2 } from '../web3-provider';
-import { config } from 'config';
+import { config, useConfig } from 'config';
 
 import type { Address, Hash } from 'viem';
 
@@ -30,6 +30,7 @@ export const useAA = () => {
       retry,
     },
   });
+  const { featureFlags } = useConfig().externalConfig;
 
   // merge capabilities per https://eips.ethereum.org/EIPS/eip-5792
   const capabilities = capabilitiesQuery.data
@@ -43,7 +44,9 @@ export const useAA = () => {
   // per EIP-5792 ANY successful call to getCapabilities is a sign of EIP support
   // but due to limited and variable support of this EIP we have to be narrow this down
   // known issues - batched action support for EOAs in many wallets
-  const isAA = !!capabilities?.atomicBatch?.supported;
+  // Also, there is an option to disable batch txs via EIP-5792 sendCalls in IPFS.json config file
+  const isAA =
+    !!capabilities?.atomicBatch?.supported && !featureFlags.disableSendCalls;
 
   const areAuxiliaryFundsSupported = !!capabilities?.auxiliaryFunds?.supported;
 


### PR DESCRIPTION
### Description

Adds feature flag for temporary disabling EIP-5792 sendCalls

### Testing notes

1. Override IPFS.json – set `config.featureFlags.disableSendCalls = true`
2. Use a wallet with EIP-5792 support to check batch transactions.

#### Examples:
##### `config.featureFlags.disableSendCalls === true`
- check Wrap stETH tx
- Expected result: no batch transactions, there are 2 txs: at first stETH approving and only after that wrapping
  

##### `config.featureFlags.disableSendCalls === false`
- check Wrap stETH tx
- Expected result: enabled batch transactions, there is one tx, which includes approving and wrapping at once

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
