### PR TITLE
Fix(earn): deposit-submit-button - check claimableRequests

### DIFF
--- a/features/earn/vault-eth/deposit/deposit-submit-button/deposit-submit-button.tsx
+++ b/features/earn/vault-eth/deposit/deposit-submit-button/deposit-submit-button.tsx
@@ -7,7 +7,7 @@ import { useEthVaultDepositRequests } from '../hooks';
 export const EthVaultDepositSubmitButton = () => {
   const { isDepositLockedForCurrentToken, token } = useETHDepositForm();
   // stETH deposits go through the wstETH queue, so check wstETH for claimable request state
-  const depositRequests = useEthVaultDepositRequests();
+  const { claimableRequests } = useEthVaultDepositRequests();
   const { isEthVaultAvailable } = useEthVaultAvailable();
 
   // stETH is wrapped into wstETH on deposit, so clarify that in the tooltip
@@ -21,7 +21,7 @@ export const EthVaultDepositSubmitButton = () => {
       isVaultAvailable={isEthVaultAvailable}
       isDepositLockedForCurrentToken={isDepositLockedForCurrentToken}
       tokenDisplayName={tokenDisplayName}
-      isClaimable={depositRequests?.claimableRequests.length > 0}
+      isClaimable={claimableRequests.length > 0}
     />
   );
 };

--- a/features/earn/vault-usd/deposit/deposit-submit-button/deposit-submit-button.tsx
+++ b/features/earn/vault-usd/deposit/deposit-submit-button/deposit-submit-button.tsx
@@ -1,15 +1,12 @@
-import { asToken } from 'utils/as-token';
 import { VaultDepositSubmitButton } from 'features/earn/shared/v2/vault-deposit-submit-button';
 import { useUsdVaultAvailable } from '../../hooks/use-vault-available';
 import { useUSDDepositForm } from '../form-context';
-import { useUsdVaultDepositRequest } from '../hooks';
+import { useUsdVaultDepositRequests } from '../hooks';
 
 export const UsdVaultDepositSubmitButton = () => {
   const { isDepositLockedForCurrentToken, token: tokenSymbol } =
     useUSDDepositForm();
-  const depositRequest = useUsdVaultDepositRequest({
-    token: asToken(tokenSymbol),
-  });
+  const { claimableRequests } = useUsdVaultDepositRequests();
   const { isUsdVaultAvailable } = useUsdVaultAvailable();
 
   return (
@@ -17,7 +14,7 @@ export const UsdVaultDepositSubmitButton = () => {
       isVaultAvailable={isUsdVaultAvailable}
       isDepositLockedForCurrentToken={isDepositLockedForCurrentToken}
       tokenDisplayName={tokenSymbol}
-      isClaimable={depositRequest?.isClaimable ?? false}
+      isClaimable={claimableRequests.length > 0}
     />
   );
 };


### PR DESCRIPTION
### Description

If a user has claimable requests in async deposit queues, use "Claim and Deposit" text on the submit button even for sync deposit queues.

### Checklist:

- [ ] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
