### PR TITLE
feat(earn): display APY update time and staleness

### DIFF
--- a/features/earn/shared/hooks/use-vault-apy.ts
+++ b/features/earn/shared/hooks/use-vault-apy.ts
@@ -1,0 +1,35 @@
+import { useQuery } from '@tanstack/react-query';
+
+const APY_STALE_THRESHOLD_MS = 2 * 24 * 60 * 60 * 1000; // 2 days
+
+type VaultApyData = {
+  apy: number;
+  apyLastUpdate: number;
+};
+
+export const useVaultApy = ({
+  queryScope,
+  queryFn,
+}: {
+  queryScope: string;
+  queryFn: () => Promise<VaultApyData>;
+}) => {
+  const { data, isLoading } = useQuery({
+    queryKey: [queryScope, 'apy'],
+    queryFn,
+  });
+
+  const apyUpdateTimestampMs =
+    data?.apyLastUpdate != null ? data.apyLastUpdate * 1000 : undefined;
+
+  const isApyStale =
+    apyUpdateTimestampMs != null &&
+    Date.now() - apyUpdateTimestampMs >= APY_STALE_THRESHOLD_MS;
+
+  return {
+    apy: data?.apy,
+    apyUpdateTimestampMs,
+    isApyStale,
+    isLoading,
+  } as const;
+};

--- a/features/earn/shared/v2/apy-update-tooltip-text/apy-update-tooltip-text.tsx
+++ b/features/earn/shared/v2/apy-update-tooltip-text/apy-update-tooltip-text.tsx
@@ -1,0 +1,16 @@
+const formatApyUpdateDate = (timestampMs: number) =>
+  new Date(timestampMs).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
+export const ApyUpdateTooltipText = ({
+  timestampMs,
+}: {
+  timestampMs?: number;
+}) => {
+  if (!timestampMs) return null;
+
+  return <>Last updated on {formatApyUpdateDate(timestampMs)}</>;
+};

--- a/features/earn/shared/v2/apy-update-tooltip-text/index.ts
+++ b/features/earn/shared/v2/apy-update-tooltip-text/index.ts
@@ -1,0 +1,1 @@
+export * from './apy-update-tooltip-text';

--- a/features/earn/shared/v2/vault-card/styles.tsx
+++ b/features/earn/shared/v2/vault-card/styles.tsx
@@ -198,7 +198,10 @@ export const StatLabel = styled.span`
 `;
 
 export const StatValue = styled.span<{ $accent?: boolean; $muted?: boolean }>`
+  width: fit-content;
   display: inline-flex;
+  position: relative;
+  z-index: 20;
   align-items: center;
   gap: ${({ theme }) => theme.spaceMap.xs}px;
   font-size: ${({ theme }) => theme.fontSizesMap.lg}px;

--- a/features/earn/shared/v2/vault-card/vault-card.tsx
+++ b/features/earn/shared/v2/vault-card/vault-card.tsx
@@ -89,7 +89,7 @@ export const VaultCard: React.FC<VaultCardProps> = ({
   const isMobile = useBreakpoint('md');
 
   const shouldShowApxUpdateTooltip =
-    !stats.isLoading && !!stats.apxUpdateTooltipText;
+    !!stats.apx && !stats.isLoading && !!stats.apxUpdateTooltipText;
 
   const apxValue = (
     <StatValue $accent $muted={stats.isApxStale}>

--- a/features/earn/shared/v2/vault-card/vault-card.tsx
+++ b/features/earn/shared/v2/vault-card/vault-card.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from '@lidofinance/lido-ui';
+import { Button, useBreakpoint } from '@lidofinance/lido-ui';
 
 import {
   CardWrapper,
@@ -86,6 +86,19 @@ export const VaultCard: React.FC<VaultCardProps> = ({
 
   const depositHref = `${EARN_PATH}/${urlSlug}/${EARN_VAULT_DEPOSIT_SLUG}`;
 
+  const isMobile = useBreakpoint('md');
+
+  const shouldShowApxUpdateTooltip =
+    !stats.isLoading && !!stats.apxUpdateTooltipText;
+
+  const apxValue = (
+    <StatValue $accent $muted={stats.isApxStale}>
+      <InlineLoader isLoading={stats.isLoading} width={70}>
+        <FormatPercent value={stats.apx} decimals="percent" />
+      </InlineLoader>
+    </StatValue>
+  );
+
   return (
     <CardWrapper $variant={variant} data-testid={`${urlSlug}-vault-card`}>
       <CardOverlayLink
@@ -143,13 +156,16 @@ export const VaultCard: React.FC<VaultCardProps> = ({
               {stats.apxHint}
             </VaultTip>
           </StatLabel>
-          <StyledTooltip title={stats.apxUpdateTooltipText} placement="top">
-            <StatValue $accent $muted={stats.isApxStale}>
-              <InlineLoader isLoading={stats.isLoading} width={70}>
-                <FormatPercent value={stats.apx} decimals="percent" />
-              </InlineLoader>
-            </StatValue>
-          </StyledTooltip>
+          {shouldShowApxUpdateTooltip ? (
+            <StyledTooltip
+              title={stats.apxUpdateTooltipText}
+              placement={isMobile ? 'topRight' : 'topLeft'}
+            >
+              {apxValue}
+            </StyledTooltip>
+          ) : (
+            apxValue
+          )}
         </StatItem>
         <StatItem data-testid="tvl">
           <StatLabel>TVL</StatLabel>

--- a/features/earn/shared/v2/vault-card/vault-card.tsx
+++ b/features/earn/shared/v2/vault-card/vault-card.tsx
@@ -40,6 +40,8 @@ type VaultStats = {
   apxLabel: string;
   isLoading?: boolean;
   apxHint?: React.ReactNode;
+  apxUpdateTooltipText?: React.ReactNode;
+  isApxStale?: boolean;
   compact?: boolean;
 };
 
@@ -141,11 +143,13 @@ export const VaultCard: React.FC<VaultCardProps> = ({
               {stats.apxHint}
             </VaultTip>
           </StatLabel>
-          <StatValue $accent>
-            <InlineLoader isLoading={stats.isLoading} width={70}>
-              <FormatPercent value={stats.apx} decimals="percent" />
-            </InlineLoader>
-          </StatValue>
+          <StyledTooltip title={stats.apxUpdateTooltipText} placement="top">
+            <StatValue $accent $muted={stats.isApxStale}>
+              <InlineLoader isLoading={stats.isLoading} width={70}>
+                <FormatPercent value={stats.apx} decimals="percent" />
+              </InlineLoader>
+            </StatValue>
+          </StyledTooltip>
         </StatItem>
         <StatItem data-testid="tvl">
           <StatLabel>TVL</StatLabel>

--- a/features/earn/shared/v2/vault-page/content/styles.tsx
+++ b/features/earn/shared/v2/vault-page/content/styles.tsx
@@ -115,12 +115,24 @@ export const TopSectionStatSubValue = styled.span`
   line-height: 24px;
 `;
 
-export const TopSectionStatValue = styled.span<{ $accent?: boolean }>`
+export const TopSectionStatValueTooltipTarget = styled.span`
+  width: fit-content;
+  display: inline-flex;
+`;
+
+export const TopSectionStatValue = styled.span<{
+  $accent?: boolean;
+  $muted?: boolean;
+}>`
   font-weight: 700;
   font-size: ${({ theme }) => theme.fontSizesMap.lg}px;
   line-height: 28px;
-  color: ${({ $accent }) =>
-    $accent ? 'var(--lido-color-success)' : 'var(--lido-color-text)'};
+  color: ${({ $accent, $muted }) =>
+    $muted
+      ? 'var(--lido-color-textSecondary)'
+      : $accent
+        ? 'var(--lido-color-success)'
+        : 'var(--lido-color-text)'};
 
   ${({ theme }) => theme.mediaQueries.md} {
     font-size: ${({ theme }) => theme.fontSizesMap.xs}px;

--- a/features/earn/shared/v2/vault-page/content/top-section.tsx
+++ b/features/earn/shared/v2/vault-page/content/top-section.tsx
@@ -69,7 +69,8 @@ export const TopSection: FC<TopSectionProps> = (props) => {
     balance,
   } = props;
   const isMobile = useBreakpoint('md');
-  const shouldShowApxUpdateTooltip = !isApxLoading && !!apxUpdateTooltipText;
+  const shouldShowApxUpdateTooltip =
+    !!apx && !isApxLoading && !!apxUpdateTooltipText;
 
   const apxValue = (
     <TopSectionStatValueTooltipTarget>

--- a/features/earn/shared/v2/vault-page/content/top-section.tsx
+++ b/features/earn/shared/v2/vault-page/content/top-section.tsx
@@ -1,5 +1,5 @@
 import type { ComponentType, FC, SVGProps } from 'react';
-import { Tooltip } from '@lidofinance/lido-ui';
+import { Tooltip, useBreakpoint } from '@lidofinance/lido-ui';
 
 import {
   FormatLargeAmount,
@@ -68,6 +68,18 @@ export const TopSection: FC<TopSectionProps> = (props) => {
     protectedBadgeTooltipText,
     balance,
   } = props;
+  const isMobile = useBreakpoint('md');
+  const shouldShowApxUpdateTooltip = !isApxLoading && !!apxUpdateTooltipText;
+
+  const apxValue = (
+    <TopSectionStatValueTooltipTarget>
+      <TopSectionStatValue $accent $muted={isApxStale}>
+        <InlineLoader isLoading={isApxLoading} width={70}>
+          <FormatPercent value={apx} decimals="percent" />
+        </InlineLoader>
+      </TopSectionStatValue>
+    </TopSectionStatValueTooltipTarget>
+  );
 
   return (
     <TopSectionStyled>
@@ -89,15 +101,16 @@ export const TopSection: FC<TopSectionProps> = (props) => {
             APY* (7d avg.)
             <VaultTip placement="bottomLeft">{apxHint}</VaultTip>
           </TopSectionStatLabel>
-          <Tooltip title={apxUpdateTooltipText} placement="top">
-            <TopSectionStatValueTooltipTarget>
-              <TopSectionStatValue $accent $muted={isApxStale}>
-                <InlineLoader isLoading={isApxLoading} width={70}>
-                  <FormatPercent value={apx} decimals="percent" />
-                </InlineLoader>
-              </TopSectionStatValue>
-            </TopSectionStatValueTooltipTarget>
-          </Tooltip>
+          {shouldShowApxUpdateTooltip ? (
+            <Tooltip
+              title={apxUpdateTooltipText}
+              placement={isMobile ? 'topRight' : 'topLeft'}
+            >
+              {apxValue}
+            </Tooltip>
+          ) : (
+            apxValue
+          )}
         </TopSectionStatItem>
         <TopSectionStatItem>
           <TopSectionStatLabel>TVL</TopSectionStatLabel>

--- a/features/earn/shared/v2/vault-page/content/top-section.tsx
+++ b/features/earn/shared/v2/vault-page/content/top-section.tsx
@@ -1,4 +1,5 @@
 import type { ComponentType, FC, SVGProps } from 'react';
+import { Tooltip } from '@lidofinance/lido-ui';
 
 import {
   FormatLargeAmount,
@@ -23,6 +24,7 @@ import {
   TopSectionStatLabel,
   TopSectionStatSubValue,
   TopSectionStatValue,
+  TopSectionStatValueTooltipTarget,
   TopSectionStatValueGroup,
 } from './styles';
 
@@ -44,6 +46,8 @@ type TopSectionProps = {
   apx?: number | null;
   tvlUsd?: number | null;
   apxHint?: React.ReactNode;
+  apxUpdateTooltipText?: React.ReactNode;
+  isApxStale?: boolean;
   isApxLoading?: boolean;
   isTvlLoading?: boolean;
   protectedBadgeTooltipText?: React.ReactNode;
@@ -57,6 +61,8 @@ export const TopSection: FC<TopSectionProps> = (props) => {
     apx,
     tvlUsd,
     apxHint,
+    apxUpdateTooltipText,
+    isApxStale,
     isApxLoading,
     isTvlLoading,
     protectedBadgeTooltipText,
@@ -83,11 +89,15 @@ export const TopSection: FC<TopSectionProps> = (props) => {
             APY* (7d avg.)
             <VaultTip placement="bottomLeft">{apxHint}</VaultTip>
           </TopSectionStatLabel>
-          <TopSectionStatValue $accent>
-            <InlineLoader isLoading={isApxLoading} width={70}>
-              <FormatPercent value={apx} decimals="percent" />
-            </InlineLoader>
-          </TopSectionStatValue>
+          <Tooltip title={apxUpdateTooltipText} placement="top">
+            <TopSectionStatValueTooltipTarget>
+              <TopSectionStatValue $accent $muted={isApxStale}>
+                <InlineLoader isLoading={isApxLoading} width={70}>
+                  <FormatPercent value={apx} decimals="percent" />
+                </InlineLoader>
+              </TopSectionStatValue>
+            </TopSectionStatValueTooltipTarget>
+          </Tooltip>
         </TopSectionStatItem>
         <TopSectionStatItem>
           <TopSectionStatLabel>TVL</TopSectionStatLabel>

--- a/features/earn/shared/v2/vault-page/vault-page.tsx
+++ b/features/earn/shared/v2/vault-page/vault-page.tsx
@@ -51,6 +51,8 @@ type Props = {
   description: string;
   apx?: number | null;
   apxHint?: React.ReactNode;
+  apxUpdateTooltipText?: React.ReactNode;
+  isApxStale?: boolean;
   isApxLoading?: boolean;
   tvlUsd?: number | null;
   isTvlLoading?: boolean;
@@ -130,6 +132,8 @@ export const VaultPage: FC<Props> = (props) => {
           apx={props.apx}
           tvlUsd={props.tvlUsd}
           apxHint={props.apxHint}
+          apxUpdateTooltipText={props.apxUpdateTooltipText}
+          isApxStale={props.isApxStale}
           isApxLoading={props.isApxLoading}
           isTvlLoading={props.isTvlLoading}
           protectedBadgeTooltipText={protectedBadgeTooltipText}

--- a/features/earn/vault-eth/hooks/use-vault-apy.ts
+++ b/features/earn/vault-eth/hooks/use-vault-apy.ts
@@ -1,26 +1,10 @@
-import { useQuery } from '@tanstack/react-query';
+import { useVaultApy } from 'features/earn/shared/hooks/use-vault-apy';
 import { ETH_VAULT_QUERY_SCOPE } from '../consts';
 import { fetchEthVaultStatsApr } from '../utils';
 
-const APY_STALE_THRESHOLD_MS = 2 * 24 * 60 * 60 * 1000; // 2 days
-
 export const useEthVaultApy = () => {
-  const { data, isLoading } = useQuery({
-    queryKey: [ETH_VAULT_QUERY_SCOPE, 'apy'],
+  return useVaultApy({
+    queryScope: ETH_VAULT_QUERY_SCOPE,
     queryFn: fetchEthVaultStatsApr,
   });
-
-  const apyUpdateTimestampMs =
-    data?.apyLastUpdate != null ? data.apyLastUpdate * 1000 : undefined;
-
-  const isApyStale =
-    apyUpdateTimestampMs != null &&
-    Date.now() - apyUpdateTimestampMs >= APY_STALE_THRESHOLD_MS;
-
-  return {
-    apy: data?.apy,
-    apyUpdateTimestampMs,
-    isApyStale,
-    isLoading,
-  } as const;
 };

--- a/features/earn/vault-eth/hooks/use-vault-apy.ts
+++ b/features/earn/vault-eth/hooks/use-vault-apy.ts
@@ -2,11 +2,25 @@ import { useQuery } from '@tanstack/react-query';
 import { ETH_VAULT_QUERY_SCOPE } from '../consts';
 import { fetchEthVaultStatsApr } from '../utils';
 
+const APY_STALE_THRESHOLD_MS = 2 * 24 * 60 * 60 * 1000; // 2 days
+
 export const useEthVaultApy = () => {
   const { data, isLoading } = useQuery({
     queryKey: [ETH_VAULT_QUERY_SCOPE, 'apy'],
     queryFn: fetchEthVaultStatsApr,
   });
 
-  return { apy: data, isLoading } as const;
+  const apyUpdateTimestampMs =
+    data?.apyLastUpdate != null ? data.apyLastUpdate * 1000 : undefined;
+
+  const isApyStale =
+    apyUpdateTimestampMs != null &&
+    Date.now() - apyUpdateTimestampMs >= APY_STALE_THRESHOLD_MS;
+
+  return {
+    apy: data?.apy,
+    apyUpdateTimestampMs,
+    isApyStale,
+    isLoading,
+  } as const;
 };

--- a/features/earn/vault-eth/utils.ts
+++ b/features/earn/vault-eth/utils.ts
@@ -34,6 +34,7 @@ export type EthVaultStatsFetchedData = z.infer<typeof ETH_VAULT_STATS_SCHEMA>;
 
 export const ETH_VAULT_APY_SCHEMA = z.object({
   apy: APY_SCHEMA,
+  apyLastUpdate: UNIX_TIMESTAMP_SCHEMA,
 });
 export type EthVaultApyFetchedData = z.infer<typeof ETH_VAULT_APY_SCHEMA>;
 
@@ -52,8 +53,8 @@ export const fetchEthVaultStatsApr = async () => {
   const ETH_APY_ENDPOINT = `${ETH_VAULT_STATS_ORIGIN}/v1/chain/${CHAINS.Mainnet}/core-vaults/${ethVaultAddress}/apy`;
 
   const data = await standardFetcher<EthVaultApyFetchedData>(ETH_APY_ENDPOINT);
-  const apy = ETH_VAULT_APY_SCHEMA.parse(data).apy;
-  return apy;
+  const { apy, apyLastUpdate } = ETH_VAULT_APY_SCHEMA.parse(data);
+  return { apy, apyLastUpdate };
 };
 
 // Converts a case sensitive TokenSymbol to an EthDepositToken which must be lowercase.

--- a/features/earn/vault-eth/vault-card.tsx
+++ b/features/earn/vault-eth/vault-card.tsx
@@ -8,6 +8,7 @@ import { EARN_VAULT_ETH_SLUG } from '../consts';
 import { useEthVaultStats } from './hooks/use-vault-stats';
 import { useEthVaultApy } from './hooks/use-vault-apy';
 import { EthVaultApyHint } from './components/apy-hint';
+import { ApyUpdateTooltipText } from '../shared/v2/apy-update-tooltip-text';
 import {
   ETH_VAULT_DESCRIPTION,
   ETH_VAULT_TITLE,
@@ -19,7 +20,12 @@ import { useEthVaultAvailable } from './hooks/use-vault-available';
 import { ProtectedTooltip } from './protected-tooltip';
 
 export const EthVaultCard = () => {
-  const { apy, isLoading: isApyLoading } = useEthVaultApy();
+  const {
+    apy,
+    apyUpdateTimestampMs,
+    isApyStale,
+    isLoading: isApyLoading,
+  } = useEthVaultApy();
   const { tvlUsd, isLoading: isTvlLoading } = useEthVaultStats();
   const { listWarningText } = useEthVaultAvailable();
 
@@ -41,6 +47,10 @@ export const EthVaultCard = () => {
         apx: apy,
         apxLabel: 'APY* (7d avg.)',
         apxHint: <EthVaultApyHint />,
+        apxUpdateTooltipText: (
+          <ApyUpdateTooltipText timestampMs={apyUpdateTimestampMs} />
+        ),
+        isApxStale: isApyStale,
         isLoading: isApyLoading || isTvlLoading,
       }}
       position={{

--- a/features/earn/vault-eth/vault-page.tsx
+++ b/features/earn/vault-eth/vault-page.tsx
@@ -17,6 +17,7 @@ import { useEthVaultApy } from './hooks/use-vault-apy';
 import { useEthVaultPosition } from './hooks/use-position';
 import { EARN_VAULT_DEPOSIT_SLUG, EARN_VAULT_WITHDRAW_SLUG } from '../consts';
 import { EthVaultApyHint } from './components/apy-hint';
+import { ApyUpdateTooltipText } from '../shared/v2/apy-update-tooltip-text';
 import {
   ETH_VAULT_DESCRIPTION,
   ETH_VAULT_TITLE,
@@ -163,7 +164,12 @@ const DATA = {
 export const EthVaultPage: FC<{
   action: typeof EARN_VAULT_DEPOSIT_SLUG | typeof EARN_VAULT_WITHDRAW_SLUG;
 }> = ({ action }) => {
-  const { apy, isLoading: isApyLoading } = useEthVaultApy();
+  const {
+    apy,
+    apyUpdateTimestampMs,
+    isApyStale,
+    isLoading: isApyLoading,
+  } = useEthVaultApy();
   const { tvlUsd, isLoading: isTvlLoading } = useEthVaultStats();
   const {
     data: earnethPositionData,
@@ -183,6 +189,10 @@ export const EthVaultPage: FC<{
         isApxLoading={isApyLoading}
         isTvlLoading={isTvlLoading}
         apxHint={<EthVaultApyHint />}
+        apxUpdateTooltipText={
+          <ApyUpdateTooltipText timestampMs={apyUpdateTimestampMs} />
+        }
+        isApxStale={isApyStale}
         sidePanel={<EthVaultPositionManager action={action} />}
         vaultName="ethVault"
         balance={

--- a/features/earn/vault-usd/hooks/use-vault-apy.ts
+++ b/features/earn/vault-usd/hooks/use-vault-apy.ts
@@ -1,26 +1,10 @@
-import { useQuery } from '@tanstack/react-query';
+import { useVaultApy } from 'features/earn/shared/hooks/use-vault-apy';
 import { USD_VAULT_QUERY_SCOPE } from '../consts';
 import { fetchUsdVaultStatsApr } from '../utils';
 
-const APY_STALE_THRESHOLD_MS = 2 * 24 * 60 * 60 * 1000; // 2 days
-
 export const useUsdVaultApy = () => {
-  const { data, isLoading } = useQuery({
-    queryKey: [USD_VAULT_QUERY_SCOPE, 'apy'],
+  return useVaultApy({
+    queryScope: USD_VAULT_QUERY_SCOPE,
     queryFn: fetchUsdVaultStatsApr,
   });
-
-  const apyUpdateTimestampMs =
-    data?.apyLastUpdate != null ? data.apyLastUpdate * 1000 : undefined;
-
-  const isApyStale =
-    apyUpdateTimestampMs != null &&
-    Date.now() - apyUpdateTimestampMs >= APY_STALE_THRESHOLD_MS;
-
-  return {
-    apy: data?.apy,
-    apyUpdateTimestampMs,
-    isApyStale,
-    isLoading,
-  } as const;
 };

--- a/features/earn/vault-usd/hooks/use-vault-apy.ts
+++ b/features/earn/vault-usd/hooks/use-vault-apy.ts
@@ -2,11 +2,25 @@ import { useQuery } from '@tanstack/react-query';
 import { USD_VAULT_QUERY_SCOPE } from '../consts';
 import { fetchUsdVaultStatsApr } from '../utils';
 
+const APY_STALE_THRESHOLD_MS = 2 * 24 * 60 * 60 * 1000; // 2 days
+
 export const useUsdVaultApy = () => {
   const { data, isLoading } = useQuery({
     queryKey: [USD_VAULT_QUERY_SCOPE, 'apy'],
     queryFn: fetchUsdVaultStatsApr,
   });
 
-  return { apy: data, isLoading } as const;
+  const apyUpdateTimestampMs =
+    data?.apyLastUpdate != null ? data.apyLastUpdate * 1000 : undefined;
+
+  const isApyStale =
+    apyUpdateTimestampMs != null &&
+    Date.now() - apyUpdateTimestampMs >= APY_STALE_THRESHOLD_MS;
+
+  return {
+    apy: data?.apy,
+    apyUpdateTimestampMs,
+    isApyStale,
+    isLoading,
+  } as const;
 };

--- a/features/earn/vault-usd/utils.ts
+++ b/features/earn/vault-usd/utils.ts
@@ -30,6 +30,7 @@ export type UsdVaultStatsFetchedData = z.infer<typeof USD_VAULT_STATS_SCHEMA>;
 
 export const USD_VAULT_APY_SCHEMA = z.object({
   apy: APY_SCHEMA,
+  apyLastUpdate: UNIX_TIMESTAMP_SCHEMA,
 });
 export type UsdVaultApyFetchedData = z.infer<typeof USD_VAULT_APY_SCHEMA>;
 
@@ -48,8 +49,8 @@ export const fetchUsdVaultStatsApr = async () => {
   const USD_APY_ENDPOINT = `${USD_VAULT_STATS_ORIGIN}/v1/chain/${CHAINS.Mainnet}/core-vaults/${usdVaultAddress}/apy`;
 
   const data = await standardFetcher<UsdVaultApyFetchedData>(USD_APY_ENDPOINT);
-  const apy = USD_VAULT_APY_SCHEMA.parse(data).apy;
-  return apy;
+  const { apy, apyLastUpdate } = USD_VAULT_APY_SCHEMA.parse(data);
+  return { apy, apyLastUpdate };
 };
 
 // Converts a case sensitive TokenSymbol to an UsdDepositToken which must be lowercase.

--- a/features/earn/vault-usd/vault-card.tsx
+++ b/features/earn/vault-usd/vault-card.tsx
@@ -8,6 +8,7 @@ import { VaultListWarning } from '../shared/v2/vault-warning';
 import { useUsdVaultApy } from './hooks/use-vault-apy';
 import { useUsdVaultStats } from './hooks/use-vault-stats';
 import { UsdVaultApyHint } from './components/apy-hint';
+import { ApyUpdateTooltipText } from '../shared/v2/apy-update-tooltip-text';
 import {
   USD_VAULT_DESCRIPTION,
   USD_VAULT_TITLE,
@@ -19,7 +20,12 @@ import { ProtectedTooltip } from './protected-tooltip';
 import { useUsdVaultAvailable } from './hooks/use-vault-available';
 
 export const UsdVaultCard = () => {
-  const { apy, isLoading: isApyLoading } = useUsdVaultApy();
+  const {
+    apy,
+    apyUpdateTimestampMs,
+    isApyStale,
+    isLoading: isApyLoading,
+  } = useUsdVaultApy();
   const { tvlUsd, isLoading: isTvlLoading } = useUsdVaultStats();
   const {
     data: usdPositionData,
@@ -40,6 +46,10 @@ export const UsdVaultCard = () => {
         apx: apy,
         apxLabel: 'APY* (7d avg.)',
         apxHint: <UsdVaultApyHint />,
+        apxUpdateTooltipText: (
+          <ApyUpdateTooltipText timestampMs={apyUpdateTimestampMs} />
+        ),
+        isApxStale: isApyStale,
         isLoading: isApyLoading || isTvlLoading,
       }}
       position={{

--- a/features/earn/vault-usd/vault-page.tsx
+++ b/features/earn/vault-usd/vault-page.tsx
@@ -17,6 +17,7 @@ import { useUsdVaultApy } from './hooks/use-vault-apy';
 import { useUsdVaultPosition } from './hooks/use-position';
 import { Disclaimers } from '../shared/v2/disclaimers';
 import { UsdVaultApyHint } from './components/apy-hint';
+import { ApyUpdateTooltipText } from '../shared/v2/apy-update-tooltip-text';
 import {
   USD_VAULT_DESCRIPTION,
   USD_VAULT_TITLE,
@@ -163,7 +164,12 @@ const DATA = {
 export const VaultPageUSD: FC<{
   action: typeof EARN_VAULT_DEPOSIT_SLUG | typeof EARN_VAULT_WITHDRAW_SLUG;
 }> = ({ action }) => {
-  const { apy, isLoading: isApyLoading } = useUsdVaultApy();
+  const {
+    apy,
+    apyUpdateTimestampMs,
+    isApyStale,
+    isLoading: isApyLoading,
+  } = useUsdVaultApy();
   const { tvlUsd, isLoading: isTvlLoading } = useUsdVaultStats();
   const {
     data: earnusdPositionData,
@@ -182,6 +188,10 @@ export const VaultPageUSD: FC<{
         isApxLoading={isApyLoading}
         isTvlLoading={isTvlLoading}
         apxHint={<UsdVaultApyHint />}
+        apxUpdateTooltipText={
+          <ApyUpdateTooltipText timestampMs={apyUpdateTimestampMs} />
+        }
+        isApxStale={isApyStale}
         sidePanel={<UsdVaultPositionManager action={action} />}
         vaultName="usdVault"
         balance={


### PR DESCRIPTION
### Description

Introduces a tooltip on APY values displaying the last update timestamp. Mutes APY text if the data is older than 2 days.

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
