### PR TITLE
refactor: change  message in security banner and optimize cached prox…

### DIFF
--- a/features/ipfs/security-status-banner/security-status-banner.tsx
+++ b/features/ipfs/security-status-banner/security-status-banner.tsx
@@ -93,9 +93,7 @@ const warningContent = ({
     case isNotValidAddress:
       return {
         content: (
-          <WarningBlock>
-            Sorry, you don’t have access to our services right now.
-          </WarningBlock>
+          <WarningBlock>Sorry, access is currently unavailable.</WarningBlock>
         ),
         canClose: false,
       };

--- a/utilsApi/cached-proxy.ts
+++ b/utilsApi/cached-proxy.ts
@@ -1,3 +1,4 @@
+import type { NextApiRequest } from 'next';
 import { API } from '@lidofinance/next-api-wrapper';
 import { Cache } from 'memory-cache';
 import { responseTimeExternalMetricWrapper } from './fetchApiWrapper';
@@ -7,7 +8,7 @@ import { FetcherError } from 'utils/fetcherError';
 import { ETH_API_ROUTES, getEthApiPath } from 'consts/api';
 
 type ProxyOptions = {
-  proxyUrl: string | (() => string);
+  proxyUrl: string | ((req: NextApiRequest) => string);
   cacheTTL: number;
   timeout?: number;
   ignoreParams?: boolean;
@@ -21,7 +22,7 @@ export const createCachedProxy = ({
   ignoreParams,
   timeout = 5000,
   transformData = (data) => data,
-  metricsHost = typeof proxyUrl === 'function' ? proxyUrl() : proxyUrl,
+  metricsHost,
 }: ProxyOptions): API => {
   const cache = new Cache<string, any>();
   return async (req, res) => {
@@ -37,21 +38,22 @@ export const createCachedProxy = ({
               {} as Record<string, string>,
             ),
           );
-    const cacheKey = `${proxyUrl}-${params?.toString() ?? ''}`;
+    // Generate the actual proxy URL, passing req if the function accepts it
+    const proxyUrlString =
+      typeof proxyUrl === 'function' ? proxyUrl(req) : proxyUrl;
+
+    const cacheKey = `${proxyUrlString}-${params?.toString() ?? ''}`;
 
     const cachedValue = cache.get(cacheKey);
     if (cachedValue) {
       res.json(cachedValue);
       return;
     }
-
-    const proxyUrlString =
-      typeof proxyUrl === 'function' ? proxyUrl() : proxyUrl;
     const url = proxyUrlString + (params ? `?${params.toString()}` : '');
 
     try {
       const data = await responseTimeExternalMetricWrapper({
-        payload: metricsHost,
+        payload: metricsHost || proxyUrlString,
         request: () =>
           standardFetcher(url, {
             signal: AbortSignal.timeout(timeout),
@@ -106,7 +108,7 @@ export const createEthApiProxy = ({
     cacheTTL,
     ignoreParams,
     transformData,
-    proxyUrl,
+    proxyUrl: () => proxyUrl, // Wrap string in function
     metricsHost: config.ethAPIBasePath,
     timeout: 5000,
   });


### PR DESCRIPTION
…y for address validation

<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

**API validation endpoint improvements:**
- Refactored the `/api/validation` handler to create the cached proxy once at the module level, ensuring cache is preserved across requests and improving performance. The proxy URL function now validates the Ethereum address and constructs the target URL dynamically. [[1]](diffhunk://#diff-395d5f416dc2a2445e516dd6dfc6bb744789e771c3fc8bd77ceda54e9d2e02fbR38-R52) [[2]](diffhunk://#diff-395d5f416dc2a2445e516dd6dfc6bb744789e771c3fc8bd77ceda54e9d2e02fbL49-R64)

**Cached proxy utility enhancements:**
- Updated `createCachedProxy` in `utilsApi/cached-proxy.ts` to accept a `proxyUrl` function that takes `req: NextApiRequest`, enabling dynamic URL construction based on the request. Adjusted cache key generation and metric reporting to use the resolved proxy URL. [[1]](diffhunk://#diff-f21a1847ee1bc5dd11216aa7bc5861395e471658921876fba044210638c51efbR1) [[2]](diffhunk://#diff-f21a1847ee1bc5dd11216aa7bc5861395e471658921876fba044210638c51efbL10-R11) [[3]](diffhunk://#diff-f21a1847ee1bc5dd11216aa7bc5861395e471658921876fba044210638c51efbL24-R25) [[4]](diffhunk://#diff-f21a1847ee1bc5dd11216aa7bc5861395e471658921876fba044210638c51efbL40-R56)
- Modified `createEthApiProxy` to wrap string proxy URLs in a function for compatibility with the new `createCachedProxy` signature.

**UI text update:**
- Updated the warning message in the security status banner to use more concise language: "Sorry, access is currently unavailable."

### Demo

<!--- If thee are visual changes, attach a link to a specific section on preview stand / add screenshots / record a [loom](https://www.loom.com/). -->

### Code review notes

<!--- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

<!--- List all possible edge cases and how to test them. -->

### Checklist:

- [ ] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
