### PR TITLE
14d TWA for Earn performance tab

### DIFF
--- a/features/earn/shared/v2/vault-chart/apy-data/metavault-apy.ts
+++ b/features/earn/shared/v2/vault-chart/apy-data/metavault-apy.ts
@@ -56,17 +56,23 @@ export const fetchMetavaultCurrentData = async (vaultAddress: string) => {
 };
 
 export const fetchMetavaultChartData = async (
-  fromTimestamp: number,
   vaultAddress: string,
+  fromTimestamp: number,
+  days = 14, // 14 days is considered as an industry standard
 ) => {
   const timestamp =
     fromTimestamp < TIMESTAMP_LAUNCH_DATE
       ? TIMESTAMP_LAUNCH_DATE
       : fromTimestamp;
-  const METAVAULT_CHART_ENDPOINT = `${METAVAULT_CHART_ORIGIN}/v1/chain/${CHAINS.Mainnet}/core-vaults/${vaultAddress}/historical-data?from_timestamp=${timestamp}`;
 
-  const data = await standardFetcher<MetavaultChartFetchedData>(
-    METAVAULT_CHART_ENDPOINT,
-  );
+  let chartDataEndpoint = `${METAVAULT_CHART_ORIGIN}/v1/chain/${CHAINS.Mainnet}/core-vaults/${vaultAddress}/historical-data?from_timestamp=${timestamp}`;
+
+  // `days` param switches the endpoint from simple moving average (volatile, legacy) to time-weighted average APY
+  if (days > 0) {
+    chartDataEndpoint += `&days=${days}`;
+  }
+
+  const data =
+    await standardFetcher<MetavaultChartFetchedData>(chartDataEndpoint);
   return METAVAULT_CHART_DATA_SCHEMA.parse(data);
 };

--- a/features/earn/shared/v2/vault-chart/apy-data/metavault-apy.ts
+++ b/features/earn/shared/v2/vault-chart/apy-data/metavault-apy.ts
@@ -65,14 +65,20 @@ export const fetchMetavaultChartData = async (
       ? TIMESTAMP_LAUNCH_DATE
       : fromTimestamp;
 
-  let chartDataEndpoint = `${METAVAULT_CHART_ORIGIN}/v1/chain/${CHAINS.Mainnet}/core-vaults/${vaultAddress}/historical-data?from_timestamp=${timestamp}`;
+  const url = new URL(
+    `${METAVAULT_CHART_ORIGIN}/v1/chain/${CHAINS.Mainnet}/core-vaults/${vaultAddress}/historical-data`,
+  );
+  url.searchParams.set('from_timestamp', String(timestamp));
 
   // `days` param switches the endpoint from simple moving average (volatile, legacy) to time-weighted average APY
   if (days > 0) {
-    chartDataEndpoint += `&days=${days}`;
+    url.searchParams.set('days', String(days));
   }
 
-  const data =
-    await standardFetcher<MetavaultChartFetchedData>(chartDataEndpoint);
+  const METAVAULT_CHART_DATA_ENDPOINT = url.toString();
+
+  const data = await standardFetcher<MetavaultChartFetchedData>(
+    METAVAULT_CHART_DATA_ENDPOINT,
+  );
   return METAVAULT_CHART_DATA_SCHEMA.parse(data);
 };

--- a/features/earn/shared/v2/vault-chart/hooks/use-vault-chart-data.ts
+++ b/features/earn/shared/v2/vault-chart/hooks/use-vault-chart-data.ts
@@ -48,7 +48,7 @@ export const useMetavaultChartData = ({
     queryFn: async () => {
       if (!vaultAddress) return null;
 
-      return fetchMetavaultChartData(fromTimestamp, vaultAddress);
+      return fetchMetavaultChartData(vaultAddress, fromTimestamp);
     },
     enabled: !!vaultAddress,
   });


### PR DESCRIPTION
### Description

Switches EarnUSD and EarnETH to 14d TWA for Earn performance tab chart.

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
