### PR TITLE
fix: security and observability hardening batch

### DIFF
--- a/features/ipfs/security-status-banner/__tests__/utils.test.ts
+++ b/features/ipfs/security-status-banner/__tests__/utils.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+
+import { isVersionLess } from '../utils';
+
+describe('isVersionLess', () => {
+  it('returns false for equal 3-component versions', () => {
+    expect(isVersionLess('1.0.0', '1.0.0')).toBe(false);
+  });
+
+  it('returns true when versionA patch is lower', () => {
+    expect(isVersionLess('1.0.0', '1.0.1')).toBe(true);
+  });
+
+  it('returns false when versionA patch is higher', () => {
+    expect(isVersionLess('1.0.1', '1.0.0')).toBe(false);
+  });
+
+  it('returns true when versionA has fewer components and shared prefix is equal', () => {
+    expect(isVersionLess('1.0.0', '1.0.0.1')).toBe(true);
+    expect(isVersionLess('1.60.1', '1.60.1.1')).toBe(true);
+  });
+
+  it('returns false when versionA has more components and shared prefix is equal', () => {
+    expect(isVersionLess('1.0.0.1', '1.0.0')).toBe(false);
+  });
+
+  it('treats trailing zeros as equal (1.0 == 1.0.0)', () => {
+    expect(isVersionLess('1.0', '1.0.0')).toBe(false);
+    expect(isVersionLess('1.0.0', '1.0')).toBe(false);
+  });
+
+  it('returns false when either side has a non-numeric component', () => {
+    expect(isVersionLess('abc', '1.0.0')).toBe(false);
+    expect(isVersionLess('1.0.0', 'abc')).toBe(false);
+  });
+
+  it('handles real production version strings', () => {
+    expect(isVersionLess('1.60.1', '1.60.2')).toBe(true);
+    expect(isVersionLess('1.60.2', '1.60.1')).toBe(false);
+    expect(isVersionLess('1.59.9', '1.60.0')).toBe(true);
+  });
+});

--- a/features/ipfs/security-status-banner/utils.ts
+++ b/features/ipfs/security-status-banner/utils.ts
@@ -8,12 +8,15 @@ export const isVersionLess = (versionA: string, versionB: string): boolean => {
     .split('.')
     .map((v) => parseInt(v));
 
+  // Iterate over the longer operand: a shorter prefix-equal version is "less"
+  // (e.g. "1.0.0" < "1.0.0.1") — iterating by verA.length would miss that.
+  const len = Math.max(verA.length, verB.length);
   // eslint-disable-next-line unicorn/no-for-loop
-  for (let index = 0; index < verA.length; index++) {
-    const a = verA[index];
-    const b = verB[index];
+  for (let index = 0; index < len; index++) {
+    const a = verA[index] ?? 0;
+    const b = verB[index] ?? 0;
     // validation
-    if (b === undefined || isNaN(a) || isNaN(b)) return false;
+    if (isNaN(a) || isNaN(b)) return false;
     if (a > b) return false;
     if (a < b) return true;
   }

--- a/next-logger.config.cjs
+++ b/next-logger.config.cjs
@@ -9,16 +9,28 @@ const loadEnvConfig = require('@next/env').loadEnvConfig;
 const projectDir = process.cwd();
 loadEnvConfig(projectDir);
 
-const patterns = [
-  ...commonPatterns,
-  process.env.INFURA_API_KEY,
-  process.env.ALCHEMY_API_KEY,
-  process.env.ETHPLORER_API_KEY,
-  // TODO: Delete this ENV
-  process.env.CLOUDFLARE_API_TOKEN,
-  process.env.CLOUDFLARE_ACCOUNT_ID,
-  process.env.CLOUDFLARE_KV_NAMESPACE_ID,
+const RPC_URL_ENV_KEYS = [
+  'EL_RPC_URLS_1',
+  'EL_RPC_URLS_10',
+  'EL_RPC_URLS_130',
+  'EL_RPC_URLS_1301',
+  'EL_RPC_URLS_1868',
+  'EL_RPC_URLS_1946',
+  'EL_RPC_URLS_17000',
+  'EL_RPC_URLS_560048',
+  'EL_RPC_URLS_11155111',
+  'EL_RPC_URLS_11155420',
 ];
+
+// Comma-split so each URL becomes its own pattern; otherwise satanizer only matches the full concatenation.
+const rpcUrlPatterns = RPC_URL_ENV_KEYS.flatMap((key) =>
+  (process.env[key] || '')
+    .split(',')
+    .map((url) => url.trim())
+    .filter(Boolean),
+);
+
+const patterns = [...commonPatterns, ...rpcUrlPatterns].filter(Boolean);
 const mask = satanizer(patterns);
 
 const logger = (defaultConfig) =>

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -161,10 +161,11 @@ export default withBundleAnalyzer({
             key: 'x-dns-prefetch-control',
             value: 'on',
           },
-          // This header is overwritten by CF, but we still align value just in case
+          // This header is overwritten by CF, but we still align value just in case.
+          // 31536000 (1 year) is the minimum required by hstspreload.org.
           {
             key: 'strict-transport-security',
-            value: 'max-age=2592000; includeSubDomains; preload',
+            value: 'max-age=31536000; includeSubDomains; preload',
           },
           {
             key: 'referrer-policy',

--- a/scripts/log-environment-variables.mjs
+++ b/scripts/log-environment-variables.mjs
@@ -6,6 +6,10 @@ export const openKeys = [
   'RESEARCH_ORIGIN',
   'BLOG_ORIGIN',
 
+  'BASE_PATH',
+  'IPFS_MODE',
+  'DEVNET_OVERRIDES',
+
   'SUPPORTED_CHAINS',
   'DEFAULT_CHAIN',
   'MANIFEST_OVERRIDE',
@@ -17,6 +21,7 @@ export const openKeys = [
   'ENABLE_QA_HELPERS',
 
   'REWARDS_BACKEND',
+  'VALIDATION_SERVICE_BASE_PATH',
 
   'RATE_LIMIT',
   'RATE_LIMIT_TIME_FRAME',
@@ -31,7 +36,6 @@ export const openKeys = [
 
 export const secretKeys = [
   'EL_RPC_URLS_1',
-  'EL_RPC_URLS_5',
   'EL_RPC_URLS_10',
   'EL_RPC_URLS_130',
   'EL_RPC_URLS_1301',

--- a/utilsApi/cached-proxy.ts
+++ b/utilsApi/cached-proxy.ts
@@ -4,9 +4,7 @@ import { LRUCache } from 'lru-cache';
 
 import { responseTimeExternalMetricWrapper } from './fetchApiWrapper';
 import { standardFetcher } from 'utils/standardFetcher';
-import { config } from 'config';
 import { FetcherError } from 'utils/fetcherError';
-import { ETH_API_ROUTES, getEthApiPath } from 'consts/api';
 import { buildParams } from './cached-proxy-build-params';
 
 export { buildParams } from './cached-proxy-build-params';
@@ -85,36 +83,4 @@ export const createCachedProxy = ({
       throw e;
     }
   };
-};
-
-type EthApiProxyOptions = Pick<
-  ProxyOptions,
-  'transformData' | 'ignoreParams' | 'cacheTTL'
-> & {
-  endpoint: ETH_API_ROUTES;
-};
-
-export const createEthApiProxy = ({
-  endpoint,
-  cacheTTL,
-  ignoreParams,
-  transformData,
-}: EthApiProxyOptions): API => {
-  const proxyUrl = getEthApiPath(endpoint);
-
-  if (!proxyUrl) {
-    console.error('[createEthApiProxy] Skipped setup: EthApiPath is null');
-    return (_req, res) => {
-      res.status(404).end();
-    };
-  }
-
-  return createCachedProxy({
-    cacheTTL,
-    ignoreParams,
-    transformData,
-    proxyUrl: async () => proxyUrl, // Wrap string in function
-    metricsHost: config.ethAPIBasePath,
-    timeout: 5000,
-  });
 };


### PR DESCRIPTION

<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

- isVersionLess: iterate over the longer operand so a shorter prefix-equal version is correctly reported as less (fixes silent IPFS kill-switch failure if leastSafeVersion ever has more components than the build version); add unit tests for the module
- HSTS: bump max-age from 30 days to 1 year
- cached-proxy: drop unused createEthApiProxy factory and now-unused imports — all ETH-API consumers fetch from the browser
- next-logger satanizer: replace patterns referencing env vars this widget doesn't read (INFURA / ALCHEMY / ETHPLORER / CLOUDFLARE_*) with EL_RPC_URLS_*; split comma-separated RPC lists so individual URLs match
- log-environment-variables: classify previously-unclassified server env vars — add BASE_PATH / IPFS_MODE / DEVNET_OVERRIDES / VALIDATION_SERVICE_BASE_PATH to openKeys; drop dead EL_RPC_URLS_5 (Goerli, not referenced anywhere)


### Demo

<!--- If thee are visual changes, attach a link to a specific section on preview stand / add screenshots / record a [loom](https://www.loom.com/). -->

### Code review notes

<!--- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

<!--- List all possible edge cases and how to test them. -->

### Checklist:

- [ ] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
