### PR TITLE
Add matomo event: ethRewardsDashboardDownloaded 

### DIFF
--- a/consts/matomo/index.ts
+++ b/consts/matomo/index.ts
@@ -2,6 +2,7 @@ export * from './matomo-click-events';
 export * from './matomo-tx-events';
 export * from './matomo-wallets-events';
 export * from './matomo-input-events';
+export * from './matomo-fetch-events';
 
 import {
   MATOMO_CLICK_EVENTS,
@@ -12,13 +13,19 @@ import {
   MATOMO_INPUT_EVENTS,
   MATOMO_INPUT_EVENTS_TYPES,
 } from './matomo-input-events';
+import {
+  MATOMO_FETCH_EVENTS,
+  MATOMO_FETCH_EVENTS_TYPES,
+} from './matomo-fetch-events';
 
 export const MATOMO_EVENTS = {
   ...MATOMO_CLICK_EVENTS,
   ...MATOMO_TX_EVENTS,
   ...MATOMO_INPUT_EVENTS,
+  ...MATOMO_FETCH_EVENTS,
 };
 export type MATOMO_EVENT_TYPE =
   | MATOMO_CLICK_EVENTS_TYPES
   | MATOMO_TX_EVENTS_TYPES
-  | MATOMO_INPUT_EVENTS_TYPES;
+  | MATOMO_INPUT_EVENTS_TYPES
+  | MATOMO_FETCH_EVENTS_TYPES;

--- a/consts/matomo/matomo-fetch-events.ts
+++ b/consts/matomo/matomo-fetch-events.ts
@@ -1,0 +1,16 @@
+import { MatomoEventType } from '@lidofinance/analytics-matomo';
+
+export const enum MATOMO_FETCH_EVENTS_TYPES {
+  ethRewardsDashboardDownloaded = 'ethRewardsDashboardDownloaded',
+}
+
+export const MATOMO_FETCH_EVENTS: Record<
+  MATOMO_FETCH_EVENTS_TYPES,
+  MatomoEventType
+> = {
+  [MATOMO_FETCH_EVENTS_TYPES.ethRewardsDashboardDownloaded]: [
+    'Ethereum_Rewards_Widget',
+    'Rewards dashboard is downloaded',
+    'eth_rewards_rewards_dashboard_downloaded',
+  ],
+};


### PR DESCRIPTION
### Description

The PR adds matomo event – the key action under that event is the state when users see the dashboard downloaded with their data

### Checklist:

- [x] Checked the changes locally.
- [x] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [x] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
