### PR TITLE
Earn – use 14d time-weighted APY values

### DIFF
--- a/features/earn/shared/v2/vault-allocation/vault-allocation.tsx
+++ b/features/earn/shared/v2/vault-allocation/vault-allocation.tsx
@@ -44,7 +44,7 @@ export const VaultAllocation: FC<VaultAllocationProps> = (props) => {
 
   if (!allocationData.groups?.length && !allocationData.flatItems?.length) {
     return (
-      <Section title="Allocation" data-testId="no-allocation-data">
+      <Section title="Allocation" data-testid="no-allocation-data">
         <EmptyBlockStyled>No data available for now</EmptyBlockStyled>
       </Section>
     );
@@ -59,7 +59,7 @@ export const VaultAllocation: FC<VaultAllocationProps> = (props) => {
         </LastUpdatedStyled>
       }
       $noMargin
-      data-testId="allocation"
+      data-testid="allocation"
     >
       <ChartLine
         border={ChartLineBorderType.rounded}
@@ -74,7 +74,7 @@ export const VaultAllocation: FC<VaultAllocationProps> = (props) => {
         flatItems={allocationData.flatItems}
       />
       <AllocationSummary totalTvlUsd={allocationData.totalTvlUsd} />
-      {footer && <Footer data-testId="allocation-disclaimer">{footer}</Footer>}
+      {footer && <Footer data-testid="allocation-disclaimer">{footer}</Footer>}
     </Section>
   );
 };

--- a/features/earn/shared/v2/vault-card/legacy-vault-card.tsx
+++ b/features/earn/shared/v2/vault-card/legacy-vault-card.tsx
@@ -36,7 +36,7 @@ import { VaultTip } from '../../vault-tip';
 type VaultStats = {
   tvl?: number | null;
   apx?: number | null;
-  apxLabel: string;
+  apxLabel?: string;
   isLoading?: boolean;
   apxHint?: React.ReactNode;
 };
@@ -123,22 +123,26 @@ export const LegacyVaultCard: React.FC<LegacyVaultCardProps> = ({
       </CardHeader>
       <CardDivider />
       <CardStats>
-        <StatItem data-testid="apx">
-          <StatLabel>
-            {stats.apxLabel}
-            <VaultTip
-              placement="bottomLeft"
-              style={{ position: 'relative', zIndex: 20 }}
-            >
-              {stats.apxHint}
-            </VaultTip>
-          </StatLabel>
-          <StatValue $accent data-testid="apx-value">
-            <InlineLoader isLoading={stats.isLoading} width={70}>
-              <FormatPercent value={stats.apx} decimals="percent" />
-            </InlineLoader>
-          </StatValue>
-        </StatItem>
+        {stats.apxLabel && (
+          <StatItem data-testid="apx">
+            <StatLabel>
+              {stats.apxLabel}
+              {stats.apxHint && (
+                <VaultTip
+                  placement="bottomLeft"
+                  style={{ position: 'relative', zIndex: 20 }}
+                >
+                  {stats.apxHint}
+                </VaultTip>
+              )}
+            </StatLabel>
+            <StatValue $accent data-testid="apx-value">
+              <InlineLoader isLoading={stats.isLoading} width={70}>
+                <FormatPercent value={stats.apx} decimals="percent" />
+              </InlineLoader>
+            </StatValue>
+          </StatItem>
+        )}
         <StatItem data-testid="tvl">
           <StatLabel>TVL</StatLabel>
           <StatValue data-testid="tvl-amount">

--- a/features/earn/shared/v2/vault-page/content/top-section.tsx
+++ b/features/earn/shared/v2/vault-page/content/top-section.tsx
@@ -80,7 +80,7 @@ export const TopSection: FC<TopSectionProps> = (props) => {
 
   const apxValue = (
     <TopSectionStatValueTooltipTarget>
-      <TopSectionStatValue $accent $muted={isApxStale} data-testId="apx-value">
+      <TopSectionStatValue $accent $muted={isApxStale} data-testid="apx-value">
         <InlineLoader isLoading={isApxLoading} width={70}>
           <FormatPercent value={apx} decimals="percent" />
         </InlineLoader>
@@ -95,25 +95,25 @@ export const TopSection: FC<TopSectionProps> = (props) => {
           <TopSectionHeaderIcon aria-hidden>
             <props.logo />
           </TopSectionHeaderIcon>
-          <TopSectionHeaderTitle data-testId="vault-title">
+          <TopSectionHeaderTitle data-testid="vault-title">
             {title}
           </TopSectionHeaderTitle>
           {protectedBadgeTooltipText && (
             <Badge text="PROTECTED" tooltipText={protectedBadgeTooltipText} />
           )}
         </TopSectionHeader>
-        <TopSectionDescription data-testId="vault-description">
+        <TopSectionDescription data-testid="vault-description">
           {description}
         </TopSectionDescription>
       </TopSectionContent>
       <TopSectionStatsRow>
         {apxLabel && (
           <TopSectionStatItem>
-            <TopSectionStatLabel data-testId="apx-label">
+            <TopSectionStatLabel data-testid="apx-label">
               {apxLabel}
               <VaultTip placement="bottomLeft">{apxHint}</VaultTip>
             </TopSectionStatLabel>
-            {shouldShowApxUpdateTooltip ? (
+            {showApxUpdateTooltip ? (
               <Tooltip
                 title={apxUpdateTooltipText}
                 placement={isMobile ? 'topRight' : 'topLeft'}
@@ -126,8 +126,8 @@ export const TopSection: FC<TopSectionProps> = (props) => {
           </TopSectionStatItem>
         )}
         <TopSectionStatItem>
-          <TopSectionStatLabel data-testId="tvl-label">TVL</TopSectionStatLabel>
-          <TopSectionStatValue data-testId="tvl-amount">
+          <TopSectionStatLabel data-testid="tvl-label">TVL</TopSectionStatLabel>
+          <TopSectionStatValue data-testid="tvl-amount">
             <InlineLoader isLoading={isTvlLoading} width={70}>
               <FormatLargeAmount amount={tvlUsd} />
             </InlineLoader>
@@ -135,7 +135,7 @@ export const TopSection: FC<TopSectionProps> = (props) => {
         </TopSectionStatItem>
         {!!balance?.sharesAmount && (
           <TopSectionStatItem>
-            <TopSectionStatLabel data-testId="my-deposit-label">
+            <TopSectionStatLabel data-testid="my-deposit-label">
               My deposit
               <VaultTip placement="bottomLeft">
                 You hold{' '}
@@ -152,7 +152,7 @@ export const TopSection: FC<TopSectionProps> = (props) => {
               </VaultTip>
             </TopSectionStatLabel>
             <TopSectionStatValueGroup>
-              <TopSectionStatValue data-testId="my-deposit-value">
+              <TopSectionStatValue data-testid="my-deposit-value">
                 <InlineLoader isLoading={balance.isLoading} width={70}>
                   <FormatToken
                     trimEllipsis
@@ -163,7 +163,7 @@ export const TopSection: FC<TopSectionProps> = (props) => {
                 </InlineLoader>
               </TopSectionStatValue>
               {!balance.isLoading && balance.usdAmount != null && (
-                <TopSectionStatSubValue data-testId="my-deposit-usd-value">
+                <TopSectionStatSubValue data-testid="my-deposit-usd-value">
                   <FormatPrice amount={balance.usdAmount} />
                 </TopSectionStatSubValue>
               )}

--- a/features/earn/shared/v2/vault-page/content/top-section.tsx
+++ b/features/earn/shared/v2/vault-page/content/top-section.tsx
@@ -45,6 +45,7 @@ type TopSectionProps = {
   title: string;
   description: string;
   apx?: number | null;
+  apxLabel?: string;
   tvlUsd?: number | null;
   apxHint?: React.ReactNode;
   apxUpdateTooltipText?: React.ReactNode;
@@ -60,6 +61,7 @@ export const TopSection: FC<TopSectionProps> = (props) => {
     title,
     description,
     apx,
+    apxLabel = 'APY* (14d avg.)',
     tvlUsd,
     apxHint,
     apxUpdateTooltipText,
@@ -105,22 +107,24 @@ export const TopSection: FC<TopSectionProps> = (props) => {
         </TopSectionDescription>
       </TopSectionContent>
       <TopSectionStatsRow>
-        <TopSectionStatItem>
-          <TopSectionStatLabel data-testId="apx-label">
-            APY* (7d avg.)
-            <VaultTip placement="bottomLeft">{apxHint}</VaultTip>
-          </TopSectionStatLabel>
-          {showApxUpdateTooltip ? (
-            <Tooltip
-              title={apxUpdateTooltipText}
-              placement={isMobile ? 'topRight' : 'topLeft'}
-            >
-              {apxValue}
-            </Tooltip>
-          ) : (
-            apxValue
-          )}
-        </TopSectionStatItem>
+        {apxLabel && (
+          <TopSectionStatItem>
+            <TopSectionStatLabel data-testId="apx-label">
+              {apxLabel}
+              <VaultTip placement="bottomLeft">{apxHint}</VaultTip>
+            </TopSectionStatLabel>
+            {shouldShowApxUpdateTooltip ? (
+              <Tooltip
+                title={apxUpdateTooltipText}
+                placement={isMobile ? 'topRight' : 'topLeft'}
+              >
+                {apxValue}
+              </Tooltip>
+            ) : (
+              apxValue
+            )}
+          </TopSectionStatItem>
+        )}
         <TopSectionStatItem>
           <TopSectionStatLabel data-testId="tvl-label">TVL</TopSectionStatLabel>
           <TopSectionStatValue data-testId="tvl-amount">

--- a/features/earn/shared/v2/vault-page/vault-page.tsx
+++ b/features/earn/shared/v2/vault-page/vault-page.tsx
@@ -50,6 +50,7 @@ type Props = {
   title: string;
   description: string;
   apx?: number | null;
+  apxLabel?: string;
   apxHint?: React.ReactNode;
   apxUpdateTooltipText?: React.ReactNode;
   isApxStale?: boolean;
@@ -130,6 +131,7 @@ export const VaultPage: FC<Props> = (props) => {
           title={props.title}
           description={props.description}
           apx={props.apx}
+          apxLabel={props.apxLabel}
           tvlUsd={props.tvlUsd}
           apxHint={props.apxHint}
           apxUpdateTooltipText={props.apxUpdateTooltipText}

--- a/features/earn/shared/vault-stats/vault-stats.tsx
+++ b/features/earn/shared/vault-stats/vault-stats.tsx
@@ -12,7 +12,7 @@ import {
 type VaultStatsProps = {
   tvl?: number | null;
   apx?: number | null;
-  apxLabel: 'APY' | 'APR';
+  apxLabel?: 'APY' | 'APR';
   isLoading?: boolean;
   apxHint?: React.ReactNode;
   compact?: boolean;
@@ -36,15 +36,19 @@ export const VaultStats: React.FC<VaultStatsProps> = ({
           </InlineLoader>
         </VaultStatsValue>
       </VaultStatsItem>
-      <VaultStatsItem data-testid="apx-value">
-        <VaultStatsLabel>{apxLabel}</VaultStatsLabel>{' '}
-        <VaultStatsValue>
-          <InlineLoader isLoading={isLoading} width={70}>
-            <FormatPercent value={apx} decimals="percent" />*
-          </InlineLoader>
-        </VaultStatsValue>
-        {!isLoading && <VaultTip placement="bottom">{apxHint}</VaultTip>}
-      </VaultStatsItem>
+      {apxLabel && (
+        <VaultStatsItem data-testid="apx-value">
+          <VaultStatsLabel>{apxLabel}</VaultStatsLabel>{' '}
+          <VaultStatsValue>
+            <InlineLoader isLoading={isLoading} width={70}>
+              <FormatPercent value={apx} decimals="percent" />*
+            </InlineLoader>
+          </VaultStatsValue>
+          {!isLoading && apxHint && (
+            <VaultTip placement="bottom">{apxHint}</VaultTip>
+          )}
+        </VaultStatsItem>
+      )}
     </VaultStatsWrapper>
   );
 };

--- a/features/earn/vault-dvv/hooks/use-dvv-stats.ts
+++ b/features/earn/vault-dvv/hooks/use-dvv-stats.ts
@@ -124,11 +124,9 @@ export const useDVVApr = () => {
 
 export const useDVVStats = () => {
   const { data: tvl, isLoading: isTvlLoading } = useDVVTvl();
-  const { data: apr, isLoading: isAprLoading } = useDVVApr();
 
   return {
-    isLoading: isTvlLoading || isAprLoading,
+    isLoading: isTvlLoading,
     tvl: tvl?.tvlUSD,
-    apr: apr?.apr,
   };
 };

--- a/features/earn/vault-dvv/vault-card-dvv-v2.tsx
+++ b/features/earn/vault-dvv/vault-card-dvv-v2.tsx
@@ -7,11 +7,10 @@ import { useDVVPosition } from './hooks/use-dvv-position';
 import { LegacyVaultCard } from '../shared/v2/vault-card';
 import { EARN_VAULT_DVV_SLUG } from '../consts';
 import { DVV_TOKEN_SYMBOL, DVV_VAULT_DESCRIPTION } from './consts';
-import { DVVAprBreakdown } from './components/dvv-apr-breakdown';
 
 export const VaultCardDVV = () => {
   const { isWalletConnected } = useDappStatus();
-  const { tvl, apr, isLoading: isLoadingStats } = useDVVStats();
+  const { tvl, isLoading: isLoadingStats } = useDVVStats();
   const { sharesBalance, isLoading: isLoadingPosition } = useDVVPosition();
 
   return (
@@ -21,9 +20,6 @@ export const VaultCardDVV = () => {
       urlSlug={EARN_VAULT_DVV_SLUG}
       stats={{
         tvl: tvl,
-        apx: apr,
-        apxLabel: 'APY* (7d avg.)',
-        apxHint: <DVVAprBreakdown />,
         isLoading: isLoadingStats,
       }}
       position={

--- a/features/earn/vault-dvv/vault-card-dvv.tsx
+++ b/features/earn/vault-dvv/vault-card-dvv.tsx
@@ -18,11 +18,10 @@ import {
   DVV_TOKEN_SYMBOL,
   DVV_VAULT_DESCRIPTION,
 } from './consts';
-import { DVVAprBreakdown } from './components/dvv-apr-breakdown';
 
 export const VaultCardDVV = () => {
   const { isWalletConnected } = useDappStatus();
-  const { tvl, apr, isLoading: isLoadingStats } = useDVVStats();
+  const { tvl, isLoading: isLoadingStats } = useDVVStats();
   const { sharesBalance, isLoading: isLoadingPosition } = useDVVPosition();
   return (
     <VaultCard
@@ -36,10 +35,7 @@ export const VaultCardDVV = () => {
       ]}
       stats={{
         tvl,
-        apx: apr,
-        apxLabel: 'APR',
         isLoading: isLoadingStats,
-        apxHint: <DVVAprBreakdown />,
       }}
       logo={<VaultDVVIcon />}
       position={

--- a/features/earn/vault-dvv/vault-page-dvv.tsx
+++ b/features/earn/vault-dvv/vault-page-dvv.tsx
@@ -38,7 +38,6 @@ import { DVV_PARTNERS, DVV_VAULT_DESCRIPTION } from './consts';
 import { trackMatomoEvent } from 'utils/track-matomo-event';
 import { DVVFaq } from './faq/dvv-faq';
 import { DVVPosition } from './components/dvv-position';
-import { DVVAprBreakdown } from './components/dvv-apr-breakdown';
 import { DVVVaultDetails } from './components/dvv-vault-details';
 import { UpgradeCardVaultPage } from '../shared/upgrade-card-vault-page/upgrade-card-vault-page';
 import { DrawerRight } from '../shared/drawer-right';
@@ -61,7 +60,7 @@ export const VaultPageDVV: FC<{
 }> = ({ action }) => {
   const isDeposit = action === EARN_VAULT_DEPOSIT_SLUG;
   const isWithdraw = action === EARN_VAULT_WITHDRAW_SLUG;
-  const { tvl, apr, isLoading: isLoadingStats } = useDVVStats();
+  const { tvl, isLoading: isLoadingStats } = useDVVStats();
   const [isDrawerRightOpen, setIsDrawerRightOpen] = useState(false);
 
   return (
@@ -85,14 +84,7 @@ export const VaultPageDVV: FC<{
             logo={<VaultDVVIcon />}
             partners={DVV_PARTNERS}
           />
-          <VaultStats
-            compact
-            tvl={tvl}
-            apxLabel="APR"
-            apx={apr}
-            apxHint={<DVVAprBreakdown />}
-            isLoading={isLoadingStats}
-          />
+          <VaultStats compact tvl={tvl} isLoading={isLoadingStats} />
 
           <VaultDescription description={DVV_VAULT_DESCRIPTION} />
         </VaultBlockHeaderSection>
@@ -134,7 +126,7 @@ export const VaultPageDVV: FC<{
       <DVVVaultDetails />
       <DVVFaq />
       <DisclaimerSection>
-        <AprDisclaimer mentionAPY />
+        <AprDisclaimer />
         <LegalDisclaimer />
       </DisclaimerSection>
       <DrawerRight

--- a/features/earn/vault-eth/components/apy-hint/apy-hint.tsx
+++ b/features/earn/vault-eth/components/apy-hint/apy-hint.tsx
@@ -8,7 +8,7 @@ export const EthVaultApyHint = () => {
     <Container>
       <Section>
         <span>
-          7-day average APY after{' '}
+          14-day average APY after{' '}
           <LinkInpageAnchor
             pagePath={ETH_DEPOSIT_PATH}
             hash={`#${FAQ_IDS.fees}`}

--- a/features/earn/vault-eth/utils.ts
+++ b/features/earn/vault-eth/utils.ts
@@ -34,6 +34,7 @@ export type EthVaultStatsFetchedData = z.infer<typeof ETH_VAULT_STATS_SCHEMA>;
 
 export const ETH_VAULT_APY_SCHEMA = z.object({
   apy: APY_SCHEMA,
+  days: z.number(),
   apyLastUpdate: UNIX_TIMESTAMP_SCHEMA,
 });
 export type EthVaultApyFetchedData = z.infer<typeof ETH_VAULT_APY_SCHEMA>;
@@ -50,7 +51,7 @@ export const fetchEthVaultStats = async () => {
 
 export const fetchEthVaultStatsApr = async () => {
   const ethVaultAddress = getContractAddress(CHAINS.Mainnet, 'ethVault');
-  const ETH_APY_ENDPOINT = `${ETH_VAULT_STATS_ORIGIN}/v1/chain/${CHAINS.Mainnet}/core-vaults/${ethVaultAddress}/apy`;
+  const ETH_APY_ENDPOINT = `${ETH_VAULT_STATS_ORIGIN}/v1/chain/${CHAINS.Mainnet}/core-vaults/${ethVaultAddress}/timeweighted-apy`;
 
   const data = await standardFetcher<EthVaultApyFetchedData>(ETH_APY_ENDPOINT);
   const { apy, apyLastUpdate } = ETH_VAULT_APY_SCHEMA.parse(data);

--- a/features/earn/vault-eth/vault-card.tsx
+++ b/features/earn/vault-eth/vault-card.tsx
@@ -45,7 +45,7 @@ export const EthVaultCard = () => {
       stats={{
         tvl: tvlUsd,
         apx: apy,
-        apxLabel: 'APY* (7d avg.)',
+        apxLabel: 'APY* (14d avg.)',
         apxHint: <EthVaultApyHint />,
         apxUpdateTooltipText: (
           <ApyUpdateTooltipText timestampMs={apyUpdateTimestampMs} />

--- a/features/earn/vault-eth/withdraw/withdraw-form.tsx
+++ b/features/earn/vault-eth/withdraw/withdraw-form.tsx
@@ -44,7 +44,7 @@ const EthVaultWithdrawFormContent: FC = () => {
             <EthVaultWithdrawWillReceive />
             <VaultTxInfoRow
               title="Waiting time"
-              data-testId="waiting-time"
+              data-testid="waiting-time"
               help={
                 <>
                   Withdrawals take up to 72 hours to process. Once ready, your

--- a/features/earn/vault-ggv/allocation/allocation.tsx
+++ b/features/earn/vault-ggv/allocation/allocation.tsx
@@ -5,14 +5,9 @@ const FOOTER_TEXT =
   'Data is provided by Veda’s API and reflects the most recent snapshot at the time of update. As a result, the TVL shown here may differ from the vault’s TVL due to the data timestamp';
 
 export const Allocation = () => {
-  const { data, isLoading, apy } = useGGVAllocation();
+  const { data, isLoading } = useGGVAllocation();
 
   return (
-    <VaultAllocation
-      data={data}
-      isLoading={isLoading}
-      apy={apy}
-      footer={FOOTER_TEXT}
-    />
+    <VaultAllocation data={data} isLoading={isLoading} footer={FOOTER_TEXT} />
   );
 };

--- a/features/earn/vault-ggv/allocation/hooks/use-ggv-allocation.ts
+++ b/features/earn/vault-ggv/allocation/hooks/use-ggv-allocation.ts
@@ -10,13 +10,11 @@ import { createAllocationsChartData } from 'features/earn/shared/vault-allocatio
 
 import { getGGVVaultContract } from '../../contracts';
 import { fetchDailyGGVChainData, fetchGGVPerformance } from '../../utils';
-import { useGGVApy } from '../../hooks/use-ggv-stats';
 
 import { getAllocationData, createAllocationsData } from '../utils';
 
 export const useGGVAllocation = () => {
   const { publicClientMainnet } = useMainnetOnlyWagmi();
-  const apy = useGGVApy();
 
   const allocation = useQuery({
     queryKey: ['ggv', 'stats', 'allocation'],
@@ -74,5 +72,5 @@ export const useGGVAllocation = () => {
     },
   });
 
-  return { ...allocation, apy: apy.data };
+  return allocation;
 };

--- a/features/earn/vault-ggv/faq/ggv-faq.tsx
+++ b/features/earn/vault-ggv/faq/ggv-faq.tsx
@@ -2,7 +2,6 @@ import { FC } from 'react';
 import { Section } from 'shared/components';
 import {
   WhatIsLidoGGV,
-  WhatIsApyForGGV,
   WhatAreTheRisksOutlinedInTheVault,
   IsGGVAudited,
   DepositFee,
@@ -26,7 +25,6 @@ export const GGVFaq: FC = () => {
   return (
     <Section title="FAQ" data-testid="vault-faq">
       <WhatIsLidoGGV />
-      <WhatIsApyForGGV />
       <DepositFee />
       <WhatAreTheRisksOutlinedInTheVault />
       <IsGGVAudited />

--- a/features/earn/vault-ggv/hooks/use-ggv-stats.ts
+++ b/features/earn/vault-ggv/hooks/use-ggv-stats.ts
@@ -83,11 +83,9 @@ export const useGGVApy = () => {
 
 export const useGGVStats = () => {
   const { data: tvl, isLoading: isTvlLoading } = useGGVTvl();
-  const { data: apy, isLoading: isApyLoading } = useGGVApy();
 
   return {
-    isLoading: isTvlLoading || isApyLoading,
+    isLoading: isTvlLoading,
     tvl: tvl?.tvlUSD,
-    apy: apy,
   };
 };

--- a/features/earn/vault-ggv/vault-card-ggv-v2.tsx
+++ b/features/earn/vault-ggv/vault-card-ggv-v2.tsx
@@ -4,14 +4,13 @@ import { trackMatomoEvent } from 'utils/track-matomo-event';
 import { MATOMO_EARN_EVENTS_TYPES } from 'consts/matomo/matomo-earn-events';
 import { LegacyVaultCard } from '../shared/v2/vault-card';
 import { EARN_VAULT_GGV_SLUG } from '../consts';
-import { GGVApyHint } from './components/ggv-apy-hint';
 import { GGV_VAULT_DESCRIPTION, GGV_TOKEN_SYMBOL } from './consts';
 import { useGGVStats } from './hooks/use-ggv-stats';
 import { useGGVPosition } from './hooks/use-ggv-position';
 
 export const VaultCardGGV = () => {
   const { isWalletConnected } = useDappStatus();
-  const { tvl, apy, isLoading: isLoadingStats } = useGGVStats();
+  const { tvl, isLoading: isLoadingStats } = useGGVStats();
   const { sharesBalance, isLoading: isLoadingPosition } = useGGVPosition();
 
   return (
@@ -21,9 +20,6 @@ export const VaultCardGGV = () => {
       urlSlug={EARN_VAULT_GGV_SLUG}
       stats={{
         tvl: tvl,
-        apx: apy,
-        apxLabel: 'APY* (7d avg.)',
-        apxHint: <GGVApyHint />,
         isLoading: isLoadingStats,
       }}
       position={

--- a/features/earn/vault-ggv/vault-card-ggv.tsx
+++ b/features/earn/vault-ggv/vault-card-ggv.tsx
@@ -20,11 +20,10 @@ import {
   GGV_PARTNERS,
   GGV_TOKEN_SYMBOL,
 } from './consts';
-import { GGVApyHint } from './components/ggv-apy-hint';
 
 export const VaultCardGGV = () => {
   const { isWalletConnected } = useDappStatus();
-  const { tvl, apy, isLoading: isLoadingStats } = useGGVStats();
+  const { tvl, isLoading: isLoadingStats } = useGGVStats();
   const { sharesBalance, isLoading: isLoadingPosition } = useGGVPosition();
   return (
     <VaultCard
@@ -50,10 +49,7 @@ export const VaultCardGGV = () => {
       }
       stats={{
         tvl,
-        apx: apy,
-        apxLabel: 'APY',
         isLoading: isLoadingStats,
-        apxHint: <GGVApyHint />,
       }}
       logo={<VaultGGVIcon />}
       depositLinkCallback={() => {

--- a/features/earn/vault-ggv/vault-page-ggv.tsx
+++ b/features/earn/vault-ggv/vault-page-ggv.tsx
@@ -45,7 +45,6 @@ import {
   GGV_TOKEN_SYMBOL,
 } from './consts';
 import { GGVFaq } from './faq/ggv-faq';
-import { GGVApyHint } from './components/ggv-apy-hint';
 import { GGVVaultDetails } from './components/ggv-vault-details';
 import { UpgradeCardVaultPage } from '../shared/upgrade-card-vault-page/upgrade-card-vault-page';
 import { DrawerRight } from '../shared/drawer-right';
@@ -70,7 +69,7 @@ export const VaultPageGGV: FC<{
   const isWithdraw = action === EARN_VAULT_WITHDRAW_SLUG;
 
   const { isDappActive } = useDappStatus();
-  const { tvl, apy, isLoading } = useGGVStats();
+  const { tvl, isLoading } = useGGVStats();
   const {
     data,
     usdBalance,
@@ -100,14 +99,7 @@ export const VaultPageGGV: FC<{
             logo={<VaultGGVIcon />}
             partners={GGV_PARTNERS}
           />
-          <VaultStats
-            compact
-            tvl={tvl}
-            apxLabel="APY"
-            apx={apy}
-            apxHint={<GGVApyHint />}
-            isLoading={isLoading}
-          />
+          <VaultStats compact tvl={tvl} isLoading={isLoading} />
           <VaultDescription description={GGV_VAULT_DESCRIPTION} />
         </VaultBlockHeaderSection>
         {isDappActive && (
@@ -160,7 +152,7 @@ export const VaultPageGGV: FC<{
       <Allocation />
       <GGVFaq />
       <DisclaimerSection>
-        <AprDisclaimer mentionAPY />
+        <AprDisclaimer />
         <LegalDisclaimer />
       </DisclaimerSection>
       <DrawerRight

--- a/features/earn/vault-stg/allocation/allocation.tsx
+++ b/features/earn/vault-stg/allocation/allocation.tsx
@@ -5,14 +5,9 @@ const FOOTER_TEXT =
   'Data is provided by Mellow’s API and reflects the most recent snapshot at the time of update. As a result, the TVL shown here may differ from the vault’s TVL due to the data timestamp';
 
 export const Allocation = () => {
-  const { data, isLoading, apy } = useSTGAllocation();
+  const { data, isLoading } = useSTGAllocation();
 
   return (
-    <VaultAllocation
-      data={data}
-      isLoading={isLoading}
-      apy={apy}
-      footer={FOOTER_TEXT}
-    />
+    <VaultAllocation data={data} isLoading={isLoading} footer={FOOTER_TEXT} />
   );
 };

--- a/features/earn/vault-stg/allocation/hooks/use-stg-allocation.ts
+++ b/features/earn/vault-stg/allocation/hooks/use-stg-allocation.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 import { createAllocationsChartData } from 'features/earn/shared/vault-allocation/utils';
 import { useSTGStats } from '../../hooks/use-stg-stats';
-import { useSTGApy } from '../../hooks/use-stg-apy';
 import { buildPositionsArray, categorizePositions } from '../utils';
 
 export const useSTGAllocation = () => {
@@ -12,8 +11,6 @@ export const useSTGAllocation = () => {
     totalTvlWei,
     isLoading,
   } = useSTGStats();
-  const { apy } = useSTGApy();
-
   const data = useMemo(() => {
     if (!fetchedPositions?.length || !totalTvlUsd) return;
 
@@ -33,6 +30,5 @@ export const useSTGAllocation = () => {
   return {
     data,
     isLoading,
-    apy,
   };
 };

--- a/features/earn/vault-stg/faq/stg-faq.tsx
+++ b/features/earn/vault-stg/faq/stg-faq.tsx
@@ -2,7 +2,6 @@ import { FC } from 'react';
 import { Section } from 'shared/components';
 import {
   WhatAreMellowPoints,
-  WhatIsAPYForStrategy,
   WhatIsLidoStrategy,
   WhatFeesAreApplied,
   RisksOfDepositing,
@@ -29,7 +28,6 @@ export const STGFaq: FC = () => {
   return (
     <Section title="FAQ" data-testid="vault-faq">
       <WhatIsLidoStrategy />
-      <WhatIsAPYForStrategy />
       <WhatAreMellowPoints />
       <WhatFeesAreApplied />
       <RisksOfDepositing />

--- a/features/earn/vault-stg/vault-card-stg-v2.tsx
+++ b/features/earn/vault-stg/vault-card-stg-v2.tsx
@@ -2,18 +2,15 @@ import { VaultStgIcon } from 'assets/earn-v2';
 import { useDappStatus } from 'modules/web3';
 import { trackMatomoEvent } from 'utils/track-matomo-event';
 import { MATOMO_EARN_EVENTS_TYPES } from 'consts/matomo/matomo-earn-events';
-import { useSTGApy } from './hooks/use-stg-apy';
 import { useSTGStats } from './hooks/use-stg-stats';
 import { useSTGPosition } from './hooks/use-stg-position';
 import { LegacyVaultCard } from '../shared/v2/vault-card';
 import { EARN_VAULT_STG_SLUG } from '../consts';
-import { STGApyHint } from './components/stg-apy-hint';
 import { STG_VAULT_DESCRIPTION, STG_TOKEN_SYMBOL } from './consts';
 
 export const VaultCardSTG = () => {
   const { isWalletConnected } = useDappStatus();
   const { totalTvlUsd, isLoading: isLoadingTvlUsd } = useSTGStats();
-  const { apy, isLoading: isLoadingApy } = useSTGApy();
   const { strethSharesBalance, isLoading: isLoadingPosition } =
     useSTGPosition();
 
@@ -24,10 +21,7 @@ export const VaultCardSTG = () => {
       urlSlug={EARN_VAULT_STG_SLUG}
       stats={{
         tvl: totalTvlUsd,
-        apx: apy,
-        apxLabel: 'APY* (7d avg.)',
-        apxHint: <STGApyHint />,
-        isLoading: isLoadingApy || isLoadingTvlUsd,
+        isLoading: isLoadingTvlUsd,
       }}
       position={
         isWalletConnected

--- a/features/earn/vault-stg/vault-card-stg.tsx
+++ b/features/earn/vault-stg/vault-card-stg.tsx
@@ -7,7 +7,6 @@ import {
 } from 'assets/earn';
 
 import { useDappStatus } from 'modules/web3';
-import { useSTGApy } from './hooks/use-stg-apy';
 import { useSTGStats } from './hooks/use-stg-stats';
 import { useSTGPosition } from './hooks/use-stg-position';
 import { VaultCard } from '../shared/vault-card';
@@ -17,7 +16,6 @@ import {
   STG_PARTNERS,
   STG_TOKEN_SYMBOL,
 } from './consts';
-import { STGApyHint } from './components/stg-apy-hint';
 import { trackMatomoEvent } from 'utils/track-matomo-event';
 import { MATOMO_EARN_EVENTS_TYPES } from 'consts/matomo/matomo-earn-events';
 import { useDepositRequests } from './deposit/hooks';
@@ -25,7 +23,6 @@ import { useDepositRequests } from './deposit/hooks';
 export const VaultCardSTG = () => {
   const { isWalletConnected } = useDappStatus();
   const { totalTvlUsd, isLoading: isLoadingTvlUsd } = useSTGStats();
-  const { apy, isLoading: isLoadingApy } = useSTGApy();
   const { strethSharesBalance, isLoading: isLoadingPosition } =
     useSTGPosition();
   const {
@@ -66,10 +63,7 @@ export const VaultCardSTG = () => {
       }
       stats={{
         tvl: totalTvlUsd,
-        apx: apy,
-        apxLabel: 'APY',
-        apxHint: <STGApyHint />,
-        isLoading: isLoadingApy || isLoadingTvlUsd,
+        isLoading: isLoadingTvlUsd,
       }}
       logo={<VaultSTGIcon />}
       depositLinkCallback={() => {

--- a/features/earn/vault-stg/vault-page-stg.tsx
+++ b/features/earn/vault-stg/vault-page-stg.tsx
@@ -35,12 +35,10 @@ import {
 
 import { STGDepositForm } from './deposit';
 import { STGWithdrawForm } from './withdraw';
-import { useSTGApy } from './hooks/use-stg-apy';
 import { useSTGStats } from './hooks/use-stg-stats';
 import { STG_VAULT_DESCRIPTION, STG_PARTNERS } from './consts';
 import { STGPosition } from './components/stg-position';
 import { STGFaq } from './faq/stg-faq';
-import { STGApyHint } from './components/stg-apy-hint';
 import { STGVaultDetails } from './components/stg-vault-details';
 import { Allocation } from './allocation';
 import { UpgradeCardVaultPage } from '../shared/upgrade-card-vault-page/upgrade-card-vault-page';
@@ -67,7 +65,6 @@ export const VaultPageSTG: FC<{
 
   const { isDappActive } = useDappStatus();
   const { totalTvlUsd, isLoading: isTvlLoading } = useSTGStats();
-  const { apy, isLoading: isApyLoading } = useSTGApy();
   const [isDrawerRightOpen, setIsDrawerRightOpen] = useState(false);
 
   return (
@@ -91,14 +88,7 @@ export const VaultPageSTG: FC<{
             logo={<VaultSTGIcon />}
             partners={STG_PARTNERS}
           />
-          <VaultStats
-            compact
-            tvl={totalTvlUsd}
-            apxLabel="APY"
-            apx={apy}
-            apxHint={<STGApyHint />}
-            isLoading={isApyLoading || isTvlLoading}
-          />
+          <VaultStats compact tvl={totalTvlUsd} isLoading={isTvlLoading} />
           <VaultDescription description={STG_VAULT_DESCRIPTION} />
         </VaultBlockHeaderSection>
         {isDappActive && <STGPosition />}
@@ -139,7 +129,7 @@ export const VaultPageSTG: FC<{
       <Allocation />
       <STGFaq />
       <DisclaimerSection>
-        <AprDisclaimer mentionAPY />
+        <AprDisclaimer />
         <LegalDisclaimer />
       </DisclaimerSection>
       <DrawerRight

--- a/features/earn/vault-usd/components/apy-hint/apy-hint.tsx
+++ b/features/earn/vault-usd/components/apy-hint/apy-hint.tsx
@@ -8,7 +8,7 @@ export const UsdVaultApyHint = () => {
     <Container>
       <Section>
         <span>
-          7-day average APY after{' '}
+          14-day average APY after{' '}
           <LinkInpageAnchor
             pagePath={USD_DEPOSIT_PATH}
             hash={`#${FAQ_IDS.fees}`}

--- a/features/earn/vault-usd/utils.ts
+++ b/features/earn/vault-usd/utils.ts
@@ -30,6 +30,7 @@ export type UsdVaultStatsFetchedData = z.infer<typeof USD_VAULT_STATS_SCHEMA>;
 
 export const USD_VAULT_APY_SCHEMA = z.object({
   apy: APY_SCHEMA,
+  days: z.number(),
   apyLastUpdate: UNIX_TIMESTAMP_SCHEMA,
 });
 export type UsdVaultApyFetchedData = z.infer<typeof USD_VAULT_APY_SCHEMA>;
@@ -46,7 +47,7 @@ export const fetchUsdVaultStats = async () => {
 
 export const fetchUsdVaultStatsApr = async () => {
   const usdVaultAddress = getContractAddress(CHAINS.Mainnet, 'usdVault');
-  const USD_APY_ENDPOINT = `${USD_VAULT_STATS_ORIGIN}/v1/chain/${CHAINS.Mainnet}/core-vaults/${usdVaultAddress}/apy`;
+  const USD_APY_ENDPOINT = `${USD_VAULT_STATS_ORIGIN}/v1/chain/${CHAINS.Mainnet}/core-vaults/${usdVaultAddress}/timeweighted-apy`;
 
   const data = await standardFetcher<UsdVaultApyFetchedData>(USD_APY_ENDPOINT);
   const { apy, apyLastUpdate } = USD_VAULT_APY_SCHEMA.parse(data);

--- a/features/earn/vault-usd/vault-card.tsx
+++ b/features/earn/vault-usd/vault-card.tsx
@@ -44,7 +44,7 @@ export const UsdVaultCard = () => {
       stats={{
         tvl: tvlUsd,
         apx: apy,
-        apxLabel: 'APY* (7d avg.)',
+        apxLabel: 'APY* (14d avg.)',
         apxHint: <UsdVaultApyHint />,
         apxUpdateTooltipText: (
           <ApyUpdateTooltipText timestampMs={apyUpdateTimestampMs} />

--- a/features/earn/vault-usd/withdraw/withdraw-form.tsx
+++ b/features/earn/vault-usd/withdraw/withdraw-form.tsx
@@ -36,7 +36,7 @@ const UsdVaultWithdrawFormContent: FC = () => {
         <UsdVaultWithdrawWillReceive />
         <VaultTxInfoRow
           title="Waiting time"
-          data-testId="waiting-time"
+          data-testid="waiting-time"
           help={
             <>
               Withdrawals take up to 72 hours to process. Once ready, your funds


### PR DESCRIPTION
### Description

- Update EarnETH and EarnUSD APY to use Mellow’s 14-day time-weighted APY endpoint.
- Change APY labels from 7-day average to 14-day average.
- Remove APY display and related tooltips from upgrading vaults: stRATEGY, DVV, and GGV.
- fix data-testId attributes

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
