### PR TITLE
Add 'strategy' vault to ipfs.json for mainnet

### DIFF
--- a/IPFS.json
+++ b/IPFS.json
@@ -9,6 +9,7 @@
         130, 1135, 1923
       ],
       "earnVaults": [
+        { "name": "strategy" },
         { "name": "ggv", "apy": { "type": "weekly" } },
         { "name": "dvv" },
         { "name": "stg" }


### PR DESCRIPTION
Related: https://github.com/lidofinance/ethereum-staking-widget/pull/775
Forgot to add the vault for mainnet too

### Checklist:

- [ ] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
