### PR TITLE
fix: support MetaMask connector type in useWeb3Transport

### DIFF
--- a/modules/web3/web3-provider/use-web3-transport.ts
+++ b/modules/web3/web3-provider/use-web3-transport.ts
@@ -169,7 +169,8 @@ export const useWeb3Transport = (
         if (
           activeConnection &&
           chain.id === activeConnection.chainId &&
-          activeConnection.connector.type === 'injected'
+          (activeConnection.connector.type === 'injected' ||
+            activeConnection.connector.type === 'metaMask')
         ) {
           const provider = (await activeConnection.connector?.getProvider?.({
             chainId: chain.id,


### PR DESCRIPTION
Resolves SI-1999

### Description

This pull request updates the `useWeb3Transport` function to support MetaMask as a recognized connector type in addition to the previously supported "injected" type. 

Enhancements to Web3 transport:

* [`modules/web3/web3-provider/use-web3-transport.ts`](diffhunk://#diff-7df0bb322f5880151ea5c698e59d3ba0158af4ccad1844de6442ea9a16848321L172-R173): Modified the condition to include `activeConnection.connector.type === 'metaMask'` alongside `'injected'`, enabling compatibility with MetaMask as a connector type.

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
