### PR TITLE
fix(earn): show apx tooltip for zero values

### DIFF
--- a/features/earn/shared/v2/apy-update-tooltip-text/__tests__/utils.test.ts
+++ b/features/earn/shared/v2/apy-update-tooltip-text/__tests__/utils.test.ts
@@ -1,0 +1,39 @@
+import { shouldShowApxUpdateTooltip } from '../utils';
+
+describe('shouldShowApxUpdateTooltip', () => {
+  it('returns true only when APX is finite, loaded, and tooltip text is present', () => {
+    expect(
+      shouldShowApxUpdateTooltip({
+        apx: 3.5,
+        isLoading: false,
+        apxUpdateTooltipText: 'Last updated on Jan 1, 2026',
+      }),
+    ).toBe(true);
+  });
+
+  it.each([
+    { apx: null, isLoading: false, apxUpdateTooltipText: 'Text' },
+    { apx: undefined, isLoading: false, apxUpdateTooltipText: 'Text' },
+    { apx: Number.NaN, isLoading: false, apxUpdateTooltipText: 'Text' },
+    {
+      apx: Number.POSITIVE_INFINITY,
+      isLoading: false,
+      apxUpdateTooltipText: 'Text',
+    },
+    { apx: 3.5, isLoading: true, apxUpdateTooltipText: 'Text' },
+    { apx: 3.5, isLoading: false, apxUpdateTooltipText: undefined },
+    { apx: 3.5, isLoading: false, apxUpdateTooltipText: null },
+    { apx: 3.5, isLoading: false, apxUpdateTooltipText: '' },
+  ])(
+    'returns false for invalid tooltip inputs: %o',
+    ({ apx, isLoading, apxUpdateTooltipText }) => {
+      expect(
+        shouldShowApxUpdateTooltip({
+          apx,
+          isLoading,
+          apxUpdateTooltipText,
+        }),
+      ).toBe(false);
+    },
+  );
+});

--- a/features/earn/shared/v2/apy-update-tooltip-text/index.ts
+++ b/features/earn/shared/v2/apy-update-tooltip-text/index.ts
@@ -1,1 +1,2 @@
 export * from './apy-update-tooltip-text';
+export * from './utils';

--- a/features/earn/shared/v2/apy-update-tooltip-text/utils.ts
+++ b/features/earn/shared/v2/apy-update-tooltip-text/utils.ts
@@ -1,0 +1,12 @@
+type ShouldShowApxUpdateTooltipParams = {
+  apx?: number | null;
+  isLoading?: boolean;
+  apxUpdateTooltipText?: unknown;
+};
+
+export const shouldShowApxUpdateTooltip = ({
+  apx,
+  isLoading,
+  apxUpdateTooltipText,
+}: ShouldShowApxUpdateTooltipParams) =>
+  apx != null && Number.isFinite(apx) && !isLoading && !!apxUpdateTooltipText;

--- a/features/earn/shared/v2/vault-card/vault-card.tsx
+++ b/features/earn/shared/v2/vault-card/vault-card.tsx
@@ -89,7 +89,10 @@ export const VaultCard: React.FC<VaultCardProps> = ({
   const isMobile = useBreakpoint('md');
 
   const shouldShowApxUpdateTooltip =
-    !!stats.apx && !stats.isLoading && !!stats.apxUpdateTooltipText;
+    stats.apx != null &&
+    Number.isFinite(stats.apx) &&
+    !stats.isLoading &&
+    !!stats.apxUpdateTooltipText;
 
   const apxValue = (
     <StatValue $accent $muted={stats.isApxStale} data-testid="apx-value">

--- a/features/earn/shared/v2/vault-card/vault-card.tsx
+++ b/features/earn/shared/v2/vault-card/vault-card.tsx
@@ -33,6 +33,7 @@ import { getTokenDecimals } from 'utils/token-decimals';
 import { useConfig } from 'config/use-config';
 import { InlineLoader } from '../../inline-loader';
 import { VaultTip } from '../../vault-tip';
+import { shouldShowApxUpdateTooltip } from '../apy-update-tooltip-text';
 
 type VaultStats = {
   tvl?: number | null;
@@ -88,11 +89,7 @@ export const VaultCard: React.FC<VaultCardProps> = ({
 
   const isMobile = useBreakpoint('md');
 
-  const shouldShowApxUpdateTooltip =
-    stats.apx != null &&
-    Number.isFinite(stats.apx) &&
-    !stats.isLoading &&
-    !!stats.apxUpdateTooltipText;
+  const showApxUpdateTooltip = shouldShowApxUpdateTooltip(stats);
 
   const apxValue = (
     <StatValue $accent $muted={stats.isApxStale} data-testid="apx-value">
@@ -157,7 +154,7 @@ export const VaultCard: React.FC<VaultCardProps> = ({
               {stats.apxHint}
             </VaultTip>
           </StatLabel>
-          {shouldShowApxUpdateTooltip ? (
+          {showApxUpdateTooltip ? (
             <StyledTooltip
               title={stats.apxUpdateTooltipText}
               placement={isMobile ? 'topRight' : 'topLeft'}

--- a/features/earn/shared/v2/vault-page/content/top-section.tsx
+++ b/features/earn/shared/v2/vault-page/content/top-section.tsx
@@ -70,7 +70,10 @@ export const TopSection: FC<TopSectionProps> = (props) => {
   } = props;
   const isMobile = useBreakpoint('md');
   const shouldShowApxUpdateTooltip =
-    !!apx && !isApxLoading && !!apxUpdateTooltipText;
+    apx != null &&
+    Number.isFinite(apx) &&
+    !isApxLoading &&
+    !!apxUpdateTooltipText;
 
   const apxValue = (
     <TopSectionStatValueTooltipTarget>

--- a/features/earn/shared/v2/vault-page/content/top-section.tsx
+++ b/features/earn/shared/v2/vault-page/content/top-section.tsx
@@ -10,6 +10,7 @@ import { FormatPrice } from 'shared/formatters/format-price';
 import { InlineLoader } from 'features/earn/shared/inline-loader';
 import { VaultTip } from 'features/earn/shared/vault-tip';
 import { Badge } from 'features/earn/shared/badge';
+import { shouldShowApxUpdateTooltip } from 'features/earn/shared/v2/apy-update-tooltip-text';
 import { getTokenDecimals } from 'utils/token-decimals';
 
 import {
@@ -69,11 +70,11 @@ export const TopSection: FC<TopSectionProps> = (props) => {
     balance,
   } = props;
   const isMobile = useBreakpoint('md');
-  const shouldShowApxUpdateTooltip =
-    apx != null &&
-    Number.isFinite(apx) &&
-    !isApxLoading &&
-    !!apxUpdateTooltipText;
+  const showApxUpdateTooltip = shouldShowApxUpdateTooltip({
+    apx,
+    isLoading: isApxLoading,
+    apxUpdateTooltipText,
+  });
 
   const apxValue = (
     <TopSectionStatValueTooltipTarget>
@@ -109,7 +110,7 @@ export const TopSection: FC<TopSectionProps> = (props) => {
             APY* (7d avg.)
             <VaultTip placement="bottomLeft">{apxHint}</VaultTip>
           </TopSectionStatLabel>
-          {shouldShowApxUpdateTooltip ? (
+          {showApxUpdateTooltip ? (
             <Tooltip
               title={apxUpdateTooltipText}
               placement={isMobile ? 'topRight' : 'topLeft'}


### PR DESCRIPTION
### Description

4ececbf6e introduced a regression in the APX update tooltip guard. The condition used !!apx / !!stats.apx, which treats a valid 0 APY/APR as “no data”.
The PR patches both guards to require a finite number instead of a truthy value, which keeps the intended “only show with APX data” behavior without dropping valid zero-rate tooltips.

### Checklist:

- [ ] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
