### PR TITLE
Dual Governance status banner

### DIFF
--- a/IPFS.json
+++ b/IPFS.json
@@ -59,7 +59,9 @@
       "multiChainBanner": [],
       "featureFlags": {
         "ledgerLiveL2": true,
-        "disableSendCalls": false
+        "disableSendCalls": false,
+        "dgBannerEnabled": false,
+        "dgWarningState": false
       }
     }
   }

--- a/config/external-config/types.ts
+++ b/config/external-config/types.ts
@@ -16,6 +16,7 @@ export type ManifestConfig = {
   featureFlags: {
     ledgerLiveL2?: boolean;
     disableSendCalls?: boolean;
+    dgBannerEnabled?: boolean;
     dgWarningState?: boolean;
     dgBlockedState?: boolean;
   };

--- a/config/external-config/types.ts
+++ b/config/external-config/types.ts
@@ -18,7 +18,6 @@ export type ManifestConfig = {
     disableSendCalls?: boolean;
     dgBannerEnabled?: boolean;
     dgWarningState?: boolean;
-    dgBlockedState?: boolean;
   };
   pages?: {
     [page in ManifestConfigPage]?: {

--- a/config/external-config/types.ts
+++ b/config/external-config/types.ts
@@ -16,6 +16,8 @@ export type ManifestConfig = {
   featureFlags: {
     ledgerLiveL2?: boolean;
     disableSendCalls?: boolean;
+    dgWarningState?: boolean;
+    dgBlockedState?: boolean;
   };
   pages?: {
     [page in ManifestConfigPage]?: {

--- a/features/stake/stake-form/stake-form.tsx
+++ b/features/stake/stake-form/stake-form.tsx
@@ -9,6 +9,7 @@ import { StakeFormInfo } from './stake-form-info';
 import { SwapDiscountBanner } from '../swap-discount-banner';
 import { StakeBlock, FormControllerStyled } from './styles';
 import { DVVBanner } from 'shared/banners/dvv-banner';
+import { DualGovernanceBanner } from 'shared/banners/dual-governance-banner';
 
 export const StakeForm: FC = memo(() => {
   return (
@@ -18,9 +19,11 @@ export const StakeForm: FC = memo(() => {
         <FormControllerStyled>
           <StakeAmountInput />
           <StakeSubmitButton />
-          <SwapDiscountBanner>
-            <DVVBanner />
-          </SwapDiscountBanner>
+          <DualGovernanceBanner>
+            <SwapDiscountBanner>
+              <DVVBanner />
+            </SwapDiscountBanner>
+          </DualGovernanceBanner>
         </FormControllerStyled>
         <StakeFormInfo />
       </StakeBlock>

--- a/modules/web3/web3-provider/lido-sdk.tsx
+++ b/modules/web3/web3-provider/lido-sdk.tsx
@@ -17,6 +17,7 @@ import {
 import { LidoSDKWrap } from '@lidofinance/lido-ethereum-sdk/wrap';
 import { LidoSDKWithdraw } from '@lidofinance/lido-ethereum-sdk/withdraw';
 import { LidoSDKStatistics } from '@lidofinance/lido-ethereum-sdk/statistics';
+import { LidoSDKDualGovernance } from '@lidofinance/lido-ethereum-sdk/dual-governance';
 
 import { config } from 'config';
 import { CONTRACT_NAMES } from 'config/networks/networks-map';
@@ -33,6 +34,7 @@ type LidoSDKContextValue = {
   wrap: LidoSDKWrap;
   withdraw: LidoSDKWithdraw;
   statistics: LidoSDKStatistics;
+  dualGovernance: LidoSDKDualGovernance;
   subscribeToTokenUpdates: ReturnType<typeof useTokenTransferSubscription>;
 };
 
@@ -101,6 +103,7 @@ export const LidoSDKProvider = ({ children }: React.PropsWithChildren) => {
     const wrap = new LidoSDKWrap({ core });
     const withdraw = new LidoSDKWithdraw({ core });
     const statistics = new LidoSDKStatistics({ core });
+    const dualGovernance = new LidoSDKDualGovernance({ core });
 
     return {
       chainId: core.chainId,
@@ -111,6 +114,7 @@ export const LidoSDKProvider = ({ children }: React.PropsWithChildren) => {
       wrap,
       withdraw,
       statistics,
+      dualGovernance,
       subscribeToTokenUpdates: subscribe,
       // the L2 module you can to find in the 'modules/web3/web3-provider/lido-sdk-l2.tsx'
     };

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@lidofinance/api-rpc": "^0.48.0",
     "@lidofinance/eth-api-providers": "^0.48.0",
     "@lidofinance/eth-providers": "^0.48.0",
-    "@lidofinance/lido-ethereum-sdk": "4.5.0-alpha.2",
+    "@lidofinance/lido-ethereum-sdk": "4.5.0-alpha.3",
     "@lidofinance/lido-ui": "^3.28.1",
     "@lidofinance/next-api-wrapper": "^0.48.0",
     "@lidofinance/next-ip-rate-limit": "^0.48.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@lidofinance/api-rpc": "^0.48.0",
     "@lidofinance/eth-api-providers": "^0.48.0",
     "@lidofinance/eth-providers": "^0.48.0",
-    "@lidofinance/lido-ethereum-sdk": "4.4.0",
+    "@lidofinance/lido-ethereum-sdk": "4.5.0-alpha.2",
     "@lidofinance/lido-ui": "^3.28.1",
     "@lidofinance/next-api-wrapper": "^0.48.0",
     "@lidofinance/next-ip-rate-limit": "^0.48.0",

--- a/shared/banners/dual-governance-banner/blocked-state.tsx
+++ b/shared/banners/dual-governance-banner/blocked-state.tsx
@@ -1,0 +1,24 @@
+import { BannerTitle, BannerDescription } from './styles';
+
+export const BlockedState = ({
+  currentVetoSupportPercent,
+}: {
+  currentVetoSupportPercent: number;
+}) => {
+  return (
+    <>
+      <BannerTitle>
+        Dual Governance: <br />
+        Dynamic Timelock active
+      </BannerTitle>
+      <BannerDescription>
+        Lido DAO governance is now in a dynamic timelock.
+        <br />
+        {currentVetoSupportPercent}% of stETH supply opposes the DAO — the
+        staking may carry elevated risk.
+        <br />
+        Check details on Dual Governance page.
+      </BannerDescription>
+    </>
+  );
+};

--- a/shared/banners/dual-governance-banner/blocked-state.tsx
+++ b/shared/banners/dual-governance-banner/blocked-state.tsx
@@ -1,9 +1,9 @@
 import { BannerTitle, BannerDescription } from './styles';
 
 export const BlockedState = ({
-  currentVetoSupportPercent,
+  vetoSupportPercent,
 }: {
-  currentVetoSupportPercent: number;
+  vetoSupportPercent: number;
 }) => {
   return (
     <>
@@ -14,8 +14,8 @@ export const BlockedState = ({
       <BannerDescription>
         Lido DAO governance is now in a dynamic timelock.
         <br />
-        {currentVetoSupportPercent}% of stETH supply opposes the DAO — the
-        staking may carry elevated risk.
+        {vetoSupportPercent}% of stETH supply opposes the DAO — the staking may
+        carry elevated risk.
         <br />
         Check details on Dual Governance page.
       </BannerDescription>

--- a/shared/banners/dual-governance-banner/dual-governance-banner.tsx
+++ b/shared/banners/dual-governance-banner/dual-governance-banner.tsx
@@ -11,11 +11,16 @@ const DG_TRIGGER_PERCENT = 33;
 const DG_LINK = 'https://dg.lido.fi';
 
 export const DualGovernanceBanner = ({ children }: React.PropsWithChildren) => {
-  const { isWarningState, isBlockedState, currentVetoSupportPercent } =
-    useDGWarningStatus();
+  const {
+    isWarningState,
+    isBlockedState,
+    isDGBannerEnabled,
+    currentVetoSupportPercent,
+  } = useDGWarningStatus();
 
   // Show banner only for Warning and Blocked DG status
-  if (!isWarningState && !isBlockedState) return <>{children}</>;
+  if (isDGBannerEnabled && !isWarningState && !isBlockedState)
+    return <>{children}</>;
 
   return (
     <BannerWrapper $state={isBlockedState ? 'Blocked' : 'Warning'}>

--- a/shared/banners/dual-governance-banner/dual-governance-banner.tsx
+++ b/shared/banners/dual-governance-banner/dual-governance-banner.tsx
@@ -1,0 +1,54 @@
+import { useDGWarningStatus } from 'shared/hooks/useDGWarningStatus';
+import {
+  BannerWrapper,
+  BannerTitle,
+  BannerDescription,
+  BannerLinkContainer,
+} from './styles';
+import { BannerLinkButton } from '../banner-link-button';
+
+const DG_TRIGGER_PERCENT = 33;
+const DG_LINK = 'REPLACE-ME'; // TODO: replace the link
+
+export const DualGovernanceBanner = ({ children }: React.PropsWithChildren) => {
+  const { isWarningState, isBlockedState, currentVetoSupportPercent } =
+    useDGWarningStatus();
+
+  // Show banner only for Warning and Blocked DG status
+  if (!isWarningState && !isBlockedState) return <>{children}</>;
+
+  return (
+    <BannerWrapper $state={isBlockedState ? 'Blocked' : 'Warning'}>
+      {isBlockedState && (
+        <>
+          <BannerTitle>
+            Dual Governance: <br />
+            Dynamic Timelock active
+          </BannerTitle>
+          <BannerDescription>
+            Lido DAO governance is now in a dynamic timelock.
+            <br />
+            {currentVetoSupportPercent}% of stETH supply opposes the DAO — the
+            staking may carry elevated risk.
+            <br />
+            Check details on Dual Governance page.
+          </BannerDescription>
+        </>
+      )}
+      {isWarningState && (
+        <>
+          <BannerTitle>Dual Governance activity</BannerTitle>
+          <BannerDescription>
+            Dual Governance is at{' '}
+            <b>{DG_TRIGGER_PERCENT}% of the Veto Signalling threshold.</b> No
+            impact to staking. Check the Dual Governance page for status
+            overview.
+          </BannerDescription>
+        </>
+      )}
+      <BannerLinkContainer>
+        <BannerLinkButton href={DG_LINK}>Dual Governance</BannerLinkButton>
+      </BannerLinkContainer>
+    </BannerWrapper>
+  );
+};

--- a/shared/banners/dual-governance-banner/dual-governance-banner.tsx
+++ b/shared/banners/dual-governance-banner/dual-governance-banner.tsx
@@ -9,28 +9,17 @@ const DG_TRIGGER_PERCENT = 33;
 const DG_LINK = 'https://dg.lido.fi';
 
 export const DualGovernanceBanner = ({ children }: React.PropsWithChildren) => {
-  const {
-    isWarningState,
-    isBlockedState,
-    isDGBannerEnabled,
-    currentVetoSupportPercent,
-  } = useDGWarningStatus();
+  const { isDGBannerEnabled, vetoSupportPercent, isDGActive, dgWarningState } =
+    useDGWarningStatus();
 
-  const isDGActive = isWarningState || isBlockedState;
   if (!isDGActive || !isDGBannerEnabled) return <>{children}</>;
 
-  // we dont want to show banner if blocked state is true and currentVetoSupportPercent is not set
-  if (isBlockedState && !currentVetoSupportPercent) return <>{children}</>;
-  const dgState = isBlockedState ? 'Blocked' : 'Warning';
-
   return (
-    <BannerWrapper $state={dgState}>
-      {dgState === 'Blocked' && (
-        <BlockedState
-          currentVetoSupportPercent={currentVetoSupportPercent ?? 0}
-        />
+    <BannerWrapper $state={dgWarningState}>
+      {dgWarningState === 'Blocked' && (
+        <BlockedState vetoSupportPercent={vetoSupportPercent ?? 0} />
       )}
-      {dgState === 'Warning' && (
+      {dgWarningState === 'Warning' && (
         <WarningState dgTriggerPercent={DG_TRIGGER_PERCENT} />
       )}
       <BannerLinkContainer>

--- a/shared/banners/dual-governance-banner/dual-governance-banner.tsx
+++ b/shared/banners/dual-governance-banner/dual-governance-banner.tsx
@@ -1,9 +1,9 @@
 import { useDGWarningStatus } from 'shared/hooks/useDGWarningStatus';
 import { BannerWrapper, BannerLinkContainer } from './styles';
-import { BannerLinkButton } from '../banner-link-button';
 
 import { BlockedState } from './blocked-state';
 import { WarningState } from './warning-state';
+import { Button, Link } from '@lidofinance/lido-ui';
 
 const DG_TRIGGER_PERCENT = 33;
 const DG_LINK = 'https://dg.lido.fi';
@@ -34,7 +34,11 @@ export const DualGovernanceBanner = ({ children }: React.PropsWithChildren) => {
         <WarningState dgTriggerPercent={DG_TRIGGER_PERCENT} />
       )}
       <BannerLinkContainer>
-        <BannerLinkButton href={DG_LINK}>Dual Governance</BannerLinkButton>
+        <Link href={DG_LINK}>
+          <Button size="xs" color="primary">
+            Dual Governance
+          </Button>
+        </Link>
       </BannerLinkContainer>
     </BannerWrapper>
   );

--- a/shared/banners/dual-governance-banner/dual-governance-banner.tsx
+++ b/shared/banners/dual-governance-banner/dual-governance-banner.tsx
@@ -1,11 +1,9 @@
 import { useDGWarningStatus } from 'shared/hooks/useDGWarningStatus';
-import {
-  BannerWrapper,
-  BannerTitle,
-  BannerDescription,
-  BannerLinkContainer,
-} from './styles';
+import { BannerWrapper, BannerLinkContainer } from './styles';
 import { BannerLinkButton } from '../banner-link-button';
+
+import { BlockedState } from './blocked-state';
+import { WarningState } from './warning-state';
 
 const DG_TRIGGER_PERCENT = 33;
 const DG_LINK = 'https://dg.lido.fi';
@@ -18,38 +16,22 @@ export const DualGovernanceBanner = ({ children }: React.PropsWithChildren) => {
     currentVetoSupportPercent,
   } = useDGWarningStatus();
 
-  // Show banner only for Warning and Blocked DG status
-  if (isDGBannerEnabled && !isWarningState && !isBlockedState)
-    return <>{children}</>;
+  const isDGActive = isWarningState || isBlockedState;
+  if (!isDGActive || !isDGBannerEnabled) return <>{children}</>;
+
+  // we dont want to show banner if blocked state is true and currentVetoSupportPercent is not set
+  if (isBlockedState && !currentVetoSupportPercent) return <>{children}</>;
+  const dgState = isBlockedState ? 'Blocked' : 'Warning';
 
   return (
-    <BannerWrapper $state={isBlockedState ? 'Blocked' : 'Warning'}>
-      {isBlockedState && (
-        <>
-          <BannerTitle>
-            Dual Governance: <br />
-            Dynamic Timelock active
-          </BannerTitle>
-          <BannerDescription>
-            Lido DAO governance is now in a dynamic timelock.
-            <br />
-            {currentVetoSupportPercent}% of stETH supply opposes the DAO — the
-            staking may carry elevated risk.
-            <br />
-            Check details on Dual Governance page.
-          </BannerDescription>
-        </>
+    <BannerWrapper $state={dgState}>
+      {dgState === 'Blocked' && (
+        <BlockedState
+          currentVetoSupportPercent={currentVetoSupportPercent ?? 0}
+        />
       )}
-      {isWarningState && (
-        <>
-          <BannerTitle>Dual Governance activity</BannerTitle>
-          <BannerDescription>
-            Dual Governance is at{' '}
-            <b>{DG_TRIGGER_PERCENT}% of the Veto Signalling threshold.</b> No
-            impact to staking. Check the Dual Governance page for status
-            overview.
-          </BannerDescription>
-        </>
+      {dgState === 'Warning' && (
+        <WarningState dgTriggerPercent={DG_TRIGGER_PERCENT} />
       )}
       <BannerLinkContainer>
         <BannerLinkButton href={DG_LINK}>Dual Governance</BannerLinkButton>

--- a/shared/banners/dual-governance-banner/dual-governance-banner.tsx
+++ b/shared/banners/dual-governance-banner/dual-governance-banner.tsx
@@ -8,7 +8,7 @@ import {
 import { BannerLinkButton } from '../banner-link-button';
 
 const DG_TRIGGER_PERCENT = 33;
-const DG_LINK = 'REPLACE-ME'; // TODO: replace the link
+const DG_LINK = 'https://dg.lido.fi';
 
 export const DualGovernanceBanner = ({ children }: React.PropsWithChildren) => {
   const { isWarningState, isBlockedState, currentVetoSupportPercent } =

--- a/shared/banners/dual-governance-banner/index.ts
+++ b/shared/banners/dual-governance-banner/index.ts
@@ -1,0 +1,1 @@
+export * from './dual-governance-banner';

--- a/shared/banners/dual-governance-banner/styles.ts
+++ b/shared/banners/dual-governance-banner/styles.ts
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+import { BannerWrap, BannerTitleText } from '../shared-banner-partials';
+
+interface BannerWrapperProps {
+  $state?: 'Warning' | 'Blocked';
+}
+export const BannerWrapper = styled(BannerWrap).attrs<BannerWrapperProps>(
+  ({ $state }) => ({
+    $state: $state || 'Warning',
+  }),
+)<BannerWrapperProps>`
+  background: ${({ $state }) => {
+    if ($state === 'Warning') return '#ec860033';
+    if ($state === 'Blocked') return '#e14d4d33';
+  }};
+  color: var(--lido-color-text);
+`;
+
+export const BannerTitle = styled(BannerTitleText)`
+  font-weight: 700;
+`;
+
+export const BannerDescription = styled.div`
+  color: var(--lido-color-text);
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 24px;
+  margin-top: 5px;
+`;
+
+export const BannerLinkContainer = styled.div`
+  margin-top: 16px;
+`;

--- a/shared/banners/dual-governance-banner/styles.ts
+++ b/shared/banners/dual-governance-banner/styles.ts
@@ -12,8 +12,8 @@ export const BannerWrapper = styled(BannerWrap).attrs<BannerWrapperProps>(
   }),
 )<BannerWrapperProps>`
   background: ${({ $state }) => {
-    if ($state === 'Warning') return '#ec860033';
     if ($state === 'Blocked') return '#e14d4d33';
+    return '#ec860033'; // Warning state and fallback for other states
   }};
   color: var(--lido-color-text);
 `;

--- a/shared/banners/dual-governance-banner/styles.ts
+++ b/shared/banners/dual-governance-banner/styles.ts
@@ -1,8 +1,10 @@
 import styled from 'styled-components';
 import { BannerWrap, BannerTitleText } from '../shared-banner-partials';
 
+import type { DGWarningState } from 'shared/hooks/useDGWarningStatus';
+
 interface BannerWrapperProps {
-  $state?: 'Warning' | 'Blocked';
+  $state?: DGWarningState;
 }
 export const BannerWrapper = styled(BannerWrap).attrs<BannerWrapperProps>(
   ({ $state }) => ({

--- a/shared/banners/dual-governance-banner/styles.ts
+++ b/shared/banners/dual-governance-banner/styles.ts
@@ -6,7 +6,7 @@ interface BannerWrapperProps {
 }
 export const BannerWrapper = styled(BannerWrap).attrs<BannerWrapperProps>(
   ({ $state }) => ({
-    $state: $state || 'Warning',
+    $state: $state,
   }),
 )<BannerWrapperProps>`
   background: ${({ $state }) => {

--- a/shared/banners/dual-governance-banner/warning-state.tsx
+++ b/shared/banners/dual-governance-banner/warning-state.tsx
@@ -1,0 +1,18 @@
+import { BannerTitle, BannerDescription } from './styles';
+
+export const WarningState = ({
+  dgTriggerPercent,
+}: {
+  dgTriggerPercent: number;
+}) => {
+  return (
+    <>
+      <BannerTitle>Dual Governance activity</BannerTitle>
+      <BannerDescription>
+        Dual Governance is at{' '}
+        <b>{dgTriggerPercent}% of the Veto Signalling threshold.</b> No impact
+        to staking. Check the Dual Governance page for status overview.
+      </BannerDescription>
+    </>
+  );
+};

--- a/shared/hooks/useDGWarningStatus.ts
+++ b/shared/hooks/useDGWarningStatus.ts
@@ -39,29 +39,28 @@ export const useDGWarningStatus = (
     ...STRATEGY_LAZY,
   });
 
-  const dgWarningStatus = queryResult.data;
-  const dgWarningOverrideState = overrideWithQAMockString(
-    featureFlags.dgWarningState
-      ? 'Warning'
-      : dgWarningStatus?.state ?? 'Unknown',
+  const dgStatus = queryResult.data;
+  const dgWarningState = dgStatus?.state ?? 'Unknown';
+  const dgWarningStateOverriden = overrideWithQAMockString(
+    featureFlags.dgWarningState ? 'Warning' : dgWarningState,
     'mock-qa-helpers-dg-state',
   ) as DGWarningState;
 
-  const vetoSupportOverridePercent = overrideWithQAMockNumber(
-    dgWarningStatus?.currentVetoSupportPercent ?? 0,
+  const vetoSupportPercent = overrideWithQAMockNumber(
+    dgStatus?.currentVetoSupportPercent ?? 0,
     'mock-qa-helpers-dg-current-veto-support-percent',
   );
 
-  const isWarningState = dgWarningOverrideState === 'Warning';
-  const isBlockedState = dgWarningOverrideState === 'Blocked';
+  const isWarningState = dgWarningStateOverriden === 'Warning';
+  const isBlockedState = dgWarningStateOverriden === 'Blocked';
   // we dont want to show banner if blocked state is true and currentVetoSupportPercent is not set
   const isDGActive =
-    isWarningState || (isBlockedState && vetoSupportOverridePercent > 0);
+    isWarningState || (isBlockedState && vetoSupportPercent > 0);
 
   return {
-    vetoSupportPercent: vetoSupportOverridePercent,
+    vetoSupportPercent,
     isDGBannerEnabled,
     isDGActive,
-    dgWarningState: dgWarningOverrideState,
+    dgWarningState: dgWarningStateOverriden,
   };
 };

--- a/shared/hooks/useDGWarningStatus.ts
+++ b/shared/hooks/useDGWarningStatus.ts
@@ -2,9 +2,22 @@ import { useQuery } from '@tanstack/react-query';
 import { useConfig } from 'config/use-config';
 import { STRATEGY_LAZY } from 'consts/react-query-strategies';
 import { useLidoSDK } from 'modules/web3';
-import { overrideWithQAMockBoolean, overrideWithQAMockNumber } from 'utils/qa';
+import {
+  overrideWithQAMockBoolean,
+  overrideWithQAMockNumber,
+  overrideWithQAMockString,
+} from 'utils/qa';
 
-export const useDGWarningStatus = (triggerPercent = 33) => {
+export type DGWarningState = 'Blocked' | 'Warning' | 'Unknown' | 'Normal';
+
+export const useDGWarningStatus = (
+  triggerPercent = 33,
+): {
+  vetoSupportPercent: number;
+  isDGBannerEnabled: boolean;
+  isDGActive: boolean;
+  dgWarningState: DGWarningState;
+} => {
   const { dualGovernance } = useLidoSDK();
 
   // Use feature flags for testing states
@@ -26,30 +39,29 @@ export const useDGWarningStatus = (triggerPercent = 33) => {
     ...STRATEGY_LAZY,
   });
 
-  const warningStatus = queryResult.data;
+  const dgWarningStatus = queryResult.data;
+  const dgWarningOverrideState = overrideWithQAMockString(
+    featureFlags.dgWarningState
+      ? 'Warning'
+      : dgWarningStatus?.state ?? 'Unknown',
+    'mock-qa-helpers-dg-state',
+  ) as DGWarningState;
 
-  const isWarningState = overrideWithQAMockBoolean(
-    warningStatus?.state === 'Warning' || Boolean(featureFlags.dgWarningState),
-    'mock-qa-helpers-dg-warning-state',
-  );
-
-  const isBlockedState = overrideWithQAMockBoolean(
-    warningStatus?.state === 'Blocked',
-    'mock-qa-helpers-dg-blocked-state',
-  );
-
-  const currentVetoSupportPercent = overrideWithQAMockNumber(
-    warningStatus?.currentVetoSupportPercent ?? 0,
+  const vetoSupportOverridePercent = overrideWithQAMockNumber(
+    dgWarningStatus?.currentVetoSupportPercent ?? 0,
     'mock-qa-helpers-dg-current-veto-support-percent',
   );
 
+  const isWarningState = dgWarningOverrideState === 'Warning';
+  const isBlockedState = dgWarningOverrideState === 'Blocked';
+  // we dont want to show banner if blocked state is true and currentVetoSupportPercent is not set
+  const isDGActive =
+    isWarningState || (isBlockedState && vetoSupportOverridePercent > 0);
+
   return {
-    state: warningStatus?.state,
-    currentVetoSupportPercent,
+    vetoSupportPercent: vetoSupportOverridePercent,
     isDGBannerEnabled,
-    isWarningState,
-    isBlockedState,
-    isNormalState: warningStatus?.state === 'Normal',
-    isUnknownState: warningStatus?.state === 'Unknown',
+    isDGActive,
+    dgWarningState: dgWarningOverrideState,
   };
 };

--- a/shared/hooks/useDGWarningStatus.ts
+++ b/shared/hooks/useDGWarningStatus.ts
@@ -9,6 +9,8 @@ export const useDGWarningStatus = (triggerPercent = 33) => {
   // Use feature flags for testing states
   const { featureFlags } = useConfig().externalConfig;
 
+  const isDGBannerEnabled = featureFlags.dgBannerEnabled;
+
   const queryResult = useQuery({
     queryKey: ['dgWarningStatus', triggerPercent],
     queryFn: async () => {
@@ -16,24 +18,21 @@ export const useDGWarningStatus = (triggerPercent = 33) => {
         triggerPercent,
       });
     },
+    enabled: isDGBannerEnabled,
     ...STRATEGY_LAZY,
   });
 
   const warningStatus = queryResult.data;
 
-  const isNormalState = warningStatus?.state === 'Normal';
-  const isWarningState =
-    warningStatus?.state === 'Warning' || featureFlags.dgWarningState;
-  const isBlockedState =
-    warningStatus?.state === 'Blocked' || featureFlags.dgBlockedState;
-  const isUnknownState = warningStatus?.state === 'Unknown';
-
   return {
     state: warningStatus?.state,
     currentVetoSupportPercent: warningStatus?.currentVetoSupportPercent,
-    isWarningState,
-    isBlockedState,
-    isNormalState,
-    isUnknownState,
+    isDGBannerEnabled,
+    isWarningState:
+      warningStatus?.state === 'Warning' || featureFlags.dgWarningState,
+    isBlockedState:
+      warningStatus?.state === 'Blocked' || featureFlags.dgBlockedState,
+    isNormalState: warningStatus?.state === 'Normal',
+    isUnknownState: warningStatus?.state === 'Unknown',
   };
 };

--- a/shared/hooks/useDGWarningStatus.ts
+++ b/shared/hooks/useDGWarningStatus.ts
@@ -1,0 +1,39 @@
+import { useQuery } from '@tanstack/react-query';
+import { useConfig } from 'config/use-config';
+import { STRATEGY_LAZY } from 'consts/react-query-strategies';
+import { useLidoSDK } from 'modules/web3';
+
+export const useDGWarningStatus = (triggerPercent = 33) => {
+  const { dualGovernance } = useLidoSDK();
+
+  // Use feature flags for testing states
+  const { featureFlags } = useConfig().externalConfig;
+
+  const queryResult = useQuery({
+    queryKey: ['dgWarningStatus', triggerPercent],
+    queryFn: async () => {
+      return dualGovernance.getGovernanceWarningStatus({
+        triggerPercent,
+      });
+    },
+    ...STRATEGY_LAZY,
+  });
+
+  const warningStatus = queryResult.data;
+
+  const isNormalState = warningStatus?.state === 'Normal';
+  const isWarningState =
+    warningStatus?.state === 'Warning' || featureFlags.dgWarningState;
+  const isBlockedState =
+    warningStatus?.state === 'Blocked' || featureFlags.dgBlockedState;
+  const isUnknownState = warningStatus?.state === 'Unknown';
+
+  return {
+    state: warningStatus?.state,
+    currentVetoSupportPercent: warningStatus?.currentVetoSupportPercent,
+    isWarningState,
+    isBlockedState,
+    isNormalState,
+    isUnknownState,
+  };
+};

--- a/shared/hooks/useDGWarningStatus.ts
+++ b/shared/hooks/useDGWarningStatus.ts
@@ -30,8 +30,7 @@ export const useDGWarningStatus = (triggerPercent = 33) => {
     isDGBannerEnabled,
     isWarningState:
       warningStatus?.state === 'Warning' || featureFlags.dgWarningState,
-    isBlockedState:
-      warningStatus?.state === 'Blocked' || featureFlags.dgBlockedState,
+    isBlockedState: warningStatus?.state === 'Blocked',
     isNormalState: warningStatus?.state === 'Normal',
     isUnknownState: warningStatus?.state === 'Unknown',
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2333,10 +2333,10 @@
   resolved "https://registry.yarnpkg.com/@lidofinance/eth-providers/-/eth-providers-0.48.0.tgz#217279cc8433968531283b985617b981d59a8393"
   integrity sha512-ItzIN9psHu8stf8MTAmNaXmKyaVnsYzQ10zdvdX6TM56TcFRlxidTnR5UVeOObtr1Bm/pz61GYCOZkUI6q3aAw==
 
-"@lidofinance/lido-ethereum-sdk@4.4.0":
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/@lidofinance/lido-ethereum-sdk/-/lido-ethereum-sdk-4.4.0.tgz#7b015dad29610c03d191ebe9631ad6ee9497b96c"
-  integrity sha512-Kw4Yr+UWUlkQVrJCyUvAyXP77A4puwdgMgQ3/LkiOYkhZEl+Zzx29rjBGKGc3AcnRz3MbnNIqatBSm9PFSKkRg==
+"@lidofinance/lido-ethereum-sdk@4.5.0-alpha.2":
+  version "4.5.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@lidofinance/lido-ethereum-sdk/-/lido-ethereum-sdk-4.5.0-alpha.2.tgz#8657f8c1e63b56ff916793d4c77f2a041757705a"
+  integrity sha512-clvCETbG4QVAxQBMoKfTl9Ns5Ru9r96z0kJEAj4yJhGU/Ah8RcE09jBAy+9zjwsact84fxLo0XXKDoZ2Ib0VWg==
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
     graphql "^16.8.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2333,10 +2333,10 @@
   resolved "https://registry.yarnpkg.com/@lidofinance/eth-providers/-/eth-providers-0.48.0.tgz#217279cc8433968531283b985617b981d59a8393"
   integrity sha512-ItzIN9psHu8stf8MTAmNaXmKyaVnsYzQ10zdvdX6TM56TcFRlxidTnR5UVeOObtr1Bm/pz61GYCOZkUI6q3aAw==
 
-"@lidofinance/lido-ethereum-sdk@4.5.0-alpha.2":
-  version "4.5.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@lidofinance/lido-ethereum-sdk/-/lido-ethereum-sdk-4.5.0-alpha.2.tgz#8657f8c1e63b56ff916793d4c77f2a041757705a"
-  integrity sha512-clvCETbG4QVAxQBMoKfTl9Ns5Ru9r96z0kJEAj4yJhGU/Ah8RcE09jBAy+9zjwsact84fxLo0XXKDoZ2Ib0VWg==
+"@lidofinance/lido-ethereum-sdk@4.5.0-alpha.3":
+  version "4.5.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@lidofinance/lido-ethereum-sdk/-/lido-ethereum-sdk-4.5.0-alpha.3.tgz#9a32ded21298317eb1dd2e961814686827d8e656"
+  integrity sha512-huk7++dkK9SuxKLUs7RBGMdWz08a6q6RoD2c8K19RWM7NIvl74AktHhNFnw7RBs2bUK+WMGMC/glp5fpCCExpg==
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
     graphql "^16.8.1"


### PR DESCRIPTION
### Description

The PR adds Dual Governance status banner.

### Demo
<img width="524" alt="image" src="https://github.com/user-attachments/assets/e2156b2f-d8e1-4a11-b4c0-b4c1e32e8e40" />

<img width="513" alt="image" src="https://github.com/user-attachments/assets/b6739977-35c3-4c79-9cf7-759ebecabe5b" />

### Testing notes

**QA mocks in localstorage**
- `mock-qa-helpers-dg-banner-enabled` - to enable
- `mock-qa-helpers-dg-state` - can be "Warning" or "Blocked"
- `mock-qa-helpers-dg-current-veto-support-percent` - number, support percent displayed in the banner

**Feature flags that also can be used**
Use `dgBannerEnabled` boolean feature flag in IPFS.json to enable the feature.
Use `dgWarningState` boolean feature flags to trigger Blocked state banner and Warning state banner.

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
