### PR TITLE
1inch – change swap link

### DIFF
--- a/features/withdrawals/request/withdrawal-rates/integrations.ts
+++ b/features/withdrawals/request/withdrawal-rates/integrations.ts
@@ -179,9 +179,7 @@ const dexWithdrawalMap: DexWithdrawalIntegrationMap = {
     icon: OneInchIcon,
     matomoEvent: MATOMO_CLICK_EVENTS_TYPES.withdrawalGoTo1inch,
     link: (amount, token) =>
-      `https://app.1inch.io/#/1/advanced/swap/${
-        token === TOKENS_TO_WITHDRAWLS.stETH ? 'stETH' : 'wstETH'
-      }/ETH?mode=classic&sourceTokenAmount=${formatEther(amount)}`,
+      `https://app.1inch.io/swap?src=1:${token === TOKENS_TO_WITHDRAWLS.stETH ? 'StETH' : 'WstETH'}&dst=1:ETH`,
   },
   bebop: {
     title: 'Bebop',


### PR DESCRIPTION
### Description

The PR changes "Go to 1inch" link on the withdrawals -> Use DEXes block


### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
