### PR TITLE
Enable Rewards History, disable maintenance

### DIFF
--- a/IPFS.json
+++ b/IPFS.json
@@ -26,7 +26,7 @@
       "featureFlags": {
         "disableSendCalls": false,
         "dgBannerEnabled": true,
-        "rewardsMaintenance": true,
+        "rewardsMaintenance": false,
         "holidayDecorEnabled": false,
         "forceAllowance": false
       },


### PR DESCRIPTION
### Description
Disables maintenance mode for rewards history page

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
