### PR TITLE
Fix: improve tooltip message for long withdrawals waiting time

### DIFF
--- a/features/withdrawals/request/form/options/options-picker.tsx
+++ b/features/withdrawals/request/form/options/options-picker.tsx
@@ -79,7 +79,7 @@ const LidoButton: React.FC<OptionButtonProps> = ({ isActive, onClick }) => {
         <OptionsPickerSubLabel>
           Waiting time:&nbsp;
           {isCongested && (
-            <Tooltip title=" Due to increased ecosystem activity, Ethereum’s validator exit queue is currently longer. As a result, Lido withdrawals can take additional time to process.">
+            <Tooltip title="Due to increased ecosystem activity, Ethereum’s validator exit queue is currently longer than usual. As a result, Lido withdrawals can take additional time to be processed.">
               <InlineQuestion />
             </Tooltip>
           )}


### PR DESCRIPTION
### Description

Slightly updates text for the tooltip on the Withdrawals page when the waiting time is too long.

### Demo

<img width="390" height="223" alt="image" src="https://github.com/user-attachments/assets/f2534b39-a12d-4c37-b483-0548260feea8" />

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
