### PR TITLE
EarnETH – Update "how it works" drawer

### DIFF
--- a/features/earn/shared/drawer-right/drawer-right.tsx
+++ b/features/earn/shared/drawer-right/drawer-right.tsx
@@ -23,9 +23,14 @@ import { DrawerTable } from './drawer-table';
 type DrawerRightProps = {
   onClose: () => void;
   isOpen: boolean;
+  shouldHideUpgradeNowButton?: boolean;
 };
 
-export const DrawerRight: FC<DrawerRightProps> = ({ onClose, isOpen }) => {
+export const DrawerRight: FC<DrawerRightProps> = ({
+  onClose,
+  isOpen,
+  shouldHideUpgradeNowButton = false,
+}) => {
   const { handleKeyDown } = useEscape({ onClose });
 
   return (
@@ -94,19 +99,21 @@ export const DrawerRight: FC<DrawerRightProps> = ({ onClose, isOpen }) => {
             .
           </DrawerRightText>
           <DrawerRightFooter>
-            <LocalLink href={ETH_DEPOSIT_PATH}>
-              <Button
-                fullwidth
-                onClick={() => {
-                  trackMatomoEvent(
-                    MATOMO_EARN_EVENTS_TYPES.earnListWhatIsLidoEarnEthUpgradeNow,
-                  );
-                }}
-                data-testid={'upgradeNowButton'}
-              >
-                Upgrade now
-              </Button>
-            </LocalLink>
+            {!shouldHideUpgradeNowButton && (
+              <LocalLink href={ETH_DEPOSIT_PATH}>
+                <Button
+                  fullwidth
+                  onClick={() => {
+                    trackMatomoEvent(
+                      MATOMO_EARN_EVENTS_TYPES.earnListWhatIsLidoEarnEthUpgradeNow,
+                    );
+                  }}
+                  data-testid={'upgradeNowButton'}
+                >
+                  Upgrade now
+                </Button>
+              </LocalLink>
+            )}
             <Link href={`${config.helpOrigin}/en`} target="_blank">
               <Button
                 fullwidth

--- a/features/earn/shared/drawer-right/drawer-right.tsx
+++ b/features/earn/shared/drawer-right/drawer-right.tsx
@@ -29,8 +29,13 @@ export const DrawerRight: FC<DrawerRightProps> = ({ onClose, isOpen }) => {
   const { handleKeyDown } = useEscape({ onClose });
 
   return (
-    <DrawerRightStyled onKeyDown={handleKeyDown} tabIndex={-1} isOpen={isOpen}>
-      <DrawerRightWrapper>
+    <DrawerRightStyled
+      onKeyDown={handleKeyDown}
+      onClick={onClose}
+      tabIndex={-1}
+      isOpen={isOpen}
+    >
+      <DrawerRightWrapper isOpen={isOpen} onClick={(e) => e.stopPropagation()}>
         <DrawerRightContent data-testid={'earn-side-panel'}>
           <DrawerRightHeader>
             <div data-testid={'title'}>

--- a/features/earn/shared/drawer-right/drawer-right.tsx
+++ b/features/earn/shared/drawer-right/drawer-right.tsx
@@ -62,8 +62,8 @@ export const DrawerRight: FC<DrawerRightProps> = ({ onClose, isOpen }) => {
             and protocol parameters.
           </DrawerRightText>
           <DrawerRightText data-testid={'mellow-points-text'}>
-            All Mellow points you accumulate remain yours, with your balance
-            visible on the{' '}
+            All accumulated Mellow points, as well as Obol and SSV rewards,
+            remain yours. Your Mellow points balance is visible on the{' '}
             <Link
               href="https://app.mellow.finance/dashboard"
               target="_blank"
@@ -75,6 +75,18 @@ export const DrawerRight: FC<DrawerRightProps> = ({ onClose, isOpen }) => {
             >
               Mellow Dashboard
             </Link>
+            . Obol rewards can be claimed{' '}
+            <Link
+              href="https://launchpad.obol.org/cluster/list/"
+              target="_blank"
+            >
+              here
+            </Link>
+            , and SSV rewards can be claimed{' '}
+            <Link href="https://www.ssvrewards.com/" target="_blank">
+              here
+            </Link>
+            .
           </DrawerRightText>
           <DrawerRightFooter>
             <LocalLink href={ETH_DEPOSIT_PATH}>

--- a/features/earn/shared/drawer-right/drawer-right.tsx
+++ b/features/earn/shared/drawer-right/drawer-right.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
 import { Close, Button, Link } from '@lidofinance/lido-ui';
 
 import { config } from 'config';
@@ -32,6 +32,19 @@ export const DrawerRight: FC<DrawerRightProps> = ({
   shouldHideUpgradeNowButton = false,
 }) => {
   const { handleKeyDown } = useEscape({ onClose });
+
+  // Prevent the page behind the drawer from scrolling while the drawer is open.
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const { body } = document;
+    const previousOverflow = body.style.overflow;
+    body.style.overflow = 'hidden';
+
+    return () => {
+      body.style.overflow = previousOverflow;
+    };
+  }, [isOpen]);
 
   return (
     <DrawerRightStyled

--- a/features/earn/shared/drawer-right/styles.ts
+++ b/features/earn/shared/drawer-right/styles.ts
@@ -4,27 +4,19 @@ import { ButtonIcon } from '@lidofinance/lido-ui';
 export const DrawerRightStyled = styled.div<{ isOpen: boolean }>`
   position: fixed;
   top: 0;
-  right: ${({ isOpen }) => (isOpen ? '0' : '-600px')};
+  right: 0;
   bottom: 0;
+  left: 0;
   z-index: 300;
-  box-shadow: -2px 0 2px 0 var(--lido-color-shadowLight);
-  width: 600px;
   outline: none;
-  transition: right 0.15s ease-out;
-  display: flex;
-  flex-direction: column;
+  background-color: ${({ isOpen }) =>
+    isOpen ? 'rgba(0, 0, 0, 0.5)' : 'rgba(0, 0, 0, 0)'};
+  pointer-events: ${({ isOpen }) => (isOpen ? 'auto' : 'none')};
+  transition: background-color 0.15s ease-out;
 
   @media (max-width: 600px) {
-    top: ${({ isOpen }) => (isOpen ? '0' : '100%')};
-    left: 0;
-    right: auto;
-    width: 100%;
     background-color: ${({ isOpen }) =>
-      isOpen ? 'rgba(0, 0, 0, 0.7)' : 'transparent'};
-    transition:
-      top 0.15s ease-out,
-      background-color
-        ${({ isOpen }) => (isOpen ? '0.15s ease-out 0.15s' : '0s')};
+      isOpen ? 'rgba(0, 0, 0, 0.5)' : 'rgba(0, 0, 0, 0)'};
   }
 `;
 
@@ -33,10 +25,21 @@ export const DrawerRightClose = styled(ButtonIcon)`
   color: var(--lido-color-textSecondary);
 `;
 
-export const DrawerRightWrapper = styled.div`
-  flex-grow: 1;
-  position: relative;
-  z-index: 1;
+export const DrawerRightWrapper = styled.div<{ isOpen: boolean }>`
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 600px;
+  box-shadow: -2px 0 2px 0 var(--lido-color-shadowLight);
+  transform: translateX(${({ isOpen }) => (isOpen ? '0' : '100%')});
+  transition: transform 0.15s ease-out;
+
+  @media (max-width: 600px) {
+    left: 0;
+    width: 100%;
+    transform: translateY(${({ isOpen }) => (isOpen ? '0' : '100%')});
+  }
 `;
 
 export const DrawerRightContent = styled.div`

--- a/features/earn/vault-eth/deposit/deposit-form.tsx
+++ b/features/earn/vault-eth/deposit/deposit-form.tsx
@@ -1,3 +1,5 @@
+import type { FC } from 'react';
+
 import { VaultFormSection } from 'features/earn/shared/vault-form-section';
 import { VaultForm } from 'features/earn/shared/vault-form';
 import { VaultTxInfo } from 'features/earn/shared/vault-tx-info';
@@ -14,7 +16,7 @@ import { ActionSwitch } from '../components/action-switch';
 import { UpgradeAssetsBlock } from '../upgrade-assets/upgrade-assets';
 import { useEthVaultAvailable } from '../hooks/use-vault-available';
 
-export const EthVaultDepositForm = () => {
+export const EthVaultDepositForm: FC = () => {
   const { isEthVaultAvailable, isDepositEnabled, depositPauseReasonText } =
     useEthVaultAvailable();
 

--- a/features/earn/vault-eth/drawer-context.tsx
+++ b/features/earn/vault-eth/drawer-context.tsx
@@ -1,0 +1,49 @@
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+  type FC,
+  type PropsWithChildren,
+} from 'react';
+
+type EthVaultDrawerContextValue = {
+  isDrawerOpen: boolean;
+  openDrawer: () => void;
+  closeDrawer: () => void;
+};
+
+const EthVaultDrawerContext = createContext<EthVaultDrawerContextValue | null>(
+  null,
+);
+
+export const useEthVaultDrawer = () => {
+  const context = useContext(EthVaultDrawerContext);
+
+  if (!context) {
+    throw new Error(
+      '[useEthVaultDrawer] EthVaultDrawerContext is used outside provider',
+    );
+  }
+
+  return context;
+};
+
+export const EthVaultDrawerProvider: FC<PropsWithChildren> = ({ children }) => {
+  const [isDrawerOpen, setIsDrawerRight] = useState(false);
+
+  const value = useMemo(
+    () => ({
+      isDrawerOpen,
+      openDrawer: () => setIsDrawerRight(true),
+      closeDrawer: () => setIsDrawerRight(false),
+    }),
+    [isDrawerOpen],
+  );
+
+  return (
+    <EthVaultDrawerContext.Provider value={value}>
+      {children}
+    </EthVaultDrawerContext.Provider>
+  );
+};

--- a/features/earn/vault-eth/drawer-context.tsx
+++ b/features/earn/vault-eth/drawer-context.tsx
@@ -9,8 +9,13 @@ import {
 
 type EthVaultDrawerContextValue = {
   isDrawerOpen: boolean;
-  openDrawer: () => void;
+  shouldHideUpgradeNowButton: boolean;
+  openDrawer: (options?: { hideUpgradeNowButton?: boolean }) => void;
   closeDrawer: () => void;
+};
+
+type OpenDrawerOptions = {
+  hideUpgradeNowButton?: boolean;
 };
 
 const EthVaultDrawerContext = createContext<EthVaultDrawerContextValue | null>(
@@ -31,14 +36,22 @@ export const useEthVaultDrawer = () => {
 
 export const EthVaultDrawerProvider: FC<PropsWithChildren> = ({ children }) => {
   const [isDrawerOpen, setIsDrawerRight] = useState(false);
+  const [shouldHideUpgradeNowButton, setShouldHideUpgradeNowButton] =
+    useState(false);
 
   const value = useMemo(
     () => ({
       isDrawerOpen,
-      openDrawer: () => setIsDrawerRight(true),
-      closeDrawer: () => setIsDrawerRight(false),
+      shouldHideUpgradeNowButton,
+      openDrawer: (options?: OpenDrawerOptions) => {
+        setShouldHideUpgradeNowButton(options?.hideUpgradeNowButton ?? false);
+        setIsDrawerRight(true);
+      },
+      closeDrawer: () => {
+        setIsDrawerRight(false);
+      },
     }),
-    [isDrawerOpen],
+    [isDrawerOpen, shouldHideUpgradeNowButton],
   );
 
   return (

--- a/features/earn/vault-eth/faq/list/how-does-deposit-work.tsx
+++ b/features/earn/vault-eth/faq/list/how-does-deposit-work.tsx
@@ -8,7 +8,7 @@ export const HowDoesDepositWork: FC<{ id?: string }> = ({ id }) => {
         <p>
           You can deposit ETH, WETH, stETH, or wstETH and, through the upgrade
           flow, also migrate GG, strETH, or DVstETH to receive earnETH share
-          tokens from the EarnETH vault. Once you deposit, earnUSD is issued
+          tokens from the EarnETH vault. Once you deposit, earnETH is issued
           directly to your wallet, with no pending state or separate claim step
           required.
         </p>

--- a/features/earn/vault-eth/upgrade-assets/styles.tsx
+++ b/features/earn/vault-eth/upgrade-assets/styles.tsx
@@ -1,3 +1,4 @@
+import { ButtonInline } from 'shared/components/button-inline/button-inline';
 import styled, { css } from 'styled-components';
 import { Block, Button } from '@lidofinance/lido-ui';
 
@@ -22,10 +23,22 @@ export const UpgradeAssets = styled(Block)`
   color: var(--lido-color-text);
 `;
 
+export const UpgradeAssetsHeader = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: ${({ theme }) => theme.spaceMap.md}px;
+  margin: 0 0 ${({ theme }) => theme.spaceMap.sm}px;
+`;
+
 export const UpgradeAssetsTitle = styled.div`
   font-size: ${({ theme }) => theme.fontSizesMap.xs}px;
   font-weight: 700;
-  margin: 0 0 ${({ theme }) => theme.spaceMap.sm}px;
+  margin: 0;
+`;
+
+export const UpgradeAssetsHowItWorksButton = styled(ButtonInline)`
+  font-weight: 700;
 `;
 
 export const UpgradeAssetsAmount = styled.div`

--- a/features/earn/vault-eth/upgrade-assets/upgrade-assets.tsx
+++ b/features/earn/vault-eth/upgrade-assets/upgrade-assets.tsx
@@ -132,7 +132,7 @@ export const UpgradeAssetsBlock: FC = () => {
           }}
           data-testid={'howItWorksButton'}
         >
-          How it works?
+          How it works
         </UpgradeAssetsHowItWorksButton>
       </UpgradeAssetsHeader>
       {tokensWithBalance.map((token) => (

--- a/features/earn/vault-eth/upgrade-assets/upgrade-assets.tsx
+++ b/features/earn/vault-eth/upgrade-assets/upgrade-assets.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { type FC, useCallback, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useDappStatus } from 'modules/web3';
 import { TOKENS, TOKEN_SYMBOLS } from 'consts/tokens';
@@ -12,7 +12,9 @@ import { useReferralQueryValue } from 'shared/hooks/use-query-values-form';
 
 import {
   UpgradeAssets,
+  UpgradeAssetsHeader,
   UpgradeAssetsTitle,
+  UpgradeAssetsHowItWorksButton,
   UpgradeAssetsRow,
   UpgradeAssetsAmount,
   UpgradeAssetsButton,
@@ -23,6 +25,7 @@ import {
   ETH_VAULT_DEPOSIT_TOKENS_UPGRADABLE,
   ETH_VAULT_QUERY_SCOPE,
 } from '../consts';
+import { useEthVaultDrawer } from '../drawer-context';
 import { useEthVaultDeposit } from '../deposit/hooks';
 import { EthDepositTokenUpgradable } from '../types';
 
@@ -49,12 +52,13 @@ type UpgradeArgs = {
   token: EthDepositTokenUpgradable;
 };
 
-export const UpgradeAssetsBlock = () => {
+export const UpgradeAssetsBlock: FC = () => {
   const { isWalletConnected } = useDappStatus();
   const queryClient = useQueryClient();
   const { balances, refetchBalances } = useUpgradableTokenBalances();
   const [isUpgrading, setIsUpgrading] = useState(false);
   const referral = useReferralQueryValue();
+  const { openDrawer: openDrawerRight } = useEthVaultDrawer();
 
   const { deposit } = useEthVaultDeposit();
 
@@ -117,7 +121,20 @@ export const UpgradeAssetsBlock = () => {
 
   return (
     <UpgradeAssets data-testid={'availableToUpgradeBanner'}>
-      <UpgradeAssetsTitle>Assets available to upgrade</UpgradeAssetsTitle>
+      <UpgradeAssetsHeader>
+        <UpgradeAssetsTitle>Assets available to upgrade</UpgradeAssetsTitle>
+        <UpgradeAssetsHowItWorksButton
+          onClick={() => {
+            trackMatomoEvent(
+              MATOMO_EARN_EVENTS_TYPES.earnListEarnEthBannerLearnHowItWorks,
+            );
+            openDrawerRight();
+          }}
+          data-testid={'howItWorksButton'}
+        >
+          How it works?
+        </UpgradeAssetsHowItWorksButton>
+      </UpgradeAssetsHeader>
       {tokensWithBalance.map((token) => (
         <UpgradeAssetsRow key={token} data-testid={token}>
           <UpgradeAssetsAmount>

--- a/features/earn/vault-eth/upgrade-assets/upgrade-assets.tsx
+++ b/features/earn/vault-eth/upgrade-assets/upgrade-assets.tsx
@@ -128,7 +128,7 @@ export const UpgradeAssetsBlock: FC = () => {
             trackMatomoEvent(
               MATOMO_EARN_EVENTS_TYPES.earnListEarnEthBannerLearnHowItWorks,
             );
-            openDrawerRight();
+            openDrawerRight({ hideUpgradeNowButton: true });
           }}
           data-testid={'howItWorksButton'}
         >

--- a/features/earn/vault-eth/vault-page.tsx
+++ b/features/earn/vault-eth/vault-page.tsx
@@ -166,7 +166,8 @@ const DATA = {
 const EthVaultPageContent: FC<{
   action: typeof EARN_VAULT_DEPOSIT_SLUG | typeof EARN_VAULT_WITHDRAW_SLUG;
 }> = ({ action }) => {
-  const { isDrawerOpen, closeDrawer } = useEthVaultDrawer();
+  const { isDrawerOpen, closeDrawer, shouldHideUpgradeNowButton } =
+    useEthVaultDrawer();
   const {
     apy,
     apyUpdateTimestampMs,
@@ -230,7 +231,11 @@ const EthVaultPageContent: FC<{
         }}
         protectedBadgeTooltipText={<ProtectedTooltip />}
       />
-      <DrawerRight onClose={closeDrawer} isOpen={isDrawerOpen} />
+      <DrawerRight
+        onClose={closeDrawer}
+        isOpen={isDrawerOpen}
+        shouldHideUpgradeNowButton={shouldHideUpgradeNowButton}
+      />
       <Disclaimers />
     </>
   );

--- a/features/earn/vault-eth/vault-page.tsx
+++ b/features/earn/vault-eth/vault-page.tsx
@@ -25,6 +25,8 @@ import {
 } from './consts';
 import { TOKEN_SYMBOLS } from 'consts/tokens';
 import { ProtectedTooltip } from './protected-tooltip';
+import { DrawerRight } from '../shared/drawer-right';
+import { EthVaultDrawerProvider, useEthVaultDrawer } from './drawer-context';
 
 const FEES = [
   { label: 'Performance fee', value: '10%' },
@@ -161,9 +163,10 @@ const DATA = {
   riskDisclosure: RISK_DISCLOSURE,
 };
 
-export const EthVaultPage: FC<{
+const EthVaultPageContent: FC<{
   action: typeof EARN_VAULT_DEPOSIT_SLUG | typeof EARN_VAULT_WITHDRAW_SLUG;
 }> = ({ action }) => {
+  const { isDrawerOpen, closeDrawer } = useEthVaultDrawer();
   const {
     apy,
     apyUpdateTimestampMs,
@@ -227,7 +230,18 @@ export const EthVaultPage: FC<{
         }}
         protectedBadgeTooltipText={<ProtectedTooltip />}
       />
+      <DrawerRight onClose={closeDrawer} isOpen={isDrawerOpen} />
       <Disclaimers />
     </>
+  );
+};
+
+export const EthVaultPage: FC<{
+  action: typeof EARN_VAULT_DEPOSIT_SLUG | typeof EARN_VAULT_WITHDRAW_SLUG;
+}> = ({ action }) => {
+  return (
+    <EthVaultDrawerProvider>
+      <EthVaultPageContent action={action} />
+    </EthVaultDrawerProvider>
   );
 };


### PR DESCRIPTION
### Description

This PR:

1. Updates the right-side drawer to behave like a standard modal drawer with a dimmed backdrop and close-on-backdrop-click behavior.
2. Adds a new How it works? action to the EarnETH Assets available to upgrade banner and wires it to open the same informational drawer used elsewhere on vault pages.
3. Updates obol and ssv rewards text in the drawer

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
