### PR TITLE
Fixes for allowance and UI consistency

### DIFF
--- a/features/withdrawals/hooks/contract/useRequest.ts
+++ b/features/withdrawals/hooks/contract/useRequest.ts
@@ -82,6 +82,12 @@ export const useWithdrawalRequest = ({
           // A rare case when the connected address has bytecode (is contract) but does not support batch txs for some reason
           // or the address has enough allowance to skip approval
           await txFlow({
+            callsFn: async () => [
+              await withdraw.request.requestWithdrawalPopulateTx({
+                amount,
+                token,
+              }),
+            ],
             sendTransaction: async (txStagesCallback) => {
               if (needsApprove) {
                 await withdraw.approval.approve({

--- a/features/withdrawals/hooks/contract/useRequest.ts
+++ b/features/withdrawals/hooks/contract/useRequest.ts
@@ -36,8 +36,11 @@ export const useWithdrawalRequest = ({
   const { withdraw } = useLidoSDK();
   const { txModalStages } = useTxModalStagesRequest();
   const txFlow = useTxFlow();
-  const { isSmartAccount, isLoading: isSmartAccountLoading } =
-    useIsSmartAccount();
+  const {
+    isSmartAccount,
+    hasBytecode,
+    isLoading: isSmartAccountLoading,
+  } = useIsSmartAccount();
   const {
     allowance,
     needsApprove,
@@ -46,12 +49,12 @@ export const useWithdrawalRequest = ({
   } = useWithdrawalApprove(amount ? amount : 0n, token, address as Address);
   const { closeModal } = useTransactionModal();
 
+  const hasEnoughAllowance = !!(allowance && !needsApprove);
+
   // “use the classic approve-then-withdraw flow” rather than “use an ERC-2612 permit”
-  const isApprovalFlow = isSmartAccount || !!(allowance && !needsApprove);
-
+  const isApprovalFlow = isSmartAccount || hasEnoughAllowance;
   const isApprovalFlowLoading = isSmartAccountLoading || isUseApproveLoading;
-
-  const isTokenLocked = !!(isApprovalFlow && needsApprove);
+  const isTokenLocked = !!(hasBytecode && !isAA && needsApprove);
 
   const request = useCallback(
     async ({
@@ -75,15 +78,9 @@ export const useWithdrawalRequest = ({
           }
         }
 
-        const txFlowCallsFn = async () => {
-          const args = { amount, token };
-          return await Promise.all([
-            needsApprove && withdraw.approval.approvePopulateTx(args),
-            withdraw.request.requestWithdrawalPopulateTx(args),
-          ]);
-        };
-
-        if (!isAA && isApprovalFlow) {
+        if ((!isAA && hasBytecode) || hasEnoughAllowance) {
+          // A rare case when the connected address has bytecode (is contract) but does not support batch txs for some reason
+          // or the address has enough allowance to skip approval
           await txFlow({
             sendTransaction: async (txStagesCallback) => {
               if (needsApprove) {
@@ -125,8 +122,16 @@ export const useWithdrawalRequest = ({
           });
         } else {
           await txFlow({
-            callsFn: txFlowCallsFn,
+            callsFn: async () => {
+              // Approve + Withdraw batch tx
+              const args = { amount, token };
+              return await Promise.all([
+                needsApprove && withdraw.approval.approvePopulateTx(args),
+                withdraw.request.requestWithdrawalPopulateTx(args),
+              ]);
+            },
             sendTransaction: async (txStagesCallback) => {
+              // ERC-2612 permit flow for EOAs (no batching)
               const deadline = BigInt(Math.floor(Date.now() / 1000) + 86_400); // 1 day
               await withdraw.request.requestWithdrawalWithPermit({
                 requests,
@@ -177,6 +182,8 @@ export const useWithdrawalRequest = ({
     },
     [
       closeModal,
+      hasBytecode,
+      hasEnoughAllowance,
       isAA,
       isApprovalFlow,
       isBunker,

--- a/features/wsteth/unwrap/hooks/use-unwrap-form-processing.ts
+++ b/features/wsteth/unwrap/hooks/use-unwrap-form-processing.ts
@@ -34,7 +34,7 @@ export const useUnwrapFormProcessor = ({
   const txFlow = useTxFlow();
 
   const {
-    isApprovalNeededBeforeUnwrap: needsApproveL2,
+    needsApprove: needsApproveL2,
     processApproveTx: processApproveTxOnL2,
   } = approvalDataOnL2;
 

--- a/features/wsteth/unwrap/hooks/use-unwrap-tx-on-l2-approve.ts
+++ b/features/wsteth/unwrap/hooks/use-unwrap-tx-on-l2-approve.ts
@@ -32,11 +32,16 @@ export const useUnwrapTxOnL2Approve = ({ amount }: UseUnwrapTxApproveArgs) => {
     token: staticTokenAddress,
   });
 
-  // Unwrap requires approval on L2 only and if the following conditions are met:
-  // 1. the connected wallet doesn't support batch txs for the connected address
+  // Unwrap requires approval if the following conditions are met:
+  // 1. the current network is L2
   // 2. the allowance is not enough for the amount to unwrap
-  const needsApprove =
-    isDappActiveOnL2 && !isAA && allowance != null && amount > allowance;
+  const hasEnoughAllowance = allowance != null && allowance >= amount;
+
+  const needsApprove = isDappActiveOnL2 && !hasEnoughAllowance;
+
+  // If the connected wallet supports batch txs for the connected address, then we don't need to show the unlock requirement,
+  // because the approval tx will be included in the batch.
+  const shouldShowUnlockRequirement = needsApprove && !isAA;
 
   const processApproveTx = useCallback(
     async ({ onRetry }: { onRetry?: () => void }) => {
@@ -79,6 +84,7 @@ export const useUnwrapTxOnL2Approve = ({ amount }: UseUnwrapTxApproveArgs) => {
       refetchAllowance,
       allowance,
       needsApprove,
+      shouldShowUnlockRequirement,
       isAllowanceLoading,
       // There are 2 cases when we show the allowance on the unwrap page:
       // 1. wallet chain is L2 chain and chain switcher is on L2 chain (isDappActiveOnL2)
@@ -90,6 +96,7 @@ export const useUnwrapTxOnL2Approve = ({ amount }: UseUnwrapTxApproveArgs) => {
       refetchAllowance,
       allowance,
       needsApprove,
+      shouldShowUnlockRequirement,
       isAllowanceLoading,
       isDappActiveOnL2,
       isChainIdOnL2,

--- a/features/wsteth/unwrap/unwrap-form-controls/amount-input-unwrap.tsx
+++ b/features/wsteth/unwrap/unwrap-form-controls/amount-input-unwrap.tsx
@@ -7,11 +7,12 @@ import { TOKENS_TO_WRAP } from '../../shared/types';
 
 export const TokenAmountInputUnwrap = () => {
   const { isWalletConnected, isDappActive } = useDappStatus();
-  const { maxAmount } = useUnwrapFormData();
+  const { maxAmount, needsApprove } = useUnwrapFormData();
 
   return (
     <TokenAmountInputHookForm
       disabled={isWalletConnected && !isDappActive}
+      isLocked={needsApprove}
       fieldName="amount"
       token={TOKENS_TO_WRAP.wstETH}
       data-testid="unwrapInput"

--- a/features/wsteth/unwrap/unwrap-form-controls/amount-input-unwrap.tsx
+++ b/features/wsteth/unwrap/unwrap-form-controls/amount-input-unwrap.tsx
@@ -7,12 +7,12 @@ import { TOKENS_TO_WRAP } from '../../shared/types';
 
 export const TokenAmountInputUnwrap = () => {
   const { isWalletConnected, isDappActive } = useDappStatus();
-  const { maxAmount, needsApprove } = useUnwrapFormData();
+  const { maxAmount, shouldShowUnlockRequirement } = useUnwrapFormData();
 
   return (
     <TokenAmountInputHookForm
       disabled={isWalletConnected && !isDappActive}
-      isLocked={needsApprove}
+      isLocked={shouldShowUnlockRequirement}
       fieldName="amount"
       token={TOKENS_TO_WRAP.wstETH}
       data-testid="unwrapInput"

--- a/features/wsteth/unwrap/unwrap-form-controls/submit-button-unwrap.tsx
+++ b/features/wsteth/unwrap/unwrap-form-controls/submit-button-unwrap.tsx
@@ -3,15 +3,15 @@ import { SubmitButtonHookForm } from 'shared/hook-form/controls/submit-button-ho
 import { useUnwrapFormData } from '../unwrap-form-context';
 
 export const SubmitButtonUnwrap = () => {
-  const { needsApprove } = useUnwrapFormData();
+  const { shouldShowUnlockRequirement } = useUnwrapFormData();
 
   return (
     <SubmitButtonHookForm
-      isLocked={needsApprove}
+      isLocked={shouldShowUnlockRequirement}
       errorField="amount"
       data-testid="unwrapSubmitBtn"
     >
-      {needsApprove ? `Unlock tokens and unwrap` : 'Unwrap'}
+      {shouldShowUnlockRequirement ? `Unlock tokens and unwrap` : 'Unwrap'}
     </SubmitButtonHookForm>
   );
 };

--- a/features/wsteth/unwrap/unwrap-form-controls/submit-button-unwrap.tsx
+++ b/features/wsteth/unwrap/unwrap-form-controls/submit-button-unwrap.tsx
@@ -3,14 +3,15 @@ import { SubmitButtonHookForm } from 'shared/hook-form/controls/submit-button-ho
 import { useUnwrapFormData } from '../unwrap-form-context';
 
 export const SubmitButtonUnwrap = () => {
-  const { isSmartAccount, isApprovalNeededBeforeUnwrap: isLocked } =
-    useUnwrapFormData();
+  const { needsApprove } = useUnwrapFormData();
 
   return (
-    <SubmitButtonHookForm errorField="amount" data-testid="unwrapSubmitBtn">
-      {isLocked
-        ? `Unlock tokens ${isSmartAccount ? 'to' : 'and'} unwrap`
-        : 'Unwrap'}
+    <SubmitButtonHookForm
+      isLocked={needsApprove}
+      errorField="amount"
+      data-testid="unwrapSubmitBtn"
+    >
+      {needsApprove ? `Unlock tokens and unwrap` : 'Unwrap'}
     </SubmitButtonHookForm>
   );
 };

--- a/features/wsteth/wrap/hooks/use-wrap-form-processing.ts
+++ b/features/wsteth/wrap/hooks/use-wrap-form-processing.ts
@@ -39,7 +39,7 @@ export const useWrapFormProcessor = ({
   const txFlow = useTxFlow();
 
   const {
-    isApprovalNeededBeforeWrap: needsApproveL1,
+    needsApprove: needsApproveL1,
     processApproveTx: processApproveTxOnL1,
   } = approvalDataOnL1;
 

--- a/features/wsteth/wrap/hooks/use-wrap-tx-on-l1-approve.ts
+++ b/features/wsteth/wrap/hooks/use-wrap-tx-on-l1-approve.ts
@@ -46,16 +46,19 @@ export const useWrapTxOnL1Approve = ({
     token: staticTokenAddress,
   });
 
-  // Wrap requires approval on L1 only and if the following conditions are met:
-  // 1. the connected wallet doesn't support batch txs for the connected address
+  // Wrap requires approval if the following conditions are met:
+  // 1. the current network is L1
   // 2. the allowance is not enough for the amount to wrap
   // 3. the token is stETH
+
+  const hasEnoughAllowance = allowance != null && allowance >= amount;
+
   const needsApprove =
-    isDappActiveOnL1 &&
-    !isAA &&
-    allowance != null &&
-    amount > allowance &&
-    token === TOKENS_TO_WRAP.stETH;
+    isDappActiveOnL1 && !hasEnoughAllowance && token === TOKENS_TO_WRAP.stETH;
+
+  // If the connected wallet supports batch txs for the connected address, then we don't need to show the unlock requirement,
+  // because the approval tx will be included in the batch.
+  const shouldShowUnlockRequirement = needsApprove && !isAA;
 
   const processApproveTx = useCallback(
     async ({ onRetry }: { onRetry?: () => void }) => {
@@ -100,6 +103,7 @@ export const useWrapTxOnL1Approve = ({
       isAllowanceLoading:
         isDappActiveOnL1 && (allowance == null || isAllowanceLoading),
       needsApprove,
+      shouldShowUnlockRequirement,
       refetchAllowance,
       // There are 3 cases when we show the allowance on the wrap page:
       // 1. is wallet not connected (!isWalletConnected)
@@ -112,6 +116,7 @@ export const useWrapTxOnL1Approve = ({
       allowance,
       isAllowanceLoading,
       needsApprove,
+      shouldShowUnlockRequirement,
       refetchAllowance,
       isWalletConnected,
       isDappActiveOnL1,

--- a/features/wsteth/wrap/wrap-form-controls/submit-button-wrap.tsx
+++ b/features/wsteth/wrap/wrap-form-controls/submit-button-wrap.tsx
@@ -3,15 +3,15 @@ import { SubmitButtonHookForm } from 'shared/hook-form/controls/submit-button-ho
 import { useWrapFormData } from '../wrap-form-context';
 
 export const SubmitButtonWrap = () => {
-  const { needsApprove } = useWrapFormData();
+  const { shouldShowUnlockRequirement } = useWrapFormData();
 
   return (
     <SubmitButtonHookForm
-      isLocked={needsApprove}
+      isLocked={shouldShowUnlockRequirement}
       errorField="amount"
       data-testid="wrapBtn"
     >
-      {needsApprove ? `Unlock tokens and wrap` : 'Wrap'}
+      {shouldShowUnlockRequirement ? `Unlock tokens and wrap` : 'Wrap'}
     </SubmitButtonHookForm>
   );
 };

--- a/features/wsteth/wrap/wrap-form-controls/submit-button-wrap.tsx
+++ b/features/wsteth/wrap/wrap-form-controls/submit-button-wrap.tsx
@@ -3,16 +3,15 @@ import { SubmitButtonHookForm } from 'shared/hook-form/controls/submit-button-ho
 import { useWrapFormData } from '../wrap-form-context';
 
 export const SubmitButtonWrap = () => {
-  const { isSmartAccount, isApprovalNeededBeforeWrap } = useWrapFormData();
-  const isLocked = isApprovalNeededBeforeWrap && !isSmartAccount;
+  const { needsApprove } = useWrapFormData();
 
   return (
     <SubmitButtonHookForm
-      isLocked={isLocked}
+      isLocked={needsApprove}
       errorField="amount"
       data-testid="wrapBtn"
     >
-      {isLocked && !isSmartAccount ? `Unlock tokens and wrap` : 'Wrap'}
+      {needsApprove ? `Unlock tokens and wrap` : 'Wrap'}
     </SubmitButtonHookForm>
   );
 };

--- a/features/wsteth/wrap/wrap-form-controls/token-amount-input-wrap.tsx
+++ b/features/wsteth/wrap/wrap-form-controls/token-amount-input-wrap.tsx
@@ -14,7 +14,7 @@ type TokenAmountInputWrapProps = Pick<
 export const TokenAmountInputWrap = (props: TokenAmountInputWrapProps) => {
   const { isWalletConnected, isDappActiveOnL2, isDappActive } = useDappStatus();
   const token = useWatch<WrapFormInputType, 'token'>({ name: 'token' });
-  const { maxAmount, needsApprove } = useWrapFormData();
+  const { maxAmount, shouldShowUnlockRequirement } = useWrapFormData();
 
   return (
     <TokenAmountInputHookForm
@@ -22,7 +22,7 @@ export const TokenAmountInputWrap = (props: TokenAmountInputWrapProps) => {
       fieldName="amount"
       token={token}
       data-testid="wrapInput"
-      isLocked={needsApprove}
+      isLocked={shouldShowUnlockRequirement}
       maxValue={maxAmount}
       showErrorMessage={false}
       leftDecorator={isDappActiveOnL2 ? <Steth /> : undefined}

--- a/features/wsteth/wrap/wrap-form-controls/token-amount-input-wrap.tsx
+++ b/features/wsteth/wrap/wrap-form-controls/token-amount-input-wrap.tsx
@@ -2,7 +2,7 @@ import { Steth } from '@lidofinance/lido-ui';
 import { useWatch } from 'react-hook-form';
 
 import { TokenAmountInputHookForm } from 'shared/hook-form/controls/token-amount-input-hook-form';
-import { useAA, useDappStatus } from 'modules/web3';
+import { useDappStatus } from 'modules/web3';
 
 import { useWrapFormData, WrapFormInputType } from '../wrap-form-context';
 
@@ -14,8 +14,7 @@ type TokenAmountInputWrapProps = Pick<
 export const TokenAmountInputWrap = (props: TokenAmountInputWrapProps) => {
   const { isWalletConnected, isDappActiveOnL2, isDappActive } = useDappStatus();
   const token = useWatch<WrapFormInputType, 'token'>({ name: 'token' });
-  const { maxAmount, isApprovalNeededBeforeWrap } = useWrapFormData();
-  const { isAA } = useAA();
+  const { maxAmount, needsApprove } = useWrapFormData();
 
   return (
     <TokenAmountInputHookForm
@@ -23,7 +22,7 @@ export const TokenAmountInputWrap = (props: TokenAmountInputWrapProps) => {
       fieldName="amount"
       token={token}
       data-testid="wrapInput"
-      isLocked={isApprovalNeededBeforeWrap && !isAA}
+      isLocked={needsApprove}
       maxValue={maxAmount}
       showErrorMessage={false}
       leftDecorator={isDappActiveOnL2 ? <Steth /> : undefined}


### PR DESCRIPTION
## Description

- Fixes withdrawal request with pre-set allowance
- Fixes withdrawal request UI for EOAs with EIP-7702 delegation
- Fixes unwrap on L2s for EOAs with EIP-7702 delegation
- Make wrap, unwrap, withdraw UIs consistent for cases when a user must unlock tokens
- Unifies some code for wrap, unwrap and withdraw

## Demo

### Withdraw

**Safe Wallet – BEFORE** 

<img width="464" height="372" alt="safe-withdraw-l1-before" src="https://github.com/user-attachments/assets/6ae103e9-7132-4fe9-aff9-a50fafc0d247" />

**Safe Wallet – AFTER**
<img width="459" height="532" alt="safe-withdraw-l1-after" src="https://github.com/user-attachments/assets/e04b29a2-08a7-4018-ae41-36fe64d7158a" />

### Unwrap

**EOA, no delegation, L2 – BEFORE**
<img width="459" height="155" alt="eoa-unwrap-l2-unlock-before" src="https://github.com/user-attachments/assets/70c53320-a95d-4518-b119-f7f6c96f9438" />


**EOA, no delegation, L2 – AFTER**
<img width="480" height="163" alt="eoa-unwrap-l2-after" src="https://github.com/user-attachments/assets/d1ced7e0-77fd-4409-b440-00a130269b8f" />


**EOA, delegation + batch txs, L2 – BEFORE**
<img width="477" height="161" alt="aa-unwrap-l2-before" src="https://github.com/user-attachments/assets/459644ab-9a55-4021-8bdf-3d3f1622914e" />


**EOA, delegation + batch txs, L2 – AFTER**
<img width="477" height="166" alt="aa-unwrap-l2-after" src="https://github.com/user-attachments/assets/d2b7de80-f8bd-4bc9-8a67-a26da59fb1cd" />


## Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
