### PR TITLE
Add APR disclaimers, unify GGV description

### DIFF
--- a/features/earn/shared/styles.ts
+++ b/features/earn/shared/styles.ts
@@ -6,18 +6,3 @@ export const LegalParagraph = styled.div`
   line-height: 20px;
   color: var(--lido-color-textSecondary);
 `;
-
-export const VaultDisclaimerBlock = styled.section`
-  color: var(--lido-color-textSecondary);
-  font-size: ${({ theme }) => theme.fontSizesMap.xxs}px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 20px;
-  margin-top: 20px;
-
-  margin-bottom: 60px;
-
-  ${({ theme }) => theme.mediaQueries.md} {
-    margin-bottom: 0px;
-  }
-`;

--- a/features/earn/vault-dvv/vault-page-dvv.tsx
+++ b/features/earn/vault-dvv/vault-page-dvv.tsx
@@ -6,6 +6,7 @@ import { VaultDVVIcon } from 'assets/earn';
 import { EARN_PATH } from 'consts/urls';
 import { MATOMO_EARN_EVENTS_TYPES } from 'consts/matomo/matomo-earn-events';
 import { LinkInpageAnchor } from 'shared/components/link-inpage-anchor';
+import { AprDisclaimer } from 'shared/components/apr-disclaimer/apr-disclaimer';
 
 import { VaultDescription } from '../shared/vault-description';
 import { VaultHeader } from '../shared/vault-header';
@@ -13,7 +14,6 @@ import { VaultStats } from '../shared/vault-stats';
 import { VaultSwitch } from '../shared/vault-switch';
 import { VaultLegal } from '../shared/vault-legal';
 import { ButtonBack } from '../shared/button-back';
-import { VaultDisclaimer } from '../shared/vault-disclaimer';
 import {
   VaultBlock,
   VaultBlockFormSection,
@@ -116,7 +116,7 @@ export const VaultPageDVV: FC<{
         </VaultBlockFormSection>
       </VaultBlock>
       <DVVFaq />
-      <VaultDisclaimer />
+      <AprDisclaimer />
     </>
   );
 };

--- a/features/earn/vault-dvv/vault-page-dvv.tsx
+++ b/features/earn/vault-dvv/vault-page-dvv.tsx
@@ -116,7 +116,7 @@ export const VaultPageDVV: FC<{
         </VaultBlockFormSection>
       </VaultBlock>
       <DVVFaq />
-      <AprDisclaimer />
+      <AprDisclaimer mentionAPY />
     </>
   );
 };

--- a/features/earn/vault-ggv/consts.tsx
+++ b/features/earn/vault-ggv/consts.tsx
@@ -16,6 +16,9 @@ export const GGV_DEPOSABLE_TOKENS: GGV_DEPOSIT_TOKENS[] = [
 export const INFINITE_DEPOSIT_CAP = maxUint112;
 export const MAX_REQUEST_DEADLINE = Number(maxUint24);
 
+export const GGV_VAULT_DESCRIPTION =
+  'Lido GGV utilizes tried and tested strategies with premier DeFi protocols for increased rewards on deposits of ETH or (w)stETH.';
+
 export const GGV_PARTNERS = [
   { role: 'Curated by', icon: <PartnerVedaIcon />, text: 'Veda' },
   {

--- a/features/earn/vault-ggv/consts.tsx
+++ b/features/earn/vault-ggv/consts.tsx
@@ -17,7 +17,7 @@ export const INFINITE_DEPOSIT_CAP = maxUint112;
 export const MAX_REQUEST_DEADLINE = Number(maxUint24);
 
 export const GGV_VAULT_DESCRIPTION =
-  'Lido GGV utilizes tried and tested strategies with premier DeFi protocols for increased rewards on deposits of ETH or (w)stETH.';
+  'Lido GGV (Golden Goose Vault) utilizes tried and tested strategies with premier DeFi protocols for increased rewards on deposits of ETH or (w)stETH.';
 
 export const GGV_PARTNERS = [
   { role: 'Curated by', icon: <PartnerVedaIcon />, text: 'Veda' },

--- a/features/earn/vault-ggv/faq/ggv-faq.tsx
+++ b/features/earn/vault-ggv/faq/ggv-faq.tsx
@@ -16,6 +16,7 @@ import {
   HowManyWithdrawalRequests,
   CanICancelWithdrawalRequest,
   HowDoIClaimRewards,
+  WhoIsCurator,
 } from './list';
 
 export const GGVFaq: FC = () => {
@@ -25,6 +26,7 @@ export const GGVFaq: FC = () => {
       <WhatIsApyForGGV />
       <DepositFee />
       <RisksOfDepositing />
+      <WhoIsCurator />
       <WhatIsGGToken />
       <WhatCanIDoWithGGToken />
       <HowDoesWithdrawalWork />

--- a/features/earn/vault-ggv/faq/list/index.ts
+++ b/features/earn/vault-ggv/faq/list/index.ts
@@ -13,3 +13,4 @@ export * from './pending-request-rewards';
 export * from './how-many-withdrawal-requests';
 export * from './can-i-cancel-withdrawal-request';
 export * from './how-do-i-claim-rewards';
+export * from './who-is-curator';

--- a/features/earn/vault-ggv/faq/list/who-is-curator.tsx
+++ b/features/earn/vault-ggv/faq/list/who-is-curator.tsx
@@ -1,0 +1,13 @@
+import { FC } from 'react';
+import { Accordion } from '@lidofinance/lido-ui';
+
+export const WhoIsCurator: FC = () => {
+  return (
+    <Accordion summary="Who is the curator for GGV and what’s their role?">
+      <p>
+        The curator for GGV is Veda, their role is overseeing strategy
+        execution, risk management, and the overall performance of the vault.
+      </p>
+    </Accordion>
+  );
+};

--- a/features/earn/vault-ggv/vault-card-ggv.tsx
+++ b/features/earn/vault-ggv/vault-card-ggv.tsx
@@ -15,7 +15,11 @@ import { EARN_VAULT_GGV_SLUG } from '../consts';
 import { VaultCard } from '../shared/vault-card';
 import { useGGVStats } from './hooks/use-ggv-stats';
 import { useGGVPosition } from './hooks/use-ggv-position';
-import { GGV_PARTNERS, GGV_TOKEN_SYMBOL } from './consts';
+import {
+  GGV_VAULT_DESCRIPTION,
+  GGV_PARTNERS,
+  GGV_TOKEN_SYMBOL,
+} from './consts';
 import { GGVApyHint } from './ggv-apy-hint';
 
 export const VaultCardGGV = () => {
@@ -25,7 +29,7 @@ export const VaultCardGGV = () => {
   return (
     <VaultCard
       title="Lido GGV"
-      description="Lido GGV utilizes tried and tested strategies with premier DeFi protocols for increased rewards on deposits of ETH or (w)stETH."
+      description={GGV_VAULT_DESCRIPTION}
       urlSlug={EARN_VAULT_GGV_SLUG}
       partners={GGV_PARTNERS}
       tokens={[

--- a/features/earn/vault-ggv/vault-page-ggv.tsx
+++ b/features/earn/vault-ggv/vault-page-ggv.tsx
@@ -145,7 +145,7 @@ export const VaultPageGGV: FC<{
         </VaultBlockFormSection>
       </VaultBlock>
       <GGVFaq />
-      <AprDisclaimer />
+      <AprDisclaimer mentionAPY />
     </>
   );
 };

--- a/features/earn/vault-ggv/vault-page-ggv.tsx
+++ b/features/earn/vault-ggv/vault-page-ggv.tsx
@@ -31,13 +31,15 @@ import { GGVDepositForm } from './deposit';
 import { GGVWithdrawForm } from './withdraw';
 import { useGGVStats } from './hooks/use-ggv-stats';
 import { useGGVPosition } from './hooks/use-ggv-position';
-import { GGV_PARTNERS, GGV_TOKEN_SYMBOL } from './consts';
+import {
+  GGV_VAULT_DESCRIPTION,
+  GGV_PARTNERS,
+  GGV_TOKEN_SYMBOL,
+} from './consts';
 import { GGVFaq } from './faq/ggv-faq';
 import { GGVApyHint } from './ggv-apy-hint';
 import { LinkInpageAnchor } from 'shared/components/link-inpage-anchor';
 
-const description =
-  'Lido GGV leverages top DeFi protocols to maximize rewards on your stETH, with a single deposit.';
 const routes = [
   {
     path: `${EARN_PATH}/${EARN_VAULT_GGV_SLUG}/${EARN_VAULT_DEPOSIT_SLUG}`,
@@ -91,7 +93,7 @@ export const VaultPageGGV: FC<{
             apxHint={<GGVApyHint />}
             isLoading={isLoading}
           />
-          <VaultDescription description={description} />
+          <VaultDescription description={GGV_VAULT_DESCRIPTION} />
         </VaultBlockHeaderSection>
         {isDappActive && (
           <VaultPosition

--- a/features/earn/vault-ggv/vault-page-ggv.tsx
+++ b/features/earn/vault-ggv/vault-page-ggv.tsx
@@ -7,6 +7,8 @@ import { trackMatomoEvent } from 'utils/track-matomo-event';
 
 import { TokenGGIcon, VaultGGVIcon } from 'assets/earn';
 import { useDappStatus } from 'modules/web3';
+import { LinkInpageAnchor } from 'shared/components/link-inpage-anchor';
+import { AprDisclaimer } from 'shared/components/apr-disclaimer/apr-disclaimer';
 
 import { VaultHeader } from '../shared/vault-header';
 import { VaultDescription } from '../shared/vault-description';
@@ -15,7 +17,6 @@ import { VaultStats } from '../shared/vault-stats';
 import { VaultPosition } from '../shared/vault-position';
 import { VaultLegal } from '../shared/vault-legal';
 import { ButtonBack } from '../shared/button-back';
-import { VaultDisclaimer } from '../shared/vault-disclaimer';
 import {
   VaultBlock,
   VaultBlockFormSection,
@@ -38,7 +39,6 @@ import {
 } from './consts';
 import { GGVFaq } from './faq/ggv-faq';
 import { GGVApyHint } from './ggv-apy-hint';
-import { LinkInpageAnchor } from 'shared/components/link-inpage-anchor';
 
 const routes = [
   {
@@ -145,7 +145,7 @@ export const VaultPageGGV: FC<{
         </VaultBlockFormSection>
       </VaultBlock>
       <GGVFaq />
-      <VaultDisclaimer />
+      <AprDisclaimer />
     </>
   );
 };

--- a/features/earn/vaults-list/vaults-list.tsx
+++ b/features/earn/vaults-list/vaults-list.tsx
@@ -1,11 +1,12 @@
 import type { FC } from 'react';
 
+import { AprDisclaimer } from 'shared/components/apr-disclaimer';
+
 import { VaultCardGGV } from '../vault-ggv';
 import { VaultCardDVV } from '../vault-dvv';
 
 import { VaultsListWrapper } from './styles';
 import { useVaultConfig } from '../shared/hooks/use-vault-config';
-import { VaultDisclaimer } from '../shared/vault-disclaimer';
 
 const VAULT_CARDS = {
   ggv: VaultCardGGV,
@@ -22,7 +23,7 @@ export const EarnVaultsList: FC = () => {
           return <VaultCard key={vault.name} />;
         })}
       </VaultsListWrapper>
-      <VaultDisclaimer />
+      <AprDisclaimer />
     </>
   );
 };

--- a/features/earn/vaults-list/vaults-list.tsx
+++ b/features/earn/vaults-list/vaults-list.tsx
@@ -23,7 +23,7 @@ export const EarnVaultsList: FC = () => {
           return <VaultCard key={vault.name} />;
         })}
       </VaultsListWrapper>
-      <AprDisclaimer />
+      <AprDisclaimer mentionAPY />
     </>
   );
 };

--- a/features/rewards/components/stats/average-apr-block.tsx
+++ b/features/rewards/components/stats/average-apr-block.tsx
@@ -16,7 +16,7 @@ export const AverageAprBlock: FC = () => {
       dataTestId="averageAprBlock"
       title={
         <FlexCenter>
-          Average APR
+          Average APR *
           <Tooltip title={'APR on stETH over your staking period'}>
             <Question />
           </Tooltip>

--- a/features/stake/lido-stats/lido-stats.tsx
+++ b/features/stake/lido-stats/lido-stats.tsx
@@ -64,7 +64,7 @@ export const LidoStats: FC = memo(() => {
           <LidoStatsItem
             title={
               <FlexCenterVertical data-testid="aprTooltip">
-                Annual percentage rate
+                Annual percentage rate *
                 <Tooltip title={LIDO_APR_TOOLTIP_TEXT}>
                   <Question />
                 </Tooltip>

--- a/features/stake/stake-form/wallet/wallet.tsx
+++ b/features/stake/stake-form/wallet/wallet.tsx
@@ -65,7 +65,7 @@ const WalletComponent = () => {
           small
           title={
             <>
-              Lido APR{' '}
+              Lido APR *{' '}
               {lidoApr.data && (
                 <Tooltip placement="bottom" title={LIDO_APR_TOOLTIP_TEXT}>
                   <Question />

--- a/features/stake/stake.tsx
+++ b/features/stake/stake.tsx
@@ -1,6 +1,7 @@
 import { FaqPlaceholder } from 'features/ipfs';
 import NoSSRWrapper from 'shared/components/no-ssr-wrapper';
 import { OnlyInfraRender } from 'shared/components/only-infra-render';
+import { AprDisclaimer } from 'shared/components/apr-disclaimer/apr-disclaimer';
 
 import { StakeFaq } from './stake-faq/stake-faq';
 import { LidoStats } from './lido-stats/lido-stats';
@@ -16,6 +17,7 @@ export const Stake = () => {
       <OnlyInfraRender renderIPFS={<FaqPlaceholder />}>
         <StakeFaq />
       </OnlyInfraRender>
+      <AprDisclaimer />
     </>
   );
 };

--- a/pages/rewards.tsx
+++ b/pages/rewards.tsx
@@ -4,7 +4,7 @@ import Head from 'next/head';
 import { TopCard, RewardsList } from 'features/rewards/features';
 import RewardsHistoryProvider from 'providers/rewardsHistory';
 
-import { Layout } from 'shared/components';
+import { Layout, AprDisclaimer } from 'shared/components';
 
 import { getDefaultStaticProps } from 'utilsApi/get-default-static-props';
 
@@ -28,6 +28,7 @@ const Rewards: FC = () => {
         <TopCard />
         <RewardsList />
       </RewardsHistoryProvider>
+      <AprDisclaimer />
     </Layout>
   );
 };

--- a/shared/components/apr-disclaimer/apr-disclaimer.tsx
+++ b/shared/components/apr-disclaimer/apr-disclaimer.tsx
@@ -1,10 +1,14 @@
 import { AprDisclaimerBlock } from './styles';
 
-export const AprDisclaimer = () => (
+export const AprDisclaimer = ({
+  mentionAPY = false,
+}: {
+  mentionAPY?: boolean;
+}) => (
   <AprDisclaimerBlock>
     <p>
-      * APR/APY figures are estimates, not guaranteed, and are subject to change
-      based on network conditions.
+      * APR{mentionAPY && '/APY'} figures are estimates, not guaranteed, and are
+      subject to change based on network conditions.
     </p>
     <br />
     <p>

--- a/shared/components/apr-disclaimer/apr-disclaimer.tsx
+++ b/shared/components/apr-disclaimer/apr-disclaimer.tsx
@@ -1,7 +1,7 @@
-import { VaultDisclaimerBlock } from './styles';
+import { AprDisclaimerBlock } from './styles';
 
-export const VaultDisclaimer = () => (
-  <VaultDisclaimerBlock>
+export const AprDisclaimer = () => (
+  <AprDisclaimerBlock>
     <p>
       * APR/APY figures are estimates, not guaranteed, and are subject to change
       based on network conditions.
@@ -16,5 +16,5 @@ export const VaultDisclaimer = () => (
       their own research, seek professional advice, and ensure they understand
       the risks before participating
     </p>
-  </VaultDisclaimerBlock>
+  </AprDisclaimerBlock>
 );

--- a/shared/components/apr-disclaimer/index.ts
+++ b/shared/components/apr-disclaimer/index.ts
@@ -1,0 +1,1 @@
+export * from './apr-disclaimer';

--- a/shared/components/apr-disclaimer/styles.tsx
+++ b/shared/components/apr-disclaimer/styles.tsx
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+
+export const AprDisclaimerBlock = styled.section`
+  color: var(--lido-color-textSecondary);
+  font-size: ${({ theme }) => theme.fontSizesMap.xxs}px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 20px;
+  margin-top: 20px;
+
+  margin-bottom: 60px;
+
+  ${({ theme }) => theme.mediaQueries.md} {
+    margin-bottom: 0px;
+  }
+`;

--- a/shared/components/index.ts
+++ b/shared/components/index.ts
@@ -7,3 +7,4 @@ export { MatomoLink } from './matomo-link/matomo-link';
 export { InfoBox } from './info-box/info-box';
 export { Switch } from './switch/switch';
 export { Banner } from './banner/banner';
+export { AprDisclaimer } from './apr-disclaimer/apr-disclaimer';


### PR DESCRIPTION
### Description
This pull request refactors and standardizes the APR disclaimer across the app, improving consistency and maintainability. The main change is the replacement of the old `VaultDisclaimer` component with a new, more general `AprDisclaimer` component, which is now used in multiple locations. Additionally, the GGV vault description is centralized for reuse, and APR labels are updated to include an asterisk for clarity.

**APR Disclaimer Refactor and Standardization**
* Replaced the `VaultDisclaimer` component with the new `AprDisclaimer` component, moving its implementation from `features/earn/shared/vault-disclaimer.tsx` to `shared/components/apr-disclaimer/apr-disclaimer.tsx`, and updated all usages throughout the app to use the new component. [[1]](diffhunk://#diff-189a313fa4f59f7eab0f1ae88a6d1495241c7667122601527a2beb63fb06b497L1-R4) [[2]](diffhunk://#diff-189a313fa4f59f7eab0f1ae88a6d1495241c7667122601527a2beb63fb06b497L19-R19) [[3]](diffhunk://#diff-05770a358fbf7d5812efa24d2bddd009173fcc7ffdc560ea46b18348fc63b6b6R9-L16) [[4]](diffhunk://#diff-05770a358fbf7d5812efa24d2bddd009173fcc7ffdc560ea46b18348fc63b6b6L119-R119) [[5]](diffhunk://#diff-2edbec5b971fdd59e7f3fe9d8aafe2c277c98a2c6afbeb25259360e1621c4815R10-R11) [[6]](diffhunk://#diff-2edbec5b971fdd59e7f3fe9d8aafe2c277c98a2c6afbeb25259360e1621c4815L18) [[7]](diffhunk://#diff-2edbec5b971fdd59e7f3fe9d8aafe2c277c98a2c6afbeb25259360e1621c4815L146-R148) [[8]](diffhunk://#diff-b62c532a5d40874dbd8bb56ed07b5cc086d15a68d1d45bc1493adf71907d01a9R3-L8) [[9]](diffhunk://#diff-b62c532a5d40874dbd8bb56ed07b5cc086d15a68d1d45bc1493adf71907d01a9L25-R26) [[10]](diffhunk://#diff-c8292519b4134a324dda0d12a522f99c5754b7fc504eada789937caf18cc1227R4) [[11]](diffhunk://#diff-c8292519b4134a324dda0d12a522f99c5754b7fc504eada789937caf18cc1227R20)
* Created a new styled block for the disclaimer in `shared/components/apr-disclaimer/styles.tsx`.
* Added an index file for the new disclaimer component for easier imports.

**GGV Vault Description Centralization**
* Moved the GGV vault description string to a constant `GGV_VAULT_DESCRIPTION` in `features/earn/vault-ggv/consts.tsx`, and updated references to use this constant in both the GGV vault card and vault page components. [[1]](diffhunk://#diff-131d94ceb446db0b71e0261ba806b8bb07511e7f447bb096d566e38a52a67c1eR19-R21) [[2]](diffhunk://#diff-bcd2569604ea2e5949b12fe851d15f1a4660e38d4c20bbe580da5767db35e736L18-R22) [[3]](diffhunk://#diff-bcd2569604ea2e5949b12fe851d15f1a4660e38d4c20bbe580da5767db35e736L28-R32) [[4]](diffhunk://#diff-2edbec5b971fdd59e7f3fe9d8aafe2c277c98a2c6afbeb25259360e1621c4815L34-L40) [[5]](diffhunk://#diff-2edbec5b971fdd59e7f3fe9d8aafe2c277c98a2c6afbeb25259360e1621c4815L94-R96)

**APR Label Clarity**
* Updated APR labels in stats and staking components to include an asterisk, clarifying that APR figures are estimates. [[1]](diffhunk://#diff-72400edcb9521cbc93627ae4f1e7b96b3d9516e0836e3556158bdf2e8efa49dcL19-R19) [[2]](diffhunk://#diff-9d9339eebf941919f7bb6a7fdc03e83a06b370742afb10e0e6fe58a2810b06beL67-R67) [[3]](diffhunk://#diff-ca3e5395b200d57edc6a7028ba44a7a1b6b7f786f27a6f6b2071c82cf80503c6L68-R68)

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
