### PR TITLE
Hide terms and privacy notice footer links on ipfs

### DIFF
--- a/shared/components/layout/footer/footer.tsx
+++ b/shared/components/layout/footer/footer.tsx
@@ -1,6 +1,7 @@
 import { FC } from 'react';
 import buildInfo from 'build-info.json';
 import { config } from 'config';
+import { OnlyInfraRender } from 'shared/components/only-infra-render';
 
 import {
   FooterStyle,
@@ -43,20 +44,22 @@ export const Footer: FC = () => {
   return (
     <FooterStyle size="full" forwardedAs="footer">
       <LogoLidoStyle />
-      <FooterLink
-        data-testid="termsOfUse"
-        href={`${config.rootOrigin}/terms-of-use`}
-      >
-        Terms of Use
-      </FooterLink>
-      <LinkDivider />
-      <FooterLink
-        data-testid="privacyNotice"
-        href={`${config.rootOrigin}/privacy-notice`}
-        $marginRight="auto"
-      >
-        Privacy Notice
-      </FooterLink>
+      <OnlyInfraRender>
+        <FooterLink
+          data-testid="termsOfUse"
+          href={`${config.rootOrigin}/terms-of-use`}
+        >
+          Terms of Use
+        </FooterLink>
+        <LinkDivider />
+        <FooterLink
+          data-testid="privacyNotice"
+          href={`${config.rootOrigin}/privacy-notice`}
+          $marginRight="auto"
+        >
+          Privacy Notice
+        </FooterLink>
+      </OnlyInfraRender>
       <LinkToIpfs />
       <Version data-testid="appVersion" href={link}>
         {label}

--- a/shared/components/layout/footer/link-to-ipfs.tsx
+++ b/shared/components/layout/footer/link-to-ipfs.tsx
@@ -7,9 +7,17 @@ export const LinkToIpfs = () => {
   const { data } = useRemoteVersion();
   return (
     <OnlyInfraRender
-      renderIPFS={<ExternalLink href={IPFS_INFO_URL}>IPFS Docs</ExternalLink>}
+      renderIPFS={
+        <ExternalLink href={IPFS_INFO_URL} $marginLeft="auto">
+          IPFS Docs
+        </ExternalLink>
+      }
     >
-      {data && <ExternalLink href={data?.link}>IPFS</ExternalLink>}
+      {data && (
+        <ExternalLink href={data?.link} $marginLeft="auto">
+          IPFS
+        </ExternalLink>
+      )}
     </OnlyInfraRender>
   );
 };

--- a/shared/components/layout/footer/styles.tsx
+++ b/shared/components/layout/footer/styles.tsx
@@ -27,6 +27,7 @@ export const FooterStyle = styled(Container)`
 
 type FooterLinkProps = {
   $marginRight?: string;
+  $marginLeft?: string;
 };
 
 export const FooterLink = styled(Link)<FooterLinkProps>`
@@ -39,6 +40,7 @@ export const FooterLink = styled(Link)<FooterLinkProps>`
   font-weight: 400;
 
   ${({ $marginRight }) => ($marginRight ? `margin-right:${$marginRight}` : '')};
+  ${({ $marginLeft }) => ($marginLeft ? `margin-left:${$marginLeft}` : '')};
 
   &:visited {
     color: var(--lido-color-textSecondary);


### PR DESCRIPTION
### Description
Hides Terms of use and Privacy notice footer links for the IPFS version

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
