### PR TITLE
Replace date-fns with custom date utilities

### DIFF
--- a/features/rewards/components/Date.tsx
+++ b/features/rewards/components/Date.tsx
@@ -1,13 +1,14 @@
 import { Tooltip, Box } from '@lidofinance/lido-ui';
-import { lightFormat, fromUnixTime } from 'date-fns';
 import type { Event } from 'features/rewards/types';
+import { fromUnixTime } from '../utils/fromUnixTime';
+import { formatDate } from '../utils/formatDate';
 
 // TODO: move to separate folders
 const Date = ({ blockTime }: { blockTime: Event['blockTime'] }) => {
   const parsed = fromUnixTime(parseInt(blockTime));
 
-  const light = lightFormat(parsed, 'dd.MM.yyyy');
-  const full = lightFormat(parsed, 'dd.MM.yyyy HH:mm');
+  const light = formatDate(parsed);
+  const full = formatDate(parsed, true);
 
   return (
     <Tooltip

--- a/features/rewards/utils/formatDate.ts
+++ b/features/rewards/utils/formatDate.ts
@@ -1,0 +1,12 @@
+const pad = (n: number) => n.toString().padStart(2, '0');
+export const formatDate = (date: Date, withTime = false) => {
+  const day = pad(date.getDate());
+  const month = pad(date.getMonth() + 1);
+  const year = date.getFullYear();
+  if (withTime) {
+    const hours = pad(date.getHours());
+    const minutes = pad(date.getMinutes());
+    return `${day}.${month}.${year} ${hours}:${minutes}`;
+  }
+  return `${day}.${month}.${year}`;
+};

--- a/features/rewards/utils/fromUnixTime.ts
+++ b/features/rewards/utils/fromUnixTime.ts
@@ -1,0 +1,4 @@
+// Converts a Unix timestamp (in seconds) to a JavaScript Date object.
+export const fromUnixTime = (unixTime: number): Date => {
+  return new Date(unixTime * 1000);
+};

--- a/features/rewards/utils/genExportData.ts
+++ b/features/rewards/utils/genExportData.ts
@@ -1,8 +1,9 @@
-import { fromUnixTime } from 'date-fns';
 import { formatEther } from 'viem';
 
 import type { Event } from 'features/rewards/types';
 import type { CurrencyType } from 'features/rewards/constants';
+
+import { fromUnixTime } from './fromUnixTime';
 
 export const genExportData = (currency: CurrencyType, data: Event[] | null) =>
   data

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@tanstack/react-query": "^5.51.21",
     "copy-to-clipboard": "^3.3.1",
     "cors": "^2.8.5",
-    "date-fns": "2.29.2",
     "fs-extra": "^10.1.0",
     "js-cookie": "^3.0.1",
     "lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5334,11 +5334,6 @@ dargs@^7.0.0:
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-7.0.0.tgz#04015c41de0bcb69ec84050f3d9be0caf8d6d5cc"
   integrity sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==
 
-date-fns@2.29.2:
-  version "2.29.2"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.2.tgz#0d4b3d0f3dff0f920820a070920f0d9662c51931"
-  integrity sha512-0VNbwmWJDS/G3ySwFSJA3ayhbURMTJLtwM2DTxf9CWondCnh6DTNlO9JgRSq6ibf4eD0lfMJNBxUdEAHHix+bA==
-
 date-fns@^2.29.3:
   version "2.30.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"


### PR DESCRIPTION
### Description
- remove date-fns dependency due to low usage, replace with custom utils
- should solve issue, when yarn wasn't able to fetch date-fns package archive during CI build

### Testing notes

This change can affect dates on Reward history page
Expected result: no changes in the UI

<img width="664" alt="image" src="https://github.com/user-attachments/assets/3cf852c4-f41d-4e67-ab1e-cb5f2c82cd5f" />


### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
