### PR TITLE
Enable MetaMask SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react-hook-form": "^7.45.2",
     "react-is": "^18.2.0",
     "react-transition-group": "^4.4.2",
-    "reef-knot": "7.3.0-alpha.2",
+    "reef-knot": "7.3.0-alpha.3",
     "styled-components": "^5.3.5",
     "tiny-async-pool": "^1.2.0",
     "tiny-invariant": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react-hook-form": "^7.45.2",
     "react-is": "^18.2.0",
     "react-transition-group": "^4.4.2",
-    "reef-knot": "7.3.0-alpha.1",
+    "reef-knot": "7.3.0-alpha.2",
     "styled-components": "^5.3.5",
     "tiny-async-pool": "^1.2.0",
     "tiny-invariant": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2938,23 +2938,23 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.24.tgz#58601079e11784d20f82d0585865bb42305c4df3"
   integrity sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ==
 
-"@reef-knot/connect-wallet-modal@7.3.0-alpha.1":
-  version "7.3.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@reef-knot/connect-wallet-modal/-/connect-wallet-modal-7.3.0-alpha.1.tgz#3a7c61555d8706436267a644f4ecfb86deced420"
-  integrity sha512-t98HMHJg6zUiULhEB+osYAnnsoh9aRt9Tliu8Kvv3vXYdo1pde6kvd7iMkZQfIKSJQyLMpE3Ha9fXCmPhq+SFw==
+"@reef-knot/connect-wallet-modal@7.3.0-alpha.2":
+  version "7.3.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@reef-knot/connect-wallet-modal/-/connect-wallet-modal-7.3.0-alpha.2.tgz#706185fc919b30002651a417d54b7e82241861de"
+  integrity sha512-TjlGWGGxRAeVl4KXUkVmiBoUqizmYtTwhXBSYPEZvYvvHI0O4Tzv+uD3f6b7h5pQpkVPjJ5pzdytELoHpfs+sA==
   dependencies:
     "@ledgerhq/hw-app-eth" "^6.37.1"
     "@ledgerhq/hw-transport" "^6.31.0"
     "@ledgerhq/hw-transport-webhid" "^6.29.0"
     "@lidofinance/lido-ui" "^3.18.0"
-    "@reef-knot/wallets-list" "4.2.0-alpha.1"
+    "@reef-knot/wallets-list" "4.2.0-alpha.2"
     "@types/react" "18.2.45"
     "@types/react-dom" "18.2.17"
 
-"@reef-knot/core-react@6.2.0-alpha.1":
-  version "6.2.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@reef-knot/core-react/-/core-react-6.2.0-alpha.1.tgz#ae2d49a54a7fdacdd42182f3df5bb3f4dd07b176"
-  integrity sha512-PzvL5iy6MpWB56m/ZuXi2dtQNaqCi0aUQH/Uma5kljPKO7veylkzuRgldtq0Po6s2ihmApCyO+oCafQYDib0nQ==
+"@reef-knot/core-react@6.2.0-alpha.2":
+  version "6.2.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@reef-knot/core-react/-/core-react-6.2.0-alpha.2.tgz#b1ff4e949e89463089af48f6f9736381a6c7ffee"
+  integrity sha512-EBh9FoAKJCKcmT08Pw0k+dg7+OVBTAh7vVWgtCGepQ7AJB38f8tnE4C3bWIqq9FFSQeQo0lIgX+H+QJPVHn1cA==
 
 "@reef-knot/ledger-connector@4.4.0-alpha.2":
   version "4.4.0-alpha.2"
@@ -3064,10 +3064,10 @@
   resolved "https://registry.yarnpkg.com/@reef-knot/wallet-adapter-ledger-live/-/wallet-adapter-ledger-live-5.2.0-alpha.1.tgz#18e38ac42dfead1f20a2f83cd65fc83b9c3b461c"
   integrity sha512-xdSwOe3G+lqExb55K0NWshct+MMX2GpTiUZkRpvoTnoSrYSRKcxhqNf1IbEofmqoMy+x6U+IhFT9y0VlRYBQCA==
 
-"@reef-knot/wallet-adapter-metamask@4.2.0-alpha.1":
-  version "4.2.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@reef-knot/wallet-adapter-metamask/-/wallet-adapter-metamask-4.2.0-alpha.1.tgz#344d95194c4dd5a307820832db48247754f09455"
-  integrity sha512-YGkEyD5cm7Wnntn+mqCbciWZN+eEXpnTOQgvPS8zXPFUnUVnSzBkrA1SnhIURwMXw6zWN3RgyTIe4MWs8geycA==
+"@reef-knot/wallet-adapter-metamask@4.2.0-alpha.2":
+  version "4.2.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@reef-knot/wallet-adapter-metamask/-/wallet-adapter-metamask-4.2.0-alpha.2.tgz#61c7aa8ddba8644a71f3db6186baffce5249832c"
+  integrity sha512-ThaEHDNxFqWpyIjza8/+HHhYyGZYi9S4HSMKyUPn/wc5vOGHUOTTho8QAOsE3MeukcEFpV7R4MWL1GGUfj1+CA==
 
 "@reef-knot/wallet-adapter-okx@4.2.0-alpha.1":
   version "4.2.0-alpha.1"
@@ -3097,10 +3097,10 @@
     "@types/ua-parser-js" "0.7.39"
     ua-parser-js "1.0.37"
 
-"@reef-knot/wallets-list@4.2.0-alpha.1":
-  version "4.2.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@reef-knot/wallets-list/-/wallets-list-4.2.0-alpha.1.tgz#a5e4de261b2cc449b6d8b24b6b53745e22a20732"
-  integrity sha512-CZANVBRJM4tTw5f03p90RcZygn1N5kEtKLn7d2vNFE4QoQNDO7RveTFZunlUFNYnusRee4PJSdkOM4E3d5cuJw==
+"@reef-knot/wallets-list@4.2.0-alpha.2":
+  version "4.2.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@reef-knot/wallets-list/-/wallets-list-4.2.0-alpha.2.tgz#62f36980e222534bcc68b58b64e88a4b7be24e7e"
+  integrity sha512-mE58wGTYhnzHbx9k7GFNrv22JrcJ9csqQ2vfFnKfLc4O23FMkkjw5gLYkXJUI2ukBw5KR8iIq6CS08jsjl4vYA==
   dependencies:
     "@reef-knot/wallet-adapter-ambire" "5.2.0-alpha.1"
     "@reef-knot/wallet-adapter-binance-wallet" "3.2.0-alpha.1"
@@ -3116,16 +3116,16 @@
     "@reef-knot/wallet-adapter-imtoken" "4.2.0-alpha.1"
     "@reef-knot/wallet-adapter-ledger-hid" "5.2.0-alpha.1"
     "@reef-knot/wallet-adapter-ledger-live" "5.2.0-alpha.1"
-    "@reef-knot/wallet-adapter-metamask" "4.2.0-alpha.1"
+    "@reef-knot/wallet-adapter-metamask" "4.2.0-alpha.2"
     "@reef-knot/wallet-adapter-okx" "4.2.0-alpha.1"
     "@reef-knot/wallet-adapter-safe" "4.2.0-alpha.1"
     "@reef-knot/wallet-adapter-trust" "4.2.0-alpha.1"
     "@reef-knot/wallet-adapter-walletconnect" "4.2.0-alpha.1"
 
-"@reef-knot/web3-react@6.2.0-alpha.1":
-  version "6.2.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@reef-knot/web3-react/-/web3-react-6.2.0-alpha.1.tgz#d23be79199034569fdc1dc473cb9522143591af2"
-  integrity sha512-SGX9OGDBHOOlN/uYany0+XtghnE6sZCV/v3hM5QLpT3m7uZJFHp2BTqgMNfnEC0LRuL0DxLPYeMFy1/NPdUKUA==
+"@reef-knot/web3-react@6.2.0-alpha.2":
+  version "6.2.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@reef-knot/web3-react/-/web3-react-6.2.0-alpha.2.tgz#001ace79b51f6a0374b9dc5d412af6914db14092"
+  integrity sha512-NK9lH09BBJGhMyH9eZk/iv0x4cuAwXFg5knhaug/b8GI+yW8OJKK4qFlIKDxORd0H0LbSwpJeBQP7AV6O8fVyQ==
   dependencies:
     tiny-invariant "^1.1.0"
 
@@ -9377,19 +9377,19 @@ redis-parser@^3.0.0:
   dependencies:
     redis-errors "^1.0.0"
 
-reef-knot@7.3.0-alpha.1:
-  version "7.3.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/reef-knot/-/reef-knot-7.3.0-alpha.1.tgz#8996cfb74c7925f75017200146e86f35daa12a2d"
-  integrity sha512-MP7VJMweXw/zxHskcIEHrq0+mND/rMG/TvInLiNgtix83MXfbaPnuFN8omOmgnSidh9drrikgr9xXoM0c8VIIA==
+reef-knot@7.3.0-alpha.2:
+  version "7.3.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/reef-knot/-/reef-knot-7.3.0-alpha.2.tgz#e0b62f64a83e2354428c64b088474aea1173a56e"
+  integrity sha512-Q4ADkrZlNXZlbuta+cafIycxG6xyJ0UyCYii8Lrp4ZQFJM+QtQyy0wQ80QGjkL6ckX419Z4udLXFsjY4w/eE8A==
   dependencies:
-    "@reef-knot/connect-wallet-modal" "7.3.0-alpha.1"
-    "@reef-knot/core-react" "6.2.0-alpha.1"
+    "@reef-knot/connect-wallet-modal" "7.3.0-alpha.2"
+    "@reef-knot/core-react" "6.2.0-alpha.2"
     "@reef-knot/ledger-connector" "4.4.0-alpha.2"
     "@reef-knot/types" "4.2.0-alpha.1"
     "@reef-knot/ui-react" "2.3.0-alpha.1"
     "@reef-knot/wallets-helpers" "2.3.0-alpha.1"
-    "@reef-knot/wallets-list" "4.2.0-alpha.1"
-    "@reef-knot/web3-react" "6.2.0-alpha.1"
+    "@reef-knot/wallets-list" "4.2.0-alpha.2"
+    "@reef-knot/web3-react" "6.2.0-alpha.2"
 
 reflect.getprototypeof@^1.0.4:
   version "1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2938,23 +2938,23 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.24.tgz#58601079e11784d20f82d0585865bb42305c4df3"
   integrity sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ==
 
-"@reef-knot/connect-wallet-modal@7.3.0-alpha.2":
-  version "7.3.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@reef-knot/connect-wallet-modal/-/connect-wallet-modal-7.3.0-alpha.2.tgz#706185fc919b30002651a417d54b7e82241861de"
-  integrity sha512-TjlGWGGxRAeVl4KXUkVmiBoUqizmYtTwhXBSYPEZvYvvHI0O4Tzv+uD3f6b7h5pQpkVPjJ5pzdytELoHpfs+sA==
+"@reef-knot/connect-wallet-modal@7.3.0-alpha.3":
+  version "7.3.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@reef-knot/connect-wallet-modal/-/connect-wallet-modal-7.3.0-alpha.3.tgz#f37e29ecb8562a9b3892a11b2bcf899fee081b3f"
+  integrity sha512-L2Q6rF1GD6KbnD4Sr+jJTWy8BJgpLERov6GzjdjULc65tHaZ3+haXW8kiE1cJtkuLs0K28qQdsrrL4OXzLPggQ==
   dependencies:
     "@ledgerhq/hw-app-eth" "^6.37.1"
     "@ledgerhq/hw-transport" "^6.31.0"
     "@ledgerhq/hw-transport-webhid" "^6.29.0"
     "@lidofinance/lido-ui" "^3.18.0"
-    "@reef-knot/wallets-list" "4.2.0-alpha.2"
+    "@reef-knot/wallets-list" "4.2.0-alpha.3"
     "@types/react" "18.2.45"
     "@types/react-dom" "18.2.17"
 
-"@reef-knot/core-react@6.2.0-alpha.2":
-  version "6.2.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@reef-knot/core-react/-/core-react-6.2.0-alpha.2.tgz#b1ff4e949e89463089af48f6f9736381a6c7ffee"
-  integrity sha512-EBh9FoAKJCKcmT08Pw0k+dg7+OVBTAh7vVWgtCGepQ7AJB38f8tnE4C3bWIqq9FFSQeQo0lIgX+H+QJPVHn1cA==
+"@reef-knot/core-react@6.2.0-alpha.3":
+  version "6.2.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@reef-knot/core-react/-/core-react-6.2.0-alpha.3.tgz#beb45b519a176005d30fb7ee99f8eace77dcca46"
+  integrity sha512-aMiUOnxtqIJrS2QQKGABRw5iToaoBJQlSSSXOTJuP0YiLHOR9FhqMGYzUqyNG8ZQzbXJN7VC7R1rXlHpPc1giA==
 
 "@reef-knot/ledger-connector@4.4.0-alpha.2":
   version "4.4.0-alpha.2"
@@ -3074,10 +3074,10 @@
   resolved "https://registry.yarnpkg.com/@reef-knot/wallet-adapter-okx/-/wallet-adapter-okx-4.2.0-alpha.1.tgz#183c670cf717f48bc3491b6107e271633acc4616"
   integrity sha512-zKEBsISsiO4VwHtqqrEPGC9YNHlwdFOo70zpqx2o5i6B+612Sz13miEnSpb+8ZHU2Jt3TylJ1Jue5mde+LWddw==
 
-"@reef-knot/wallet-adapter-safe@4.2.0-alpha.1":
-  version "4.2.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@reef-knot/wallet-adapter-safe/-/wallet-adapter-safe-4.2.0-alpha.1.tgz#a371f7ddd69c4bf938fe64eb153543fdc8bacf98"
-  integrity sha512-rdP3JOPbsKZTscGJGkawMEYrIRVa47/oivlapUGby9es57+ax7Cu8zUeOGv5RNoRWNeKNKvEyaouabHHPf+j0g==
+"@reef-knot/wallet-adapter-safe@4.2.0-alpha.2":
+  version "4.2.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@reef-knot/wallet-adapter-safe/-/wallet-adapter-safe-4.2.0-alpha.2.tgz#34f4d6986f06b3c4e664b0f916797d76b85b2213"
+  integrity sha512-NpIIyxAkoyCNW9mwYimBqUlrYFj4LoQCDJGzccOAvFVytm4OIdE1zdsbYv9vXJDnInH8pNsOWZBpnpnk2bICjA==
 
 "@reef-knot/wallet-adapter-trust@4.2.0-alpha.1":
   version "4.2.0-alpha.1"
@@ -3097,10 +3097,10 @@
     "@types/ua-parser-js" "0.7.39"
     ua-parser-js "1.0.37"
 
-"@reef-knot/wallets-list@4.2.0-alpha.2":
-  version "4.2.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@reef-knot/wallets-list/-/wallets-list-4.2.0-alpha.2.tgz#62f36980e222534bcc68b58b64e88a4b7be24e7e"
-  integrity sha512-mE58wGTYhnzHbx9k7GFNrv22JrcJ9csqQ2vfFnKfLc4O23FMkkjw5gLYkXJUI2ukBw5KR8iIq6CS08jsjl4vYA==
+"@reef-knot/wallets-list@4.2.0-alpha.3":
+  version "4.2.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@reef-knot/wallets-list/-/wallets-list-4.2.0-alpha.3.tgz#da9697abe417ec9cfff35809034ec6da47cc92d2"
+  integrity sha512-l2kCkavq/cUqhQE5CFdsb5Q2ZtZqP4SQUE1aczKPkav+i9c6derrRo1mRK9JO88PU818Nwv2o4PbNm1DZZXdgw==
   dependencies:
     "@reef-knot/wallet-adapter-ambire" "5.2.0-alpha.1"
     "@reef-knot/wallet-adapter-binance-wallet" "3.2.0-alpha.1"
@@ -3118,14 +3118,14 @@
     "@reef-knot/wallet-adapter-ledger-live" "5.2.0-alpha.1"
     "@reef-knot/wallet-adapter-metamask" "4.2.0-alpha.2"
     "@reef-knot/wallet-adapter-okx" "4.2.0-alpha.1"
-    "@reef-knot/wallet-adapter-safe" "4.2.0-alpha.1"
+    "@reef-knot/wallet-adapter-safe" "4.2.0-alpha.2"
     "@reef-knot/wallet-adapter-trust" "4.2.0-alpha.1"
     "@reef-knot/wallet-adapter-walletconnect" "4.2.0-alpha.1"
 
-"@reef-knot/web3-react@6.2.0-alpha.2":
-  version "6.2.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@reef-knot/web3-react/-/web3-react-6.2.0-alpha.2.tgz#001ace79b51f6a0374b9dc5d412af6914db14092"
-  integrity sha512-NK9lH09BBJGhMyH9eZk/iv0x4cuAwXFg5knhaug/b8GI+yW8OJKK4qFlIKDxORd0H0LbSwpJeBQP7AV6O8fVyQ==
+"@reef-knot/web3-react@6.2.0-alpha.3":
+  version "6.2.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@reef-knot/web3-react/-/web3-react-6.2.0-alpha.3.tgz#f8fe1db034a57a8277df9f27ef1fb2db4b7e1ec0"
+  integrity sha512-HtUoCZsQfjpLaE6FIIyUy79eBRoVAzw1/u7pP2q0nTikI8cYjH5kxr2AQq47WhzGKF85VtyHWQ0yBHKEmei/Yg==
   dependencies:
     tiny-invariant "^1.1.0"
 
@@ -9377,19 +9377,19 @@ redis-parser@^3.0.0:
   dependencies:
     redis-errors "^1.0.0"
 
-reef-knot@7.3.0-alpha.2:
-  version "7.3.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/reef-knot/-/reef-knot-7.3.0-alpha.2.tgz#e0b62f64a83e2354428c64b088474aea1173a56e"
-  integrity sha512-Q4ADkrZlNXZlbuta+cafIycxG6xyJ0UyCYii8Lrp4ZQFJM+QtQyy0wQ80QGjkL6ckX419Z4udLXFsjY4w/eE8A==
+reef-knot@7.3.0-alpha.3:
+  version "7.3.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/reef-knot/-/reef-knot-7.3.0-alpha.3.tgz#acbf7eb9e5e7b3b91bcdc1660b71787c0d852769"
+  integrity sha512-zdcI3+FbIdBO22jwEvfbxS5buLiiAue2XxwhKMCMcghX0ZELdBhHbcNKyqbMp5q8K2LDWfFIkirwxOKg3n9A7A==
   dependencies:
-    "@reef-knot/connect-wallet-modal" "7.3.0-alpha.2"
-    "@reef-knot/core-react" "6.2.0-alpha.2"
+    "@reef-knot/connect-wallet-modal" "7.3.0-alpha.3"
+    "@reef-knot/core-react" "6.2.0-alpha.3"
     "@reef-knot/ledger-connector" "4.4.0-alpha.2"
     "@reef-knot/types" "4.2.0-alpha.1"
     "@reef-knot/ui-react" "2.3.0-alpha.1"
     "@reef-knot/wallets-helpers" "2.3.0-alpha.1"
-    "@reef-knot/wallets-list" "4.2.0-alpha.2"
-    "@reef-knot/web3-react" "6.2.0-alpha.2"
+    "@reef-knot/wallets-list" "4.2.0-alpha.3"
+    "@reef-knot/web3-react" "6.2.0-alpha.3"
 
 reflect.getprototypeof@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
### Description

Updates reef-knot to the version where MM SDK is used to connect MetaMask

### Code review notes
Uses reef-knot alpha version at first, to be updated to the stable version after tests

### Testing notes
Uses reef-knot alpha version at first, to be updated to the stable version after tests

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
