### PR TITLE
Feature/si 2552 earn list warning

### DIFF
--- a/IPFS.json
+++ b/IPFS.json
@@ -20,7 +20,8 @@
         {
           "name": "eth",
           "deposit": false,
-          "depositPauseReasonText": "Deposits for EarnETH are currently paused by the vault curator, pending resolution of the Kelp and Aave incident."
+          "depositPauseReasonText": "Deposits for EarnETH are currently paused by the vault curator, pending resolution of the Kelp and Aave incident.",
+          "listWarningText": "Deposits for EarnETH are currently paused by the vault curator, pending resolution of the Kelp and Aave incident."
         },
         { "name": "usd" },
         { "name": "strategy", "deprecated": true },

--- a/IPFS.json
+++ b/IPFS.json
@@ -20,8 +20,8 @@
         {
           "name": "eth",
           "deposit": false,
-          "depositPauseReasonText": "Deposits for EarnETH are currently paused by the vault curator, pending resolution of the Kelp and Aave incident.",
-          "listWarningText": "Deposits for EarnETH are currently paused by the vault curator, pending resolution of the Kelp and Aave incident."
+          "depositPauseReasonText": "Deposits and withdrawal processing for EarnETH are currently paused by the vault curator, pending resolution of the Kelp and Aave incident.",
+          "listWarningText": "Deposits and withdrawal processing for EarnETH are currently paused by the vault curator, pending resolution of the Kelp and Aave incident."
         },
         { "name": "usd" },
         { "name": "strategy", "deprecated": true },

--- a/config/external-config/types.ts
+++ b/config/external-config/types.ts
@@ -22,6 +22,7 @@ export type EarnVaultConfigEntry = {
   withdraw?: boolean;
   depositPauseReasonText?: string;
   withdrawPauseReasonText?: string;
+  listWarningText?: string;
   apy?: VaultAPY;
   showNew?: boolean;
   deprecated?: boolean;

--- a/config/external-config/utils.ts
+++ b/config/external-config/utils.ts
@@ -61,6 +61,29 @@ export const isEnabledDexesValid = (config: object) => {
   return new Set(enabledWithdrawalDexes).size === enabledWithdrawalDexes.length;
 };
 
+const MAX_VAULT_TEXT_LENGTH = 250;
+
+const isOptionalShortString = (value: unknown): boolean =>
+  value === undefined ||
+  (typeof value === 'string' && value.length <= MAX_VAULT_TEXT_LENGTH);
+
+export const isEarnVaultsValid = (config: object): boolean => {
+  // allow empty config
+  if (!('earnVaults' in config) || !config.earnVaults) return true;
+
+  if (!Array.isArray(config.earnVaults)) return false;
+
+  return config.earnVaults.every(
+    (vault) =>
+      vault &&
+      typeof vault === 'object' &&
+      typeof vault.name === 'string' &&
+      isOptionalShortString(vault.depositPauseReasonText) &&
+      isOptionalShortString(vault.withdrawPauseReasonText) &&
+      isOptionalShortString(vault.listWarningText),
+  );
+};
+
 export const isPagesValid = (config: object) => {
   if (!('pages' in config)) {
     return true;
@@ -94,6 +117,7 @@ export const isManifestEntryValid = (
       isMultiChainBannerValid,
       isFeatureFlagsValid,
       isPagesValid,
+      isEarnVaultsValid,
     ]
       .map((validator) => validator(config))
       .every((isValid) => isValid);

--- a/features/earn/shared/hooks/use-vault-available.ts
+++ b/features/earn/shared/hooks/use-vault-available.ts
@@ -37,6 +37,9 @@ export const useVaultAvailable = ({
   const depositPauseReasonText = vaultConfig?.depositPauseReasonText;
   const withdrawPauseReasonText = vaultConfig?.withdrawPauseReasonText;
 
+  // Warning text on the Earn page (vaults list) - shown on the vault card
+  const listWarningText = vaultConfig?.listWarningText;
+
   return {
     isVaultAvailable,
     isVaultDeprecated,
@@ -44,5 +47,6 @@ export const useVaultAvailable = ({
     isWithdrawEnabled,
     depositPauseReasonText,
     withdrawPauseReasonText,
+    listWarningText,
   };
 };

--- a/features/earn/shared/v2/vault-card/styles.tsx
+++ b/features/earn/shared/v2/vault-card/styles.tsx
@@ -254,3 +254,8 @@ export const CardOverlayLink = styled.a`
     z-index: 1;
   }
 `;
+
+export const VaultWarning = styled.div`
+  margin-top: 32px;
+  z-index: 2;
+`;

--- a/features/earn/shared/v2/vault-card/vault-card.tsx
+++ b/features/earn/shared/v2/vault-card/vault-card.tsx
@@ -21,6 +21,7 @@ import {
   StyledTooltip,
   BadgeStyled,
   TitleTextStyled,
+  VaultWarning,
 } from './styles';
 import { LocalLink } from 'shared/components/local-link';
 import { EARN_PATH } from 'consts/urls';
@@ -63,6 +64,7 @@ type VaultCardProps = {
   illustration?: React.ReactNode;
   depositLinkCallback?: () => void;
   protectedBadgeTooltipText?: React.ReactNode;
+  warning?: React.ReactNode;
 };
 
 export const VaultCard: React.FC<VaultCardProps> = ({
@@ -76,6 +78,7 @@ export const VaultCard: React.FC<VaultCardProps> = ({
   illustration,
   depositLinkCallback,
   protectedBadgeTooltipText,
+  warning,
 }) => {
   const isDeprecated = useConfig().externalConfig.earnVaults.find(
     (vault) => vault.name === urlSlug,
@@ -167,6 +170,7 @@ export const VaultCard: React.FC<VaultCardProps> = ({
           </StatItem>
         )}
       </CardStats>
+      {warning && <VaultWarning>{warning}</VaultWarning>}
       <CardCta>
         <LocalLink href={depositHref} onClick={depositLinkCallback}>
           <Button fullwidth variant="translucent">

--- a/features/earn/shared/v2/vault-warning/index.ts
+++ b/features/earn/shared/v2/vault-warning/index.ts
@@ -1,2 +1,3 @@
 export { VaultDepositWarning } from './vault-deposit-warning';
 export { VaultWithdrawWarning } from './vault-withdraw-warning';
+export { VaultListWarning } from './vault-list-warning';

--- a/features/earn/shared/v2/vault-warning/vault-list-warning.tsx
+++ b/features/earn/shared/v2/vault-warning/vault-list-warning.tsx
@@ -1,0 +1,27 @@
+import { ReactNode } from 'react';
+import { VaultWarning } from 'features/earn/shared/vault-warning';
+
+type VaultListWarningProps = {
+  isVaultAvailable: boolean;
+  warningText?: ReactNode;
+};
+
+export const VaultListWarning = ({
+  isVaultAvailable,
+  warningText,
+}: VaultListWarningProps) => {
+  // Without this check, the warning can be displayed even if the vault is generally disabled
+  if (!isVaultAvailable) return null;
+
+  if (!warningText) return null;
+
+  return (
+    <VaultWarning>
+      {warningText} Follow{' '}
+      <a href="https://x.com/LidoFinance" target="_blank" rel="noreferrer">
+        Lido on X
+      </a>{' '}
+      for the latest updates.
+    </VaultWarning>
+  );
+};

--- a/features/earn/vault-eth/hooks/use-vault-available.ts
+++ b/features/earn/vault-eth/hooks/use-vault-available.ts
@@ -8,6 +8,7 @@ export const useEthVaultAvailable = () => {
     isWithdrawEnabled,
     depositPauseReasonText,
     withdrawPauseReasonText,
+    listWarningText,
   } = useVaultAvailable({
     vaultName: EARN_VAULT_ETH_SLUG,
     contractName: 'ethVault',
@@ -19,5 +20,6 @@ export const useEthVaultAvailable = () => {
     isWithdrawEnabled,
     depositPauseReasonText,
     withdrawPauseReasonText,
+    listWarningText,
   };
 };

--- a/features/earn/vault-eth/vault-card.tsx
+++ b/features/earn/vault-eth/vault-card.tsx
@@ -2,6 +2,8 @@ import { VaultEthIcon } from 'assets/earn-v2';
 import { trackMatomoEvent } from 'utils/track-matomo-event';
 import { getTokenIcon } from 'utils/get-token-icon';
 import { MATOMO_EARN_EVENTS_TYPES } from 'consts/matomo';
+import { VaultListWarning } from 'features/earn/shared/v2/vault-warning';
+
 import { VaultCard } from '../shared/v2/vault-card';
 import { EARN_VAULT_ETH_SLUG } from '../consts';
 import { useEthVaultStats } from './hooks/use-vault-stats';
@@ -13,11 +15,13 @@ import {
   ETH_VAULT_TOKEN_SYMBOL,
 } from './consts';
 import { useEthVaultPosition } from './hooks/use-position';
+import { useEthVaultAvailable } from './hooks/use-vault-available';
 import { ProtectedTooltip } from './protected-tooltip';
 
 export const EthVaultCard = () => {
   const { apy, isLoading: isApyLoading } = useEthVaultApy();
   const { tvlUsd, isLoading: isTvlLoading } = useEthVaultStats();
+  const { isEthVaultAvailable, listWarningText } = useEthVaultAvailable();
 
   const { data: earnethPositionData, isLoading: isPositionLoading } =
     useEthVaultPosition();
@@ -49,6 +53,12 @@ export const EthVaultCard = () => {
         trackMatomoEvent(MATOMO_EARN_EVENTS_TYPES.earnListEarnEthDeposit);
       }}
       protectedBadgeTooltipText={<ProtectedTooltip />}
+      warning={
+        <VaultListWarning
+          isVaultAvailable={isEthVaultAvailable}
+          warningText={listWarningText}
+        />
+      }
     />
   );
 };

--- a/features/earn/vault-usd/hooks/use-vault-available.ts
+++ b/features/earn/vault-usd/hooks/use-vault-available.ts
@@ -8,6 +8,7 @@ export const useUsdVaultAvailable = () => {
     isWithdrawEnabled,
     depositPauseReasonText,
     withdrawPauseReasonText,
+    listWarningText,
   } = useVaultAvailable({
     vaultName: EARN_VAULT_USD_SLUG,
     contractName: 'usdVault',
@@ -19,5 +20,6 @@ export const useUsdVaultAvailable = () => {
     isWithdrawEnabled,
     depositPauseReasonText,
     withdrawPauseReasonText,
+    listWarningText,
   };
 };

--- a/features/earn/vault-usd/vault-card.tsx
+++ b/features/earn/vault-usd/vault-card.tsx
@@ -5,6 +5,7 @@ import { MATOMO_EARN_EVENTS_TYPES } from 'consts/matomo';
 
 import { VaultCard } from '../shared/v2/vault-card';
 import { EARN_VAULT_USD_SLUG } from '../consts';
+import { VaultListWarning } from '../shared/v2/vault-warning';
 import { useUsdVaultApy } from './hooks/use-vault-apy';
 import { useUsdVaultStats } from './hooks/use-vault-stats';
 import { UsdVaultApyHint } from './components/apy-hint';
@@ -15,12 +16,14 @@ import {
 } from './consts';
 import { useUsdVaultPosition } from './hooks/use-position';
 import { ProtectedTooltip } from './protected-tooltip';
+import { useUsdVaultAvailable } from './hooks/use-vault-available';
 
 export const UsdVaultCard = () => {
   const { apy, isLoading: isApyLoading } = useUsdVaultApy();
   const { tvlUsd, isLoading: isTvlLoading } = useUsdVaultStats();
   const { data: usdPositionData, isLoading: isPositionLoading } =
     useUsdVaultPosition();
+  const { isUsdVaultAvailable, listWarningText } = useUsdVaultAvailable();
 
   const sharesBalance = usdPositionData?.earnusdSharesBalance;
 
@@ -49,6 +52,12 @@ export const UsdVaultCard = () => {
         trackMatomoEvent(MATOMO_EARN_EVENTS_TYPES.earnListEarnUsdDeposit);
       }}
       protectedBadgeTooltipText={<ProtectedTooltip />}
+      warning={
+        <VaultListWarning
+          isVaultAvailable={isUsdVaultAvailable}
+          warningText={listWarningText}
+        />
+      }
     />
   );
 };


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

This pull request adds support for displaying vault-specific warning messages on the Earn vaults list, allowing curators to communicate important information to users directly on the vault cards. The main changes include introducing a new `listWarningText` field in the vault configuration, updating types and hooks to propagate this field, and rendering a standardized warning component on the vault cards for ETH and USD vaults.

**Vault warning message support**

* Added a new optional `listWarningText` field to the vault configuration (`IPFS.json`, `EarnVaultConfigEntry` in `types.ts`) to allow curators to specify warning messages for individual vaults. [[1]](diffhunk://#diff-89a9ab41012f4a96ef168e5f3bcf41be85e4879b55203c27b0a3b5b25bb42cc6L23-R24) [[2]](diffhunk://#diff-8102f96f7f989994893812f1d3d0373f264dfad0ce6f97a34e6ff579dccd28e3R25)
* Updated the `useVaultAvailable` hook and ETH/USD-specific hooks to return the new `listWarningText` field, making it available to the UI. [[1]](diffhunk://#diff-c9157424d88c8c1e24806fdf31954ec704404ecc89a3ec5a826906219d9751e5R40-R50) [[2]](diffhunk://#diff-3e7d31172307c7fd2c44a4d7b99796be36c1caed94760740e340c839e8d62388R11) [[3]](diffhunk://#diff-3e7d31172307c7fd2c44a4d7b99796be36c1caed94760740e340c839e8d62388R23) [[4]](diffhunk://#diff-1755447cc94e9ba42aa029c209c7f9f264084bc96ed88cf2eb1639b698c3f751R11) [[5]](diffhunk://#diff-1755447cc94e9ba42aa029c209c7f9f264084bc96ed88cf2eb1639b698c3f751R23)

**UI integration for warnings**

* Added and styled a new `VaultWarning` component and integrated it into the `VaultCard` component, allowing vault warnings to be displayed on the Earn vault cards. [[1]](diffhunk://#diff-b1adde545d3189628a0ffd641e956ac3e86deccf007ae38cbdf317dfa748a2b0R257-R261) [[2]](diffhunk://#diff-c724e95ae6709296de0f0a7f0398d0322afa58c5654666fb6a18e1f8f159fe5cR24) [[3]](diffhunk://#diff-c724e95ae6709296de0f0a7f0398d0322afa58c5654666fb6a18e1f8f159fe5cR67) [[4]](diffhunk://#diff-c724e95ae6709296de0f0a7f0398d0322afa58c5654666fb6a18e1f8f159fe5cR81) [[5]](diffhunk://#diff-c724e95ae6709296de0f0a7f0398d0322afa58c5654666fb6a18e1f8f159fe5cR173)
* Created a `VaultListWarning` component to standardize the display of list warnings, including a link to Lido's official X account for updates. [[1]](diffhunk://#diff-d4f7ed7d820d9e2107980ee705caabe329f8f4dbca8946739986818649b2c416R3) [[2]](diffhunk://#diff-5068cb56234e9ed43869379e2de6386591ab46b0ea97f48aa6a8e34a8492b7d5R1-R27)

**ETH and USD vault card updates**

* Updated `EthVaultCard` and `UsdVaultCard` to display the new vault warning (if present) using the `VaultListWarning` component, ensuring users are informed about important vault status changes directly on the Earn page. [[1]](diffhunk://#diff-8ca4e52ed78b61b72d43837b674523de1c51b1d9fba639ca8625fded20f2a6edR5-R6) [[2]](diffhunk://#diff-8ca4e52ed78b61b72d43837b674523de1c51b1d9fba639ca8625fded20f2a6edR18-R24) [[3]](diffhunk://#diff-8ca4e52ed78b61b72d43837b674523de1c51b1d9fba639ca8625fded20f2a6edR56-R61) [[4]](diffhunk://#diff-57259c797bf0bfdcb251cc8592d9878b61ccd33b6f5d41739fad937ab1a60f4fR8) [[5]](diffhunk://#diff-57259c797bf0bfdcb251cc8592d9878b61ccd33b6f5d41739fad937ab1a60f4fR19-R26) [[6]](diffhunk://#diff-57259c797bf0bfdcb251cc8592d9878b61ccd33b6f5d41739fad937ab1a60f4fR55-R60)

### Demo

<img width="901" height="631" alt="image" src="https://github.com/user-attachments/assets/aae7076b-bd26-4692-9a17-9dc88d31bfca" />

<!--- If thee are visual changes, attach a link to a specific section on preview stand / add screenshots / record a [loom](https://www.loom.com/). -->

### Code review notes

<!--- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

<!--- List all possible edge cases and how to test them. -->

### Checklist:

- [ ] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
