### PR TITLE
Enable sendCalls batching (flag = false)

### DIFF
--- a/IPFS.json
+++ b/IPFS.json
@@ -9,7 +9,7 @@
         130, 1135
       ],
       "featureFlags": {
-        "disableSendCalls": true
+        "disableSendCalls": false
       }
     }
   },


### PR DESCRIPTION
### Description

Set disableSendCalls feature flag = false, which ENABLES batching txs

### Checklist:

- [ ] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
