### PR TITLE
Earn – rework form layout spacing and input error reservation

### DIFF
--- a/features/earn/shared/v2/vault-deposit-submit-button/styles.tsx
+++ b/features/earn/shared/v2/vault-deposit-submit-button/styles.tsx
@@ -1,6 +1,10 @@
 import { Question, Tooltip } from '@lidofinance/lido-ui';
 import styled from 'styled-components';
 
+export const SubmitButtonWrapper = styled.div`
+  margin-top: calc(20px - var(--earn-vault-form-gap, 8px));
+`;
+
 export const StyledTooltip = styled(Tooltip)`
   font-size: ${({ theme }) => theme.fontSizesMap.xxs}px !important;
   margin-top: 8px;

--- a/features/earn/shared/v2/vault-deposit-submit-button/vault-deposit-submit-button.tsx
+++ b/features/earn/shared/v2/vault-deposit-submit-button/vault-deposit-submit-button.tsx
@@ -1,6 +1,7 @@
 import { useFormState } from 'react-hook-form';
 import { SubmitButtonHookForm } from 'shared/hook-form/controls/submit-button-hook-form';
 import {
+  SubmitButtonWrapper,
   StyledTooltip,
   StyledQuestionIcon,
   SubmitButtonInnerContainer,
@@ -26,38 +27,44 @@ export const VaultDepositSubmitButton = ({
   if (!disabled) {
     if (!isVaultAvailable) {
       return (
-        <SubmitButtonHookForm disabled data-testid="submit-btn">
-          Switch to Ethereum Mainnet
-        </SubmitButtonHookForm>
+        <SubmitButtonWrapper>
+          <SubmitButtonHookForm disabled data-testid="submit-btn">
+            Switch to Ethereum Mainnet
+          </SubmitButtonHookForm>
+        </SubmitButtonWrapper>
       );
     }
 
     if (isDepositLockedForCurrentToken) {
       return (
-        <StyledTooltip
-          placement="bottom"
-          title={`You already have a pending request in ${tokenDisplayName}. To create a new deposit, please select a different token or cancel the existing deposit.`}
-        >
-          {/*
-            `div` wrapper is required around disabled button for the tooltip to work,
-            because disabled buttons do not trigger events
-          */}
-          <div>
-            <SubmitButtonHookForm disabled data-testid="submit-btn">
-              <SubmitButtonInnerContainer>
-                Deposit
-                <StyledQuestionIcon />
-              </SubmitButtonInnerContainer>
-            </SubmitButtonHookForm>
-          </div>
-        </StyledTooltip>
+        <SubmitButtonWrapper>
+          <StyledTooltip
+            placement="bottom"
+            title={`You already have a pending request in ${tokenDisplayName}. To create a new deposit, please select a different token or cancel the existing deposit.`}
+          >
+            {/*
+              `div` wrapper is required around disabled button for the tooltip to work,
+              because disabled buttons do not trigger events
+            */}
+            <div>
+              <SubmitButtonHookForm disabled data-testid="submit-btn">
+                <SubmitButtonInnerContainer>
+                  Deposit
+                  <StyledQuestionIcon />
+                </SubmitButtonInnerContainer>
+              </SubmitButtonHookForm>
+            </div>
+          </StyledTooltip>
+        </SubmitButtonWrapper>
       );
     }
   }
 
   return (
-    <SubmitButtonHookForm disabled={disabled} data-testid="submit-btn">
-      {isClaimable ? 'Claim and Deposit' : 'Deposit'}
-    </SubmitButtonHookForm>
+    <SubmitButtonWrapper>
+      <SubmitButtonHookForm disabled={disabled} data-testid="submit-btn">
+        {isClaimable ? 'Claim and Deposit' : 'Deposit'}
+      </SubmitButtonHookForm>
+    </SubmitButtonWrapper>
   );
 };

--- a/features/earn/shared/vault-form-section.ts
+++ b/features/earn/shared/vault-form-section.ts
@@ -3,5 +3,5 @@ import styled from 'styled-components';
 export const VaultFormSection = styled.div`
   display: flex;
   flex-direction: column;
-  gap: ${({ theme }) => theme.spaceMap.xs};
+  gap: ${({ theme }) => theme.spaceMap.xs}px;
 `;

--- a/features/earn/shared/vault-form.ts
+++ b/features/earn/shared/vault-form.ts
@@ -2,8 +2,12 @@ import styled from 'styled-components';
 
 import { FormController } from 'shared/hook-form/form-controller';
 
-export const VaultForm = styled(FormController)`
+type VaultFormProps = {
+  $gap?: number;
+};
+
+export const VaultForm = styled(FormController)<VaultFormProps>`
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: ${({ $gap = 8 }) => $gap}px;
 `;

--- a/features/earn/shared/vault-form.ts
+++ b/features/earn/shared/vault-form.ts
@@ -7,7 +7,8 @@ type VaultFormProps = {
 };
 
 export const VaultForm = styled(FormController)<VaultFormProps>`
+  --earn-vault-form-gap: ${({ $gap = 8 }) => $gap}px;
   display: flex;
   flex-direction: column;
-  gap: ${({ $gap = 8 }) => $gap}px;
+  gap: var(--earn-vault-form-gap);
 `;

--- a/features/earn/shared/vault-input-group-hook-form.tsx
+++ b/features/earn/shared/vault-input-group-hook-form.tsx
@@ -1,0 +1,11 @@
+import { InputGroupHookForm } from 'shared/hook-form/controls/input-group-hook-form';
+
+// Reserves space for the validation error banner (38px = its height + gaps)
+// so layout doesn't shift when the error appears/disappears.
+const INPUT_BOTTOM_SPACING = 38;
+
+type Props = React.ComponentProps<typeof InputGroupHookForm>;
+
+export const VaultInputGroupHookForm: React.FC<Props> = (props) => (
+  <InputGroupHookForm bottomSpacing={INPUT_BOTTOM_SPACING} {...props} />
+);

--- a/features/earn/shared/vault-submit-button.tsx
+++ b/features/earn/shared/vault-submit-button.tsx
@@ -1,4 +1,9 @@
+import styled from 'styled-components';
 import { SubmitButtonHookForm } from 'shared/hook-form/controls/submit-button-hook-form';
+
+const SubmitButtonWrapper = styled.div`
+  margin-top: calc(20px - var(--earn-vault-form-gap, 8px));
+`;
 
 type VaultSubmitButtonProps = React.PropsWithChildren<{
   disabled?: boolean;
@@ -14,11 +19,15 @@ export const VaultSubmitButton = ({
   const shouldSwitchChain = !isAvailable;
 
   return (
-    <SubmitButtonHookForm
-      disabled={disabled || shouldSwitchChain}
-      data-testid="submit-btn"
-    >
-      {!disabled && shouldSwitchChain ? 'Switch to Ethereum Mainnet' : children}
-    </SubmitButtonHookForm>
+    <SubmitButtonWrapper>
+      <SubmitButtonHookForm
+        disabled={disabled || shouldSwitchChain}
+        data-testid="submit-btn"
+      >
+        {!disabled && shouldSwitchChain
+          ? 'Switch to Ethereum Mainnet'
+          : children}
+      </SubmitButtonHookForm>
+    </SubmitButtonWrapper>
   );
 };

--- a/features/earn/shared/vault-will-receive/vault-will-receive.tsx
+++ b/features/earn/shared/vault-will-receive/vault-will-receive.tsx
@@ -19,6 +19,7 @@ type VaultWillReceiveProps = {
   help?: React.ReactNode;
   fallbackMainValue?: string;
   fallbackSecondaryValue?: string;
+  showSecondaryValue?: boolean;
 };
 
 export const VaultWillReceive = ({
@@ -31,6 +32,7 @@ export const VaultWillReceive = ({
   help,
   fallbackMainValue = '-',
   fallbackSecondaryValue = '-',
+  showSecondaryValue = true,
 }: VaultWillReceiveProps) => {
   return (
     <VaultTxInfoRow title={'You will receive'} help={help}>
@@ -47,23 +49,28 @@ export const VaultWillReceive = ({
             {icon}
           </VaultReceiveMainValue>
         </InlineLoader>
-        <InlineLoader isLoading={isLoading} width={80}>
-          <VaultReceiveSecondaryValue>
-            <FormatPrice amount={usdAmount} fallback={fallbackSecondaryValue} />
-            &nbsp;
-            {ethAmount !== undefined && (
-              <>
-                (
-                <FormatToken
-                  amount={ethAmount}
-                  symbol="ETH"
-                  showAmountTip={false}
-                />
-                )
-              </>
-            )}
-          </VaultReceiveSecondaryValue>
-        </InlineLoader>
+        {showSecondaryValue && (
+          <InlineLoader isLoading={isLoading} width={80}>
+            <VaultReceiveSecondaryValue>
+              <FormatPrice
+                amount={usdAmount}
+                fallback={fallbackSecondaryValue}
+              />
+              &nbsp;
+              {ethAmount !== undefined && (
+                <>
+                  (
+                  <FormatToken
+                    amount={ethAmount}
+                    symbol="ETH"
+                    showAmountTip={false}
+                  />
+                  )
+                </>
+              )}
+            </VaultReceiveSecondaryValue>
+          </InlineLoader>
+        )}
       </VaultReceiveValue>
     </VaultTxInfoRow>
   );

--- a/features/earn/vault-dvv/deposit/dvv-deposit-form.tsx
+++ b/features/earn/vault-dvv/deposit/dvv-deposit-form.tsx
@@ -17,7 +17,7 @@ export const DVVDepositForm: FC = () => {
 
   return (
     <DVVDepositFormProvider>
-      <VaultForm data-testid="deposit-form">
+      <VaultForm $gap={12} data-testid="deposit-form">
         <DVVDepositWarning />
         {!isVaultDeprecated && (
           <>

--- a/features/earn/vault-dvv/deposit/dvv-deposit-input-group.tsx
+++ b/features/earn/vault-dvv/deposit/dvv-deposit-input-group.tsx
@@ -54,7 +54,7 @@ export const DVVDepositInputGroup: React.FC = () => {
   const { disabled } = useFormState();
 
   return (
-    <InputGroupHookForm errorField="amount" bottomSpacing={false}>
+    <InputGroupHookForm errorField="amount" bottomSpacing={0}>
       <TokenSelectHookForm
         errorField="amount"
         fieldName="token"

--- a/features/earn/vault-dvv/withdraw/dvv-withdraw-form.tsx
+++ b/features/earn/vault-dvv/withdraw/dvv-withdraw-form.tsx
@@ -14,7 +14,7 @@ import { DVVWithdrawWarning } from './dvv-withdraw-warning';
 export const DVVWithdrawForm: FC = () => {
   return (
     <DVVWithdrawFormProvider>
-      <VaultForm>
+      <VaultForm $gap={12}>
         <DVVWithdrawWarning />
         <VaultFormSection>
           <DVVWithdrawAvailable />

--- a/features/earn/vault-eth/deposit/deposit-input-group.tsx
+++ b/features/earn/vault-eth/deposit/deposit-input-group.tsx
@@ -1,7 +1,7 @@
 import { useFormState, useWatch } from 'react-hook-form';
 
 import { BALANCE_PADDING, useAA } from 'modules/web3';
-import { InputGroupHookForm } from 'shared/hook-form/controls/input-group-hook-form';
+import { VaultInputGroupHookForm } from 'features/earn/shared/vault-input-group-hook-form';
 import { TokenAmountInputHookForm } from 'shared/hook-form/controls/token-amount-input-hook-form';
 import { TokenSelectHookForm } from 'shared/hook-form/controls/token-select-hook-form/token-select-hook-form';
 import { useTokenMaxAmount } from 'shared/hooks/use-token-max-amount';
@@ -69,7 +69,7 @@ export const EthVaultDepositInputGroup = () => {
   const { disabled } = useFormState();
 
   return (
-    <InputGroupHookForm errorField="amount" bottomSpacing={false}>
+    <VaultInputGroupHookForm errorField="amount">
       <TokenSelectHookForm
         errorField="amount"
         fieldName="token"
@@ -89,6 +89,6 @@ export const EthVaultDepositInputGroup = () => {
           trackMatomoEvent(MATOMO_EARN_EVENTS_TYPES.earnEthDepositMax);
         }}
       />
-    </InputGroupHookForm>
+    </VaultInputGroupHookForm>
   );
 };

--- a/features/earn/vault-eth/deposit/form-context/validation.ts
+++ b/features/earn/vault-eth/deposit/form-context/validation.ts
@@ -1,5 +1,4 @@
 import type { Resolver } from 'react-hook-form';
-import { formatEther } from 'viem';
 import invariant from 'tiny-invariant';
 import type {
   ETHDepositFormValidationContext,
@@ -14,13 +13,10 @@ import { validateBigintMin } from 'shared/hook-form/validation/validate-bigint-m
 import { validateBigintMax } from 'shared/hook-form/validation/validate-bigint-max';
 
 import { awaitWithTimeout } from 'utils/await-with-timeout';
-import { getTokenDisplayName } from 'utils/getTokenDisplayName';
 import { type TokenSymbol } from 'consts/tokens';
 
-const messageMaxBalance = (max: bigint, token: TokenSymbol) =>
-  `Entered ${getTokenDisplayName(
-    token,
-  )} amount exceeds your available balance of ${formatEther(max)}`;
+const messageMaxBalance = (_max: bigint, token: TokenSymbol) =>
+  `Insufficient ${token} balance`;
 
 export const EthVaultDepositFormValidationResolver: Resolver<
   ETHDepositFormValues,

--- a/features/earn/vault-eth/withdraw/form-context/validation.ts
+++ b/features/earn/vault-eth/withdraw/form-context/validation.ts
@@ -1,5 +1,4 @@
 import type { Resolver } from 'react-hook-form';
-import { formatEther } from 'viem';
 import invariant from 'tiny-invariant';
 
 import { VALIDATION_CONTEXT_TIMEOUT } from 'features/withdrawals/withdrawals-constants';
@@ -14,8 +13,8 @@ import type {
   EthVaultWithdrawFormValues,
 } from './types';
 
-const messageMaxBalance = (max: bigint, token: string) =>
-  `Entered ${token} amount exceeds your available balance of ${formatEther(max)}`;
+const messageMaxBalance = (_max: bigint, token: string) =>
+  `Insufficient ${token} balance`;
 
 export const EthVaultWithdrawFormValidationResolver: Resolver<
   EthVaultWithdrawFormValues,

--- a/features/earn/vault-eth/withdraw/withdraw-input.tsx
+++ b/features/earn/vault-eth/withdraw/withdraw-input.tsx
@@ -1,6 +1,6 @@
 import { useFormState } from 'react-hook-form';
 
-import { InputGroupHookForm } from 'shared/hook-form/controls/input-group-hook-form';
+import { VaultInputGroupHookForm } from 'features/earn/shared/vault-input-group-hook-form';
 import { TokenAmountInputHookForm } from 'shared/hook-form/controls/token-amount-input-hook-form';
 import { TokenEarnEthIcon } from 'assets/earn-v2';
 import { trackMatomoEvent } from 'utils/track-matomo-event';
@@ -14,7 +14,7 @@ export const EthVaultWithdrawInput: React.FC = () => {
   const { disabled } = useFormState();
 
   return (
-    <InputGroupHookForm errorField="amount" bottomSpacing={false}>
+    <VaultInputGroupHookForm errorField="amount">
       <TokenAmountInputHookForm
         leftDecorator={<TokenEarnEthIcon width={24} height={24} />}
         disabled={disabled}
@@ -27,6 +27,6 @@ export const EthVaultWithdrawInput: React.FC = () => {
           trackMatomoEvent(MATOMO_EARN_EVENTS_TYPES.earnEthWithdrawalMax);
         }}
       />
-    </InputGroupHookForm>
+    </VaultInputGroupHookForm>
   );
 };

--- a/features/earn/vault-ggv/deposit/ggv-deposit-form.tsx
+++ b/features/earn/vault-ggv/deposit/ggv-deposit-form.tsx
@@ -18,7 +18,7 @@ export const GGVDepositForm: FC = () => {
 
   return (
     <GGVDepositFormProvider>
-      <VaultForm data-testid="deposit-form">
+      <VaultForm $gap={12} data-testid="deposit-form">
         <GGVDepositWarning />
         {!isVaultDeprecated && (
           <>

--- a/features/earn/vault-ggv/deposit/ggv-deposit-input-group.tsx
+++ b/features/earn/vault-ggv/deposit/ggv-deposit-input-group.tsx
@@ -60,7 +60,7 @@ export const GGVDepositInputGroup: React.FC = () => {
   const { disabled } = useFormState();
 
   return (
-    <InputGroupHookForm errorField="amount" bottomSpacing={false}>
+    <InputGroupHookForm errorField="amount" bottomSpacing={0}>
       <TokenSelectHookForm
         errorField="amount"
         fieldName="token"

--- a/features/earn/vault-ggv/withdraw/ggv-withdraw-form.tsx
+++ b/features/earn/vault-ggv/withdraw/ggv-withdraw-form.tsx
@@ -19,7 +19,7 @@ import { GGVWhenNoActiveRequests } from './ggv-when-no-active-requests';
 export const GGVWithdrawForm: FC = () => {
   return (
     <GGVWithdrawFormProvider>
-      <VaultForm data-testid="withdraw-form">
+      <VaultForm $gap={12} data-testid="withdraw-form">
         <GGVWithdrawRequest />
         <GGVWhenNoActiveRequests>
           <GGVWithdrawWarning />

--- a/features/earn/vault-ggv/withdraw/ggv-withdraw-input.tsx
+++ b/features/earn/vault-ggv/withdraw/ggv-withdraw-input.tsx
@@ -13,7 +13,7 @@ export const GGVWithdrawInput = () => {
   const { disabled } = useFormState();
 
   return (
-    <InputGroupHookForm errorField="amount" bottomSpacing={false}>
+    <InputGroupHookForm errorField="amount" bottomSpacing={0}>
       <TokenAmountInputHookForm
         leftDecorator={
           <TokenGGIcon width={24} height={24} viewBox={'0 0 28 28'} />

--- a/features/earn/vault-stg/deposit/stg-deposit-form.tsx
+++ b/features/earn/vault-stg/deposit/stg-deposit-form.tsx
@@ -31,7 +31,7 @@ export const STGDepositForm = () => {
 
   return (
     <STGDepositFormProvider>
-      <VaultForm data-testid="deposit-form">
+      <VaultForm $gap={12} data-testid="deposit-form">
         <STGDepositWarning />
         <VaultFormSection>
           <STGDepositRequests />

--- a/features/earn/vault-stg/deposit/stg-deposit-input-group.tsx
+++ b/features/earn/vault-stg/deposit/stg-deposit-input-group.tsx
@@ -56,7 +56,7 @@ export const STGDepositInputGroup = () => {
   const { disabled } = useFormState();
 
   return (
-    <InputGroupHookForm errorField="amount" bottomSpacing={false}>
+    <InputGroupHookForm errorField="amount" bottomSpacing={0}>
       <TokenSelectHookForm
         errorField="amount"
         fieldName="token"

--- a/features/earn/vault-stg/withdraw/stg-withdraw-form.tsx
+++ b/features/earn/vault-stg/withdraw/stg-withdraw-form.tsx
@@ -17,7 +17,7 @@ import { STGWithdrawWarning } from './stg-withdraw-warning';
 
 const STGWithdrawFormContent: FC = () => {
   return (
-    <VaultForm data-testid="withdraw-form">
+    <VaultForm $gap={12} data-testid="withdraw-form">
       <STGWithdrawWarning />
       <VaultFormSection>
         <STGWithdrawRequests />

--- a/features/earn/vault-stg/withdraw/stg-withdraw-input.tsx
+++ b/features/earn/vault-stg/withdraw/stg-withdraw-input.tsx
@@ -13,7 +13,7 @@ export const STGWithdrawInput: React.FC = () => {
   const { disabled } = useFormState();
 
   return (
-    <InputGroupHookForm errorField="amount" bottomSpacing={false}>
+    <InputGroupHookForm errorField="amount" bottomSpacing={0}>
       <TokenAmountInputHookForm
         leftDecorator={<TokenStrethIcon width={24} height={24} />}
         disabled={disabled}

--- a/features/earn/vault-usd/deposit/deposit-input-group.tsx
+++ b/features/earn/vault-usd/deposit/deposit-input-group.tsx
@@ -1,6 +1,6 @@
 import { useFormState, useWatch } from 'react-hook-form';
 
-import { InputGroupHookForm } from 'shared/hook-form/controls/input-group-hook-form';
+import { VaultInputGroupHookForm } from 'features/earn/shared/vault-input-group-hook-form';
 import { TokenAmountInputHookForm } from 'shared/hook-form/controls/token-amount-input-hook-form';
 import { TokenSelectHookForm } from 'shared/hook-form/controls/token-select-hook-form/token-select-hook-form';
 import { UsdDepositToken } from 'features/earn/vault-usd/types';
@@ -39,7 +39,7 @@ export const UsdVaultDepositInputGroup = () => {
   const { disabled } = useFormState();
 
   return (
-    <InputGroupHookForm errorField="amount" bottomSpacing={false}>
+    <VaultInputGroupHookForm errorField="amount">
       <TokenSelectHookForm
         errorField="amount"
         fieldName="token"
@@ -59,6 +59,6 @@ export const UsdVaultDepositInputGroup = () => {
           trackMatomoEvent(MATOMO_EARN_EVENTS_TYPES.earnUsdDepositMax);
         }}
       />
-    </InputGroupHookForm>
+    </VaultInputGroupHookForm>
   );
 };

--- a/features/earn/vault-usd/deposit/deposit-will-receive.tsx
+++ b/features/earn/vault-usd/deposit/deposit-will-receive.tsx
@@ -21,9 +21,9 @@ export const UsdVaultDepositWillReceive = () => {
       icon={<TokenEarnUsdIcon width={16} height={16} />}
       amount={data.shares}
       symbol={USD_VAULT_TOKEN_SYMBOL}
-      // TODO: show USD amount, check where to get conversion rate for earnETH
+      // TODO: show USD amount, check where to get conversion rate for earnUSD
       // usdAmount={data.usd}
-      fallbackSecondaryValue="" // remove when usdAmount is added
+      showSecondaryValue={false} // remove when usdAmount is added
       isLoading={isLoading}
       help={
         <>

--- a/features/earn/vault-usd/deposit/form-context/validation.ts
+++ b/features/earn/vault-usd/deposit/form-context/validation.ts
@@ -1,5 +1,5 @@
 import type { Resolver } from 'react-hook-form';
-import { formatUnits, maxUint256 } from 'viem';
+import { maxUint256 } from 'viem';
 import invariant from 'tiny-invariant';
 import type {
   USDDepositFormValidationContext,
@@ -29,8 +29,8 @@ const validateUsdAmount: (
     throw new ValidationError(field, `${token} ${field} is not valid`);
 };
 
-const messageMaxBalance = (max: bigint, token: string) =>
-  `Entered ${token} amount exceeds your available balance of ${formatUnits(max, 6)}`;
+const messageMaxBalance = (_max: bigint, token: string) =>
+  `Insufficient ${token} balance`;
 
 export const UsdVaultDepositFormValidationResolver: Resolver<
   USDDepositFormValues,

--- a/features/earn/vault-usd/withdraw/form-context/validation.ts
+++ b/features/earn/vault-usd/withdraw/form-context/validation.ts
@@ -1,5 +1,5 @@
 import type { Resolver } from 'react-hook-form';
-import { formatUnits, maxUint256 } from 'viem';
+import { maxUint256 } from 'viem';
 import invariant from 'tiny-invariant';
 
 import { VALIDATION_CONTEXT_TIMEOUT } from 'features/withdrawals/withdrawals-constants';
@@ -28,8 +28,8 @@ const validateUsdAmount: (
     throw new ValidationError(field, `${token} ${field} is not valid`);
 };
 
-const messageMaxBalance = (max: bigint, token: string) =>
-  `Entered ${token} amount exceeds your available balance of ${formatUnits(max, 18)}`;
+const messageMaxBalance = (_max: bigint, token: string) =>
+  `Insufficient ${token} balance`;
 
 export const UsdVaultWithdrawFormValidationResolver: Resolver<
   UsdVaultWithdrawFormValues,

--- a/features/earn/vault-usd/withdraw/withdraw-input.tsx
+++ b/features/earn/vault-usd/withdraw/withdraw-input.tsx
@@ -1,6 +1,6 @@
 import { useFormState } from 'react-hook-form';
 
-import { InputGroupHookForm } from 'shared/hook-form/controls/input-group-hook-form';
+import { VaultInputGroupHookForm } from 'features/earn/shared/vault-input-group-hook-form';
 import { TokenAmountInputHookForm } from 'shared/hook-form/controls/token-amount-input-hook-form';
 import { TokenEarnUsdIcon } from 'assets/earn-v2';
 import { trackMatomoEvent } from 'utils/track-matomo-event';
@@ -14,7 +14,7 @@ export const UsdVaultWithdrawInput: React.FC = () => {
   const { disabled } = useFormState();
 
   return (
-    <InputGroupHookForm errorField="amount" bottomSpacing={false}>
+    <VaultInputGroupHookForm errorField="amount">
       <TokenAmountInputHookForm
         leftDecorator={<TokenEarnUsdIcon width={24} height={24} />}
         disabled={disabled}
@@ -27,6 +27,6 @@ export const UsdVaultWithdrawInput: React.FC = () => {
           trackMatomoEvent(MATOMO_EARN_EVENTS_TYPES.earnUsdWithdrawalMax);
         }}
       />
-    </InputGroupHookForm>
+    </VaultInputGroupHookForm>
   );
 };

--- a/features/earn/vault-usd/withdraw/withdraw-will-receive.tsx
+++ b/features/earn/vault-usd/withdraw/withdraw-will-receive.tsx
@@ -17,7 +17,7 @@ export const UsdVaultWithdrawWillReceive = () => {
       icon={<TokenUsdcIcon width={16} height={16} />}
       amount={usdc}
       symbol={getTokenSymbol(TOKENS.usdc)}
-      fallbackSecondaryValue="" // TODO: remove if usdAmount is added
+      showSecondaryValue={false}
       isLoading={isLoading}
       help={
         <>

--- a/shared/hook-form/controls/input-group-hook-form.tsx
+++ b/shared/hook-form/controls/input-group-hook-form.tsx
@@ -7,7 +7,7 @@ type InputGroupProps = React.ComponentProps<typeof InputGroup>;
 
 type InputGroupStyleProps = {
   success?: InputGroupProps['success'];
-  bottomSpacing?: boolean;
+  bottomSpacing?: number;
 };
 
 type InputGroupHookFormProps = InputGroupProps &
@@ -17,7 +17,7 @@ type InputGroupHookFormProps = InputGroupProps &
 
 const InputGroupStyled = styled(InputGroup)<InputGroupStyleProps>`
   margin-bottom: ${({ theme, bottomSpacing }) =>
-    bottomSpacing ? theme.spaceMap.md : 0}px;
+    bottomSpacing ?? theme.spaceMap.md}px;
   z-index: 2;
   span:nth-of-type(2) {
     white-space: unset;
@@ -26,7 +26,7 @@ const InputGroupStyled = styled(InputGroup)<InputGroupStyleProps>`
 
 export const InputGroupHookForm: React.FC<InputGroupHookFormProps> = ({
   errorField,
-  bottomSpacing = true,
+  bottomSpacing,
   ...props
 }) => {
   const { errors } = useFormState<Record<string, unknown>>({


### PR DESCRIPTION
### Description

- Input group bottom spacing is now a pixel value instead of a boolean toggle, making it explicit and flexible
- Earn vault forms now consistently reserve space for the validation error banner below the input, so the layout doesn't jump when an error appears or disappears
- The form gap is now configurable per vault, with a shared default. All existing vaults preserve their current appearance
- Submit buttons across all vault forms now maintain a consistent 20px visual distance from the element above them, automatically accounting for the form's gap — no need to hardcode or manually track spacing values

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
