### PR TITLE
EarnETH – show "upgrade assets" block on withdraw

### DIFF
--- a/features/earn/vault-eth/upgrade-assets/upgrade-assets.tsx
+++ b/features/earn/vault-eth/upgrade-assets/upgrade-assets.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { useFormContext } from 'react-hook-form';
 import { useDappStatus } from 'modules/web3';
 import { TOKENS, TOKEN_SYMBOLS } from 'consts/tokens';
 import { TokenGGIcon, TokenDvstethIcon, TokenStrethIcon } from 'assets/earn-v2';
@@ -9,6 +8,7 @@ import { MATOMO_EARN_EVENTS_TYPES } from 'consts/matomo/matomo-earn-events';
 import { trackMatomoEvent } from 'utils/track-matomo-event';
 import { MELLOW_VAULTS_QUERY_SCOPE } from 'modules/mellow-meta-vaults/consts';
 import { overrideWithQAMockBigInt } from 'utils/qa';
+import { useReferralQueryValue } from 'shared/hooks/use-query-values-form';
 
 import {
   UpgradeAssets,
@@ -25,7 +25,6 @@ import {
 } from '../consts';
 import { useEthVaultDeposit } from '../deposit/hooks';
 import { EthDepositTokenUpgradable } from '../types';
-import { ETHDepositFormValues } from '../deposit/form-context/types';
 
 const TOKEN_ICON_MAP = {
   [TOKENS.gg]: <TokenGGIcon />,
@@ -56,9 +55,7 @@ export const UpgradeAssetsBlock = () => {
   const queryClient = useQueryClient();
   const { balances, refetchBalances } = useUpgradableTokenBalances();
   const [isUpgrading, setIsUpgrading] = useState(false);
-
-  const { watch } = useFormContext<ETHDepositFormValues>();
-  const referral = watch('referral');
+  const referral = useReferralQueryValue();
 
   const { deposit } = useEthVaultDeposit();
 

--- a/features/earn/vault-eth/withdraw/withdraw-form.tsx
+++ b/features/earn/vault-eth/withdraw/withdraw-form.tsx
@@ -15,36 +15,40 @@ import { EthVaultWithdrawWillReceive } from './withdraw-will-receive';
 import { EthVaultWithdrawSubmitButton } from './withdraw-submit-button';
 import { EthVaultWithdrawRequests } from './withdraw-requests';
 import { ActionSwitch } from '../components/action-switch';
+import { UpgradeAssetsBlock } from '../upgrade-assets/upgrade-assets';
 
 // TODO: add Withdraw Warning and ability to disable withdraw via config
 
 const EthVaultWithdrawFormContent: FC = () => {
   return (
-    <BlockSidePanel>
-      <ActionSwitch isWithdraw />
-      <VaultForm data-testid="withdraw-form">
-        <VaultFormSection>
-          <EthVaultWithdrawRequests />
-          <EthVaultWithdrawAvailable />
-          <EthVaultWithdrawInput />
-        </VaultFormSection>
-        <VaultTxInfo>
-          <EthVaultWithdrawWillReceive />
-          <VaultTxInfoRow
-            title="Waiting time"
-            help={
-              <>
-                Withdrawals take up to 72 hours to process. Once ready, your
-                funds can be claimed in the Lido UI
-              </>
-            }
-          >
-            {'up to 72 hours'}
-          </VaultTxInfoRow>
-        </VaultTxInfo>
-        <EthVaultWithdrawSubmitButton />
-      </VaultForm>
-    </BlockSidePanel>
+    <>
+      <UpgradeAssetsBlock />
+      <BlockSidePanel>
+        <ActionSwitch isWithdraw />
+        <VaultForm data-testid="withdraw-form">
+          <VaultFormSection>
+            <EthVaultWithdrawRequests />
+            <EthVaultWithdrawAvailable />
+            <EthVaultWithdrawInput />
+          </VaultFormSection>
+          <VaultTxInfo>
+            <EthVaultWithdrawWillReceive />
+            <VaultTxInfoRow
+              title="Waiting time"
+              help={
+                <>
+                  Withdrawals take up to 72 hours to process. Once ready, your
+                  funds can be claimed in the Lido UI
+                </>
+              }
+            >
+              {'up to 72 hours'}
+            </VaultTxInfoRow>
+          </VaultTxInfo>
+          <EthVaultWithdrawSubmitButton />
+        </VaultForm>
+      </BlockSidePanel>
+    </>
   );
 };
 

--- a/shared/hooks/use-query-values-form.ts
+++ b/shared/hooks/use-query-values-form.ts
@@ -3,6 +3,17 @@ import { useRouter } from 'next/router';
 import { Path, PathValue, UseFormSetValue } from 'react-hook-form';
 import { parseEther } from 'viem';
 
+export const useReferralQueryValue = () => {
+  const { isReady, query } = useRouter();
+  const { ref } = query;
+
+  if (!isReady || typeof ref !== 'string') {
+    return null;
+  }
+
+  return ref;
+};
+
 type UseQueryParamsReferralFormArgs<T extends { referral: string | null }> = {
   setValue: UseFormSetValue<T>;
 };
@@ -12,19 +23,16 @@ export const useQueryParamsReferralForm = <
 >({
   setValue,
 }: UseQueryParamsReferralFormArgs<T>) => {
-  const { isReady, query } = useRouter();
-  const { ref } = query;
+  const referral = useReferralQueryValue();
 
   useEffect(() => {
-    if (!isReady) return;
+    if (!referral) return;
     try {
-      if (typeof ref === 'string') {
-        setValue('referral' as Path<T>, ref as PathValue<T, Path<T>>);
-      }
+      setValue('referral' as Path<T>, referral as PathValue<T, Path<T>>);
     } catch (error) {
       console.warn('Error setting referral value from query params', error);
     }
-  }, [isReady, ref, setValue]);
+  }, [referral, setValue]);
 };
 
 type UseQueryParamsAmountFormArgs<T extends { amount: bigint | null }> = {


### PR DESCRIPTION
### Description

Enables showing the "Assets available to upgrade" on the EarnETH withdraw page.

<img width="370" height="192" alt="image" src="https://github.com/user-attachments/assets/84e2d244-340f-4a79-8939-5fed9263c75c" />

### Testing notes

Affects getting "referral" from URL and passing it into the "Upgrade" transaction, so it is better to make sure that the value is passed in the tx (no need to finish the tx, just check that it is passed into it). I've checked that - works for me.

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
