### PR TITLE
Disable sendCalls batching (flag = true)

### DIFF
--- a/IPFS.json
+++ b/IPFS.json
@@ -9,7 +9,7 @@
         130, 1135
       ],
       "featureFlags": {
-        "disableSendCalls": false
+        "disableSendCalls": true
       }
     }
   },


### PR DESCRIPTION
### Description

Set `disableSendCalls` feature flag = true, which DISABLES batching txs

### Checklist:

- [ ] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
