### PR TITLE
fix: update withdrawal warning in GGV deposit form to clarify restric…

### DIFF
--- a/features/earn/vault-ggv/deposit/ggv-deposit-form.tsx
+++ b/features/earn/vault-ggv/deposit/ggv-deposit-form.tsx
@@ -25,7 +25,8 @@ export const GGVDepositForm: FC = () => {
           <GGVWillReceive />
         </VaultTxInfo>
         <VaultWarning variant="info">
-          Deposited funds can’t be withdrawn for 24 hours after deposit.
+          Deposited funds cannot be withdrawn, and GG token is non-transferable
+          for 24 hours after deposit.
           <br />
           Withdrawals are only in wstETH, regardless of deposited asset(s).
         </VaultWarning>


### PR DESCRIPTION
…tions

<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

User-facing messaging update:

* The warning in `GGVDepositForm` now specifies that deposited funds cannot be withdrawn and that the GG token is non-transferable for 24 hours after deposit, providing clearer guidance to users.

### Demo

<!--- If thee are visual changes, attach a link to a specific section on preview stand / add screenshots / record a [loom](https://www.loom.com/). -->

### Code review notes

<!--- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

<!--- List all possible edge cases and how to test them. -->

### Checklist:

- [ ] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
