### PR TITLE
feat: add 'blob:' to imgSrc in content security policy

### DIFF
--- a/config/csp/index.ts
+++ b/config/csp/index.ts
@@ -23,6 +23,7 @@ export const contentSecurityPolicy: ContentSecurityPolicyOption = {
     imgSrc: [
       "'self'",
       'data:',
+      'blob:',
       'https://*.walletconnect.org',
       'https://*.walletconnect.com',
     ],


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

* Added `'blob:'` to the `imgSrc` directive in `config/csp/index.ts`, permitting images sourced from blob URLs.

### Demo

<!--- If thee are visual changes, attach a link to a specific section on preview stand / add screenshots / record a [loom](https://www.loom.com/). -->

### Code review notes

<!--- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

<!--- List all possible edge cases and how to test them. -->

### Checklist:

- [ ] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
