### PR TITLE
Remove link to privacy notice from cookies popup for ipfs mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@lidofinance/eth-api-providers": "^0.48.0",
     "@lidofinance/eth-providers": "^0.48.0",
     "@lidofinance/lido-ethereum-sdk": "4.5.0",
-    "@lidofinance/lido-ui": "^3.28.1",
+    "@lidofinance/lido-ui": "^3.31.0",
     "@lidofinance/next-api-wrapper": "^0.48.0",
     "@lidofinance/next-ip-rate-limit": "^0.48.0",
     "@lidofinance/next-pages": "^0.48.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,8 +5,8 @@ import 'nprogress/nprogress.css';
 import Head from 'next/head';
 
 import {
-  ToastContainer,
   CookiesTooltip,
+  ToastContainer,
   migrationAllowCookieToCrossDomainCookieClientSide,
   migrationThemeCookiesToCrossDomainCookiesClientSide,
 } from '@lidofinance/lido-ui';
@@ -64,7 +64,10 @@ const AppWrapper = (
       <MemoApp {...props} />
 
       <NoSsrWrapper>
-        <CookiesTooltip privacyLink={`${config.rootOrigin}/privacy-notice`} />
+        <CookiesTooltip
+          privacyLink={`${config.rootOrigin}/privacy-notice`}
+          privacyLinkEnabled={!config.ipfsMode}
+        />
       </NoSsrWrapper>
 
       <SecurityStatusBanner />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2356,10 +2356,10 @@
     ua-parser-js "^1.0.35"
     use-callback-ref "1.2.5"
 
-"@lidofinance/lido-ui@^3.28.1":
-  version "3.28.1"
-  resolved "https://registry.yarnpkg.com/@lidofinance/lido-ui/-/lido-ui-3.28.1.tgz#9de11afa6f1b3a070781e9f055b56c0d959ef316"
-  integrity sha512-nQmJPLKhdSzfqeq+9kmVTjK0FFPuBcFN1XN26a5wURlcLDsDryjgxTyNM4uZgyaR/bqKl3XfgF6JNsUNvktVKQ==
+"@lidofinance/lido-ui@^3.31.0":
+  version "3.31.0"
+  resolved "https://registry.yarnpkg.com/@lidofinance/lido-ui/-/lido-ui-3.31.0.tgz#d03bc11e6d1b5c3032e0ff4c422034be0869bce3"
+  integrity sha512-JTlugReBgsqdghPFp30Kp/f9JdhtT8H5Lfi1RqH1TEeY4QCNSexE9/i70VHfsEfXajq66DlDoLwJb3C3AcULYg==
   dependencies:
     "@styled-system/should-forward-prop" "5.1.5"
     react-collapsed "3.0.2"


### PR DESCRIPTION
### Description

- copies CookiesTooltip from lido-ui and modifies it – adds ability to hide the privacy notice link
- configures the updated component to hide the privacy notice link from the CookiesTooltip when the widget is in the IPFS mode

### Demo

<img width="719" height="90" alt="image" src="https://github.com/user-attachments/assets/59005a00-c3b3-44d8-8043-44365c5e9da2" />

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
