### PR TITLE
refactor: update staking apy endpoint to use getEthApiPath

### DIFF
--- a/consts/api.ts
+++ b/consts/api.ts
@@ -17,6 +17,7 @@ export const enum ETH_API_ROUTES {
   ETH_PRICE = '/v1/protocol/eth/price',
   STETH_STATS = '/v1/protocol/steth/stats',
   STETH_SMA_APR = '/v1/protocol/steth/apr/sma',
+  STETH_APR = '/v1/protocol/steth/apr',
   SWAP_ONE_INCH = '/v1/swap/one-inch',
   SWAP_JUMPER = '/v1/swap/jumper',
   CURVE_APR = '/v1/pool/curve/steth-eth/apr/last',

--- a/features/earn/shared/v2/vault-chart/apy-data/staking-apy.ts
+++ b/features/earn/shared/v2/vault-chart/apy-data/staking-apy.ts
@@ -1,13 +1,7 @@
 import { z } from 'zod';
 
-import { config } from 'config';
+import { getEthApiPath, ETH_API_ROUTES } from 'consts/api';
 import { standardFetcher } from 'utils/standardFetcher';
-
-/**
- * Lido Ethereum API — APR for stETH.
- * @see https://eth-api.lido.fi/api#/APR%20for%20Eth%20and%20stEth/ProtocolController_findAPRforSTETH
- */
-const LIDO_STETH_APR_ORIGIN = `${config.ethAPIBasePath}/v1/protocol/steth/apr`;
 
 const LidoAprItemSchema = z.object({
   timeUnix: z.number(),
@@ -53,7 +47,13 @@ export const fetchStakingApyData = async (
   fromTimestamp: number,
 ): Promise<StakingApyFetchedData | null> => {
   const endTime = Math.floor(Date.now() / 1000);
-  const url = `${LIDO_STETH_APR_ORIGIN}?startTime=${fromTimestamp}&endTime=${endTime}&page=1&pageSize=${PAGE_SIZE}`;
+  const url = getEthApiPath(ETH_API_ROUTES.STETH_APR, {
+    startTime: fromTimestamp.toString(),
+    endTime: endTime.toString(),
+    page: '1',
+    pageSize: PAGE_SIZE.toString(),
+  });
+  if (!url) return null;
 
   const raw = await standardFetcher<unknown>(url);
   const parsed = LidoStethAprResponseSchema.parse(raw);


### PR DESCRIPTION
### Description

Fixes potential issue when `config.ethAPIBasePath` is not set.

### Testing notes

Affects Staking APY line data on the Meta Vaults chart. But no changes from the production version should be visible

<img width="899" height="397" alt="image" src="https://github.com/user-attachments/assets/b1cbfd83-8434-4a58-8f04-c6b3acfd45ff" />


### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
