### PR TITLE
1inch – use sourceTokenAmount param

### DIFF
--- a/features/withdrawals/request/withdrawal-rates/integrations.ts
+++ b/features/withdrawals/request/withdrawal-rates/integrations.ts
@@ -179,7 +179,9 @@ const dexWithdrawalMap: DexWithdrawalIntegrationMap = {
     icon: OneInchIcon,
     matomoEvent: MATOMO_CLICK_EVENTS_TYPES.withdrawalGoTo1inch,
     link: (amount, token) =>
-      `https://app.1inch.io/swap?src=1:${token === TOKENS_TO_WITHDRAWLS.stETH ? 'StETH' : 'WstETH'}&dst=1:ETH`,
+      `https://app.1inch.io/swap?src=1:${token === TOKENS_TO_WITHDRAWLS.stETH ? 'stETH' : 'wstETH'}&dst=1:ETH&sourceTokenAmount=${formatEther(
+        amount,
+      )}`,
   },
   bebop: {
     title: 'Bebop',


### PR DESCRIPTION
### Description

Updates 1inch link in the DEXs tab on the Withdrawals page to include formatted token amount

### Testing notes

1. Open Withdrawals page, DEX tab
2. Input stETH amount
3. Click "Go to 1inch"
4. Expected: 1inch shows the same amount of stETH as in the step 2

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
