### PR TITLE
fix: click on upgrading vaults title disabling pointer events

### DIFF
--- a/features/earn/shared/badge/styles.ts
+++ b/features/earn/shared/badge/styles.ts
@@ -13,8 +13,9 @@ export const BadgeStyled = styled.div`
   font-weight: 700;
   line-height: 10px;
   color: var(--lido-color-success);
+  user-select: none;
 `;
 
 export const TooltipStyled = styled(Tooltip)`
-  margin-top: 16px;
+  margin-top: ${({ theme }) => theme.spaceMap.xs}px !important;
 `;

--- a/features/earn/shared/v2/vault-card/styles.tsx
+++ b/features/earn/shared/v2/vault-card/styles.tsx
@@ -82,7 +82,6 @@ export const CardTitle = styled.div`
   font-size: 26px;
   line-height: 38px;
   font-weight: 700;
-  z-index: 1;
 
   ${({ theme }) => theme.mediaQueries.md} {
     flex-direction: column;
@@ -96,7 +95,7 @@ export const CardTitleBadge = styled(Badge)`
   height: 32px;
   user-select: none;
   position: relative;
-  z-index: 2;
+  z-index: 20;
 `;
 
 export const ChevronsUpIcon = styled(ChevronsUp)`
@@ -234,7 +233,7 @@ export const StyledTooltip = styled(Tooltip)`
 
 export const BadgeStyled = styled.span`
   position: relative;
-  z-index: 2;
+  z-index: 20;
 
   ${({ theme }) => theme.mediaQueries.md} {
     order: 1;
@@ -251,11 +250,11 @@ export const CardOverlayLink = styled.a`
   && {
     position: absolute;
     inset: 0;
-    z-index: 1;
+    z-index: 10;
   }
 `;
 
 export const VaultWarning = styled.div`
   margin-top: 32px;
-  z-index: 2;
+  z-index: 20;
 `;

--- a/features/earn/shared/v2/vault-card/vault-card.tsx
+++ b/features/earn/shared/v2/vault-card/vault-card.tsx
@@ -130,7 +130,7 @@ export const VaultCard: React.FC<VaultCardProps> = ({
             {stats.apxLabel}
             <VaultTip
               placement="bottom"
-              style={{ position: 'relative', zIndex: 2 }}
+              style={{ position: 'relative', zIndex: 20 }}
             >
               {stats.apxHint}
             </VaultTip>

--- a/features/earn/vaults-list/styles.tsx
+++ b/features/earn/vaults-list/styles.tsx
@@ -5,11 +5,13 @@ export const AccordionTransparentStyled = styled(AccordionTransparent)`
   overflow: visible;
 
   /*
-    Disabling pointer-events while animation is in progress,
+    Disabling hover box-shadow for child elements while animation is in progress,
     fixes issue with card shadow on hover caused by inline overflow:hidden during animation
   */
   &[data-animating] * {
-    pointer-events: none;
+    &:hover {
+      box-shadow: none;
+    }
   }
 `;
 

--- a/features/earn/vaults-list/vaults-list.tsx
+++ b/features/earn/vaults-list/vaults-list.tsx
@@ -82,11 +82,13 @@ export const EarnVaultsList: FC = () => {
         {hasDeprecatedVaults && (
           <AccordionTransparentStyled
             data-animating={isAccordionAnimating || undefined}
-            onClick={() => setIsAccordionAnimating(true)}
             onExpand={() => setIsAccordionAnimating(false)}
             onCollapse={() => setIsAccordionAnimating(false)}
             summary={
-              <AccordionTitle data-testid={'upgradingVaults'}>
+              <AccordionTitle
+                data-testid={'upgradingVaults'}
+                onClick={() => setIsAccordionAnimating(true)}
+              >
                 Upgrading vaults
               </AccordionTitle>
             }


### PR DESCRIPTION
### Description
1. The `onClick={() => setIsAccordionAnimating(true)}` is on the full `AccordionTransparentStyled`, so clicking ANY child inside the accordion (including vault card titles) sets `isAccordionAnimating = true`. Since clicking a card doesn't trigger onExpand/onCollapse, the state never resets and `pointer-events: none` stays on permanently.
The fix: move onClick to only the summary element (the accordion header), not the whole accordion.

2. Don't disable pointer events while animation in progress [[change]](https://github.com/lidofinance/ethereum-staking-widget/pull/1038/changes#diff-b1c26aacccbb3c6fcfbace4604327dea42d1a95ce16c99ad08a8af1352ba2d69R12-R14)

3. z-index changes – click on CardTitle should redirect inside the vault

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
