### PR TITLE
Fix: rewards enter_address_manually matomo event

### DIFF
--- a/features/rewards/components/address-input/address-input.tsx
+++ b/features/rewards/components/address-input/address-input.tsx
@@ -1,10 +1,14 @@
-import { FC, useMemo } from 'react';
+import { FC, useMemo, ChangeEvent } from 'react';
+import { isAddress } from 'viem';
 import { Input, Loader, Identicon } from '@lidofinance/lido-ui';
+
 import CopyAddressUrl from 'features/rewards/components/CopyAddressUrl';
 import { isValidAnyAddress } from 'features/rewards/utils';
 import { ReactComponent as ErrorTriangle } from 'assets/icons/error-triangle.svg';
+import { trackMatomoEvent } from 'utils/track-matomo-event';
+import { MATOMO_INPUT_EVENTS_TYPES } from 'consts/matomo';
 
-import { AddressInputProps } from './types';
+import type { AddressInputProps } from './types';
 
 export const AddressInput: FC<AddressInputProps> = (props) => {
   const {
@@ -20,11 +24,21 @@ export const AddressInput: FC<AddressInputProps> = (props) => {
     [inputValue],
   );
 
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    handleInputChange(value);
+    if (isAddress(value)) {
+      trackMatomoEvent(
+        MATOMO_INPUT_EVENTS_TYPES.ethRewardsEnterAddressManually,
+      );
+    }
+  };
+
   return (
     <Input
       fullwidth
       value={inputValue}
-      onChange={(e) => handleInputChange(e.target.value)}
+      onChange={onChange}
       placeholder="Ethereum address"
       leftDecorator={
         isAddressResolving ? (

--- a/features/rewards/hooks/useGetCurrentAddress.ts
+++ b/features/rewards/hooks/useGetCurrentAddress.ts
@@ -65,9 +65,6 @@ export const useGetCurrentAddress: UseGetCurrentAddress = () => {
           await getEnsAddress(value);
         } else if (isAddress(value)) {
           setAddress(value);
-          trackMatomoEvent(
-            MATOMO_INPUT_EVENTS_TYPES.ethRewardsEnterAddressManually,
-          );
         } else {
           setAddress('');
         }


### PR DESCRIPTION
### Description

Fixes the issue when the `enter_address_manually` event fires together with the `enter_address_auto` event.


### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
