### PR TITLE
fix(earn): loading state for earn queries in use-position

### DIFF
--- a/features/earn/vault-eth/hooks/use-position.ts
+++ b/features/earn/vault-eth/hooks/use-position.ts
@@ -65,7 +65,7 @@ export const useEthVaultPosition = () => {
     ...earnethBalanceQuery,
     isLoading:
       earnethBalanceQuery.isLoading ||
-      earnethToWstethQuery.isPending ||
+      earnethToWstethQuery.isLoading ||
       usdQuery.isLoading,
     data,
     earnethSharesBalance: data?.earnethSharesBalance,

--- a/features/earn/vault-usd/hooks/use-position.ts
+++ b/features/earn/vault-usd/hooks/use-position.ts
@@ -60,7 +60,7 @@ export const useUsdVaultPosition = () => {
 
   return {
     ...earnusdBalanceQuery,
-    isLoading: earnusdBalanceQuery.isLoading || earnusdToUsdcQuery.isPending,
+    isLoading: earnusdBalanceQuery.isLoading || earnusdToUsdcQuery.isLoading,
     data,
     earnusdSharesBalance: data?.earnusdSharesBalance,
     usdQuery,


### PR DESCRIPTION
### Description

In TanStack Query v5, isPending is true for disabled queries with no cached data, not just for active fetches. The ETH and USD vault position hooks used isPending on chained queries that are disabled when no wallet is connected, causing the "Available to withdraw" field to show an infinite loader instead of a dash.

Replaced isPending with isLoading (isPending && isFetching) on earnethToWstethQuery and earnusdToUsdcQuery — disabled queries correctly return isLoading: false, so the dash fallback renders as expected.


### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
