### PR TITLE
Fix: refetch upgradable token balances after legacy vault operations

### DIFF
--- a/features/earn/vault-dvv/deposit/form-context/use-dvv-deposit-form-data.ts
+++ b/features/earn/vault-dvv/deposit/form-context/use-dvv-deposit-form-data.ts
@@ -13,6 +13,7 @@ import {
 } from '../types';
 import { useAwaiter } from 'shared/hooks/use-awaiter';
 import { useQueryClient } from '@tanstack/react-query';
+import { ETH_VAULT_QUERY_SCOPE } from 'features/earn/vault-eth/consts';
 
 export const useDVVDepositFormData = () => {
   const queryClient = useQueryClient();
@@ -66,6 +67,10 @@ export const useDVVDepositFormData = () => {
         tokenBalanceRefetch(options),
         // refetch all DVV related queries
         queryClient.refetchQueries({ queryKey: ['dvv'] }, options),
+        queryClient.refetchQueries(
+          { queryKey: [ETH_VAULT_QUERY_SCOPE] },
+          options,
+        ),
       ]);
     },
     [queryClient, ethBalanceQuery.refetch, wethBalanceQuery.refetch],

--- a/features/earn/vault-dvv/withdraw/form-context/use-dvv-withdraw-form-data.tsx
+++ b/features/earn/vault-dvv/withdraw/form-context/use-dvv-withdraw-form-data.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useAwaiter } from 'shared/hooks/use-awaiter';
 import { useDappStatus } from 'modules/web3/hooks/use-dapp-status';
+import { ETH_VAULT_QUERY_SCOPE } from 'features/earn/vault-eth/consts';
 import { useDVVPosition } from '../../hooks/use-dvv-position';
 import { useDVVWithdrawLimit } from '../hooks/use-dvv-withdraw-limit';
 import {
@@ -41,6 +42,10 @@ export const useDVVWithdrawFormData = () => {
     return Promise.all([
       balanceQuery.refetch(options), // refetch all DVV related queries
       queryClient.refetchQueries({ queryKey: ['dvv'] }, options),
+      queryClient.refetchQueries(
+        { queryKey: [ETH_VAULT_QUERY_SCOPE] },
+        options,
+      ),
     ]);
   }, [balanceQuery, queryClient]);
 

--- a/features/earn/vault-eth/upgrade-assets/upgrade-assets.tsx
+++ b/features/earn/vault-eth/upgrade-assets/upgrade-assets.tsx
@@ -46,7 +46,6 @@ const getMatomoEventForToken = (token: EthDepositTokenUpgradable) => {
 };
 
 type UpgradeArgs = {
-  amount: bigint;
   token: EthDepositTokenUpgradable;
 };
 
@@ -60,20 +59,21 @@ export const UpgradeAssetsBlock = () => {
   const { deposit } = useEthVaultDeposit();
 
   const upgrade = useCallback(
-    async ({
-      // TODO: consider getting amount inside upgrade function
-      amount,
-      token,
-    }: UpgradeArgs) => {
-      const depositAmount = overrideWithQAMockBigInt(
-        amount ?? 0n,
-        'mock-qa-helpers-earn-eth-upgrade-amount',
-      );
-
-      if (!depositAmount) return;
+    async ({ token }: UpgradeArgs) => {
       setIsUpgrading(true);
 
       try {
+        const balancesQuery = await refetchBalances();
+        if (!balancesQuery.isSuccess) return;
+
+        const balanceAmount = balancesQuery.data?.[token] ?? 0n;
+        const depositAmount = overrideWithQAMockBigInt(
+          balanceAmount,
+          'mock-qa-helpers-earn-eth-upgrade-amount',
+        );
+
+        if (!depositAmount) return;
+
         const isDepositSuccessful = await deposit({
           amount: depositAmount,
           token,
@@ -137,7 +137,6 @@ export const UpgradeAssetsBlock = () => {
             onClick={() =>
               upgrade({
                 token,
-                amount: balances[token] as bigint,
               })
             }
             loading={isUpgrading}

--- a/features/earn/vault-ggv/deposit/hooks/use-ggv-deposit-form-data.tsx
+++ b/features/earn/vault-ggv/deposit/hooks/use-ggv-deposit-form-data.tsx
@@ -15,6 +15,7 @@ import type {
 } from '../form-context/types';
 import { useAwaiter } from 'shared/hooks/use-awaiter';
 import { useQueryClient } from '@tanstack/react-query';
+import { ETH_VAULT_QUERY_SCOPE } from 'features/earn/vault-eth/consts';
 
 export const useGGVDepositFormData = () => {
   const queryClient = useQueryClient();
@@ -86,6 +87,10 @@ export const useGGVDepositFormData = () => {
         tokenBalanceRefetch(options),
         // refetch all GGV related queries
         queryClient.refetchQueries({ queryKey: ['ggv'] }, options),
+        queryClient.refetchQueries(
+          { queryKey: [ETH_VAULT_QUERY_SCOPE] },
+          options,
+        ),
       ]);
     },
     [

--- a/features/earn/vault-ggv/withdraw/form-context/use-withdraw-form-data.tsx
+++ b/features/earn/vault-ggv/withdraw/form-context/use-withdraw-form-data.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 
 import { useAwaiter } from 'shared/hooks/use-awaiter';
 import { useDappStatus } from 'modules/web3';
+import { ETH_VAULT_QUERY_SCOPE } from 'features/earn/vault-eth/consts';
 
 import { useGGVPosition } from '../../hooks/use-ggv-position';
 import { useGGVWithdrawalRequests } from '../hooks/use-ggv-withdrawal-requests';
@@ -109,6 +110,10 @@ export const useGGVWithdrawFormData = () => {
       balanceQuery.refetch(options),
       // refetch all GGV related queries
       queryClient.refetchQueries({ queryKey: ['ggv'] }, options),
+      queryClient.refetchQueries(
+        { queryKey: [ETH_VAULT_QUERY_SCOPE] },
+        options,
+      ),
     ]);
   }, [balanceQuery, queryClient]);
 

--- a/features/earn/vault-ggv/withdraw/hooks/use-ggv-cancel-withdraw.ts
+++ b/features/earn/vault-ggv/withdraw/hooks/use-ggv-cancel-withdraw.ts
@@ -74,18 +74,10 @@ export const useGGVCancelWithdraw = () => {
             );
           },
           onSuccess: async ({ txHash }) => {
-            const opts = {
+            const newBalance = await positionQuery.refetch({
               cancelRefetch: true,
               throwOnError: false,
-            };
-            const [newBalance] = await Promise.all([
-              positionQuery.refetch(opts),
-              queryClient.refetchQueries({ queryKey: ['ggv'] }, opts),
-              queryClient.refetchQueries(
-                { queryKey: [ETH_VAULT_QUERY_SCOPE] },
-                opts,
-              ),
-            ]);
+            });
             return txModalStages.success(
               newBalance.data?.sharesBalance as bigint,
               txHash,

--- a/features/earn/vault-ggv/withdraw/hooks/use-ggv-cancel-withdraw.ts
+++ b/features/earn/vault-ggv/withdraw/hooks/use-ggv-cancel-withdraw.ts
@@ -4,6 +4,7 @@ import { encodeFunctionData, type WalletClient } from 'viem';
 import { useQueryClient } from '@tanstack/react-query';
 
 import { AACall, useDappStatus, useLidoSDK, useTxFlow } from 'modules/web3';
+import { ETH_VAULT_QUERY_SCOPE } from 'features/earn/vault-eth/consts';
 
 import { getGGVQueueWritableContract } from '../../contracts';
 import { useGGVPosition } from '../../hooks/use-ggv-position';
@@ -80,6 +81,10 @@ export const useGGVCancelWithdraw = () => {
             const [newBalance] = await Promise.all([
               positionQuery.refetch(opts),
               queryClient.refetchQueries({ queryKey: ['ggv'] }, opts),
+              queryClient.refetchQueries(
+                { queryKey: [ETH_VAULT_QUERY_SCOPE] },
+                opts,
+              ),
             ]);
             return txModalStages.success(
               newBalance.data?.sharesBalance as bigint,
@@ -98,6 +103,10 @@ export const useGGVCancelWithdraw = () => {
 
         await Promise.all([
           queryClient.refetchQueries({ queryKey: ['ggv'] }, opts),
+          queryClient.refetchQueries(
+            { queryKey: [ETH_VAULT_QUERY_SCOPE] },
+            opts,
+          ),
           positionQuery.refetch(opts),
         ]);
       } catch (error) {

--- a/features/earn/vault-stg/deposit/hooks/use-stg-deposit-claim.ts
+++ b/features/earn/vault-stg/deposit/hooks/use-stg-deposit-claim.ts
@@ -3,6 +3,7 @@ import { encodeFunctionData, WalletClient } from 'viem';
 import { useQueryClient } from '@tanstack/react-query';
 import invariant from 'tiny-invariant';
 import { useDappStatus, useLidoSDK, useTxFlow } from 'modules/web3';
+import { ETH_VAULT_QUERY_SCOPE } from 'features/earn/vault-eth/consts';
 import { getSTGVaultWritableContract } from '../../contracts';
 import { useTxModalStagesSTGDepositClaim } from './use-stg-deposit-claim-tx-modal';
 import { trackMatomoEvent } from 'utils/track-matomo-event';
@@ -64,10 +65,14 @@ export const useSTGDepositClaim = (onRetry?: () => void) => {
           onSuccess: async ({ txHash }) => {
             txModalStages.success(amount, txHash);
             trackMatomoEvent(MATOMO_EARN_EVENTS_TYPES.strategyDepositClaim);
-            await queryClient.refetchQueries(
-              { queryKey: ['stg'] },
-              { cancelRefetch: true, throwOnError: false },
-            );
+            const options = { cancelRefetch: true, throwOnError: false };
+            await Promise.all([
+              queryClient.refetchQueries({ queryKey: ['stg'] }, options),
+              queryClient.refetchQueries(
+                { queryKey: [ETH_VAULT_QUERY_SCOPE] },
+                options,
+              ),
+            ]);
           },
         });
 

--- a/features/earn/vault-stg/deposit/hooks/use-stg-deposit-form-data.tsx
+++ b/features/earn/vault-stg/deposit/hooks/use-stg-deposit-form-data.tsx
@@ -8,6 +8,7 @@ import {
   useWethBalance,
   useDappStatus,
 } from 'modules/web3';
+import { ETH_VAULT_QUERY_SCOPE } from 'features/earn/vault-eth/consts';
 import {
   STGDepositFormAsyncValidationContext,
   STGDepositFormValidationContext,
@@ -66,6 +67,10 @@ export const useSTGDepositFormData = () => {
         tokenBalanceRefetch(options),
         // refetch all STG related queries
         queryClient.refetchQueries({ queryKey: ['stg'] }, options),
+        queryClient.refetchQueries(
+          { queryKey: [ETH_VAULT_QUERY_SCOPE] },
+          options,
+        ),
       ]);
     },
     [

--- a/features/earn/vault-stg/withdraw/hooks/use-stg-withdraw-form-data.tsx
+++ b/features/earn/vault-stg/withdraw/hooks/use-stg-withdraw-form-data.tsx
@@ -3,6 +3,7 @@ import { useAwaiter } from 'shared/hooks/use-awaiter';
 import { useQueryClient } from '@tanstack/react-query';
 
 import { useDappStatus } from 'modules/web3';
+import { ETH_VAULT_QUERY_SCOPE } from 'features/earn/vault-eth/consts';
 import { useSTGPosition } from '../../hooks/use-stg-position';
 import {
   STGWithdrawFormAsyncValidationContext,
@@ -41,6 +42,12 @@ export const useSTGWithdrawFormData = () => {
     return Promise.all([
       // refetch all STG related queries
       queryClient.refetchQueries({ queryKey: ['stg'] }, options),
+      // strETH is an upgradable EarnETH asset, so STG balance mutations
+      // must refresh the EarnETH upgrade banner.
+      queryClient.refetchQueries(
+        { queryKey: [ETH_VAULT_QUERY_SCOPE] },
+        options,
+      ),
     ]);
   }, [queryClient]);
 


### PR DESCRIPTION
### Description
#### 1. Fix stale EarnETH upgrade balances after vault balance mutations.

Changes:

- Re-read upgradable token balance right before submitting an Upgrade transaction.
- Refresh EarnETH upgrade-balance queries after STG, GGV, and DVV deposit/withdraw/claim/cancel flows that can change upgradable token balances.
- Prevent Upgrade banner from submitting a cached amount after a user withdraws or otherwise changes GG, strETH, or DVstETH balance.

#### 2. Fix: show success modal after GGV cancel withdrawal (Resolves SI-2163):

`onSuccess` was calling `queryClient.refetchQueries(['ggv'])` before transitioning the modal to the success state. This caused the withdrawal  requests query to update immediately, unmounting `PendingRequestEntry` (no open requests left), which triggered `useTransactionModalStage`'s cleanup and set `isMountedRef.current = false`. The subsequent `txModalStages.success()` call hit the early-return guard in `transitStage` and was silently dropped, leaving the modal stuck on "Awaiting block confirmation".

_Solution_

Removed `queryClient.refetchQueries` from `onSuccess` — only `positionQuery.refetch` stays there to supply the balance for the success modal. The broader query invalidation still happens in the existing `Promise.all` block after `txFlow` resolves.

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
