### PR TITLE
Enable Earn banners

### DIFF
--- a/IPFS.json
+++ b/IPFS.json
@@ -13,8 +13,8 @@
         130, 1135, 1923
       ],
       "earnVaultsBanner": {
-        "showOnStakeForm": false,
-        "showAfterStake": false
+        "showOnStakeForm": true,
+        "showAfterStake": true
       },
       "earnVaults": [
         { "name": "eth" },


### PR DESCRIPTION
### Description

Enables previously disable Earn banner for stake form and after stake

### Checklist:

- [ ] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
