### PR TITLE
Reward Page – fix stETH balance if wallet not connected

### DIFF
--- a/modules/web3/web3-provider/dapp-chain.tsx
+++ b/modules/web3/web3-provider/dapp-chain.tsx
@@ -93,7 +93,7 @@ export const useDappChain = (): UseDappChainValue => {
 
     return {
       ...context,
-      isChainMatched: context.chainId === walletChain,
+      isChainMatched: walletChain ? context.chainId === walletChain : true,
       isSupportedChain: walletChain
         ? context.supportedChainIds.includes(walletChain) &&
           isSDKSupportedChain(walletChain)


### PR DESCRIPTION
### Description
Fixes the issue (SI-1930) – "the stETH balance isn't displayed on the reward page without a connected wallet".

The issue comes from this change (line 241):
https://github.com/lidofinance/ethereum-staking-widget/commit/9be7291548f7e5d0fc022417bbb00b12142880a7#diff-a5c65cdd246477f648aa2b4bb9372bdcdba53da41756dfbb475640765850ca95R240-R241

**Reason:**
- `isChainMatched` is always false, when wallet is not connected
- `isSupportedChain` is always true, when wallet is not connected
-  `isSupportedChain` was replaced with `isChainMatched`, therefore `useQuery` getting the contract address is never `enabled` if wallet is not connected

**Solution:**
I decided to apply to isChainMatched the same logic that isSupportedChain uses — to always return true if the wallet is not connected.

An alternative would be something like this:
```
const enabled = isWalletConnected ? !!mergedAccount && isChainMatched : !!mergedAccount;
```
But I think this mistake may happen again in the future in that case.

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
