### PR TITLE
fix: fix metrics for revalidation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,3 +74,6 @@ WIDGET_API_BASE_PATH_FOR_IPFS=
 
 # Actual for IPFS mode
 REWARDS_BACKEND_BASE_PATH=
+
+# JSON file with blocked addresses
+VALIDATION_FILE_PATH=


### PR DESCRIPTION
### Description

Ensure a single Metrics instance per Node.js process by storing it on globalThis.
This prevents multiple Registry objects from being created when modules are re-imported under different paths — which can happen during Next.js ISR (Incremental Static Regeneration).

With this change, all imports (including from ISR) will share the same Metrics instance, and counters updated inside getStaticProps during ISR will be visible through /api/metrics.

<img width="1117" height="453" alt="Снимок экрана 2025-09-03 в 18 30 55" src="https://github.com/user-attachments/assets/a69f8bee-4e9f-4e78-a702-0f383998c2eb" />


### Checklist:

- [ ] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
