### PR TITLE
refactor: simplify VaultListWarning component by removing isVaultAvai…

### DIFF
--- a/features/earn/shared/v2/vault-warning/vault-list-warning.tsx
+++ b/features/earn/shared/v2/vault-warning/vault-list-warning.tsx
@@ -2,17 +2,10 @@ import { ReactNode } from 'react';
 import { VaultWarning } from 'features/earn/shared/vault-warning';
 
 type VaultListWarningProps = {
-  isVaultAvailable: boolean;
   warningText?: ReactNode;
 };
 
-export const VaultListWarning = ({
-  isVaultAvailable,
-  warningText,
-}: VaultListWarningProps) => {
-  // Without this check, the warning can be displayed even if the vault is generally disabled
-  if (!isVaultAvailable) return null;
-
+export const VaultListWarning = ({ warningText }: VaultListWarningProps) => {
   if (!warningText) return null;
 
   return (

--- a/features/earn/vault-eth/vault-card.tsx
+++ b/features/earn/vault-eth/vault-card.tsx
@@ -21,7 +21,7 @@ import { ProtectedTooltip } from './protected-tooltip';
 export const EthVaultCard = () => {
   const { apy, isLoading: isApyLoading } = useEthVaultApy();
   const { tvlUsd, isLoading: isTvlLoading } = useEthVaultStats();
-  const { isEthVaultAvailable, listWarningText } = useEthVaultAvailable();
+  const { listWarningText } = useEthVaultAvailable();
 
   const { data: earnethPositionData, isLoading: isPositionLoading } =
     useEthVaultPosition();
@@ -53,12 +53,7 @@ export const EthVaultCard = () => {
         trackMatomoEvent(MATOMO_EARN_EVENTS_TYPES.earnListEarnEthDeposit);
       }}
       protectedBadgeTooltipText={<ProtectedTooltip />}
-      warning={
-        <VaultListWarning
-          isVaultAvailable={isEthVaultAvailable}
-          warningText={listWarningText}
-        />
-      }
+      warning={<VaultListWarning warningText={listWarningText} />}
     />
   );
 };

--- a/features/earn/vault-usd/vault-card.tsx
+++ b/features/earn/vault-usd/vault-card.tsx
@@ -23,7 +23,7 @@ export const UsdVaultCard = () => {
   const { tvlUsd, isLoading: isTvlLoading } = useUsdVaultStats();
   const { data: usdPositionData, isLoading: isPositionLoading } =
     useUsdVaultPosition();
-  const { isUsdVaultAvailable, listWarningText } = useUsdVaultAvailable();
+  const { listWarningText } = useUsdVaultAvailable();
 
   const sharesBalance = usdPositionData?.earnusdSharesBalance;
 
@@ -52,12 +52,7 @@ export const UsdVaultCard = () => {
         trackMatomoEvent(MATOMO_EARN_EVENTS_TYPES.earnListEarnUsdDeposit);
       }}
       protectedBadgeTooltipText={<ProtectedTooltip />}
-      warning={
-        <VaultListWarning
-          isVaultAvailable={isUsdVaultAvailable}
-          warningText={listWarningText}
-        />
-      }
+      warning={<VaultListWarning warningText={listWarningText} />}
     />
   );
 };


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

**Vault warning logic simplification:**

* [`features/earn/shared/v2/vault-warning/vault-list-warning.tsx`](diffhunk://#diff-5068cb56234e9ed43869379e2de6386591ab46b0ea97f48aa6a8e34a8492b7d5L5-R8): Removed the `isVaultAvailable` prop and its conditional check from the `VaultListWarning` component, so the warning is now shown based solely on the presence of `warningText`.

* `features/earn/vault-eth/vault-card.tsx`: 
  - Stopped extracting `isEthVaultAvailable` from `useEthVaultAvailable` and updated the usage of `VaultListWarning` to only pass `warningText`. [[1]](diffhunk://#diff-8ca4e52ed78b61b72d43837b674523de1c51b1d9fba639ca8625fded20f2a6edL24-R24) [[2]](diffhunk://#diff-8ca4e52ed78b61b72d43837b674523de1c51b1d9fba639ca8625fded20f2a6edL56-R56)

* `features/earn/vault-usd/vault-card.tsx`: 
  - Stopped extracting `isUsdVaultAvailable` from `useUsdVaultAvailable` and updated the usage of `VaultListWarning` to only pass `warningText`. [[1]](diffhunk://#diff-57259c797bf0bfdcb251cc8592d9878b61ccd33b6f5d41739fad937ab1a60f4fL26-R26) [[2]](diffhunk://#diff-57259c797bf0bfdcb251cc8592d9878b61ccd33b6f5d41739fad937ab1a60f4fL55-R55)

### Demo

<!--- If thee are visual changes, attach a link to a specific section on preview stand / add screenshots / record a [loom](https://www.loom.com/). -->

### Code review notes

<!--- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

<!--- List all possible edge cases and how to test them. -->

### Checklist:

- [ ] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
