### PR TITLE
fix: wrap l2 form state

### DIFF
--- a/features/dex-withdrawals/cowswap/validate-tx/utils.ts
+++ b/features/dex-withdrawals/cowswap/validate-tx/utils.ts
@@ -19,7 +19,10 @@ import { getTokenAddress } from 'config/networks/token-address';
 import mainnetNetwork from 'networks/mainnet.json';
 import sepoliaNetwork from 'networks/sepolia.json';
 
+type ContactsMap = typeof mainnetNetwork.contracts;
+
 import { LIDO_APP_CODE, MAX_SLIPPAGE, PARTNER_FEE_BPS } from '../consts';
+import invariant from 'tiny-invariant';
 
 // ---- Contract addresses from network configs ----
 
@@ -29,9 +32,7 @@ const SELL_TOKEN_KEYS = ['lido', 'wsteth'] as const;
 const BUY_TOKEN_KEYS = ['weth', 'usdc', 'usdt', 'usds', 'wbtc'] as const;
 const DEX_TOKEN_KEYS = [...SELL_TOKEN_KEYS, ...BUY_TOKEN_KEYS] as const;
 
-const collectTokenAddresses = (
-  contracts: Record<string, Address>,
-): Set<Address> => {
+const collectTokenAddresses = (contracts: ContactsMap): Set<Address> => {
   const addresses = new Set<Address>();
   for (const key of DEX_TOKEN_KEYS) {
     const addr = contracts[key];
@@ -40,9 +41,7 @@ const collectTokenAddresses = (
   return addresses;
 };
 
-const collectSellTokenAddresses = (
-  contracts: Record<string, Address>,
-): Set<Address> => {
+const collectSellTokenAddresses = (contracts: ContactsMap): Set<Address> => {
   const addresses = new Set<Address>();
   for (const key of SELL_TOKEN_KEYS) {
     const addr = contracts[key];
@@ -51,18 +50,17 @@ const collectSellTokenAddresses = (
   return addresses;
 };
 
-const collectBuyTokenAddresses = (
-  contracts: Record<string, Address>,
-): Set<Address> => {
+const collectBuyTokenAddresses = (contracts: ContactsMap): Set<Address> => {
   const addresses = new Set<Address>();
   for (const key of BUY_TOKEN_KEYS) {
     const addr = contracts[key];
     if (addr) addresses.add(addr.toLowerCase() as Address);
   }
+
+  const ethAddress = getTokenAddress(1, 'eth');
+  invariant(ethAddress, 'eth address is undefined');
   // 0xeeee...
-  addresses.add(
-    (getTokenAddress(1, 'eth') as Address).toLowerCase() as Address,
-  );
+  addresses.add(ethAddress.toLowerCase() as Address);
   return addresses;
 };
 
@@ -75,9 +73,7 @@ type NetworkTxConfig = {
   feeRecipient: Address;
 };
 
-const buildNetworkTxConfig = (
-  contracts: Record<string, Address>,
-): NetworkTxConfig => ({
+const buildNetworkTxConfig = (contracts: ContactsMap): NetworkTxConfig => ({
   tokens: collectTokenAddresses(contracts),
   sellTokens: collectSellTokenAddresses(contracts),
   buyTokens: collectBuyTokenAddresses(contracts),
@@ -86,11 +82,10 @@ const buildNetworkTxConfig = (
   feeRecipient: contracts.daoAgent.toLowerCase() as Address,
 });
 
-const MAINNET_CONFIG = buildNetworkTxConfig(
-  mainnetNetwork.contracts as Record<string, Address>,
-);
+const MAINNET_CONFIG = buildNetworkTxConfig(mainnetNetwork.contracts);
+// Most tokens are missing on Sepolia, so we only validation is partial and support for this testnet is limited
 const SEPOLIA_CONFIG = buildNetworkTxConfig(
-  sepoliaNetwork.contracts as Record<string, Address>,
+  sepoliaNetwork.contracts as ContactsMap,
 );
 
 // ---- Schemas -----

--- a/features/wsteth/wrap/wrap-form-context/wrap-form-context.tsx
+++ b/features/wsteth/wrap/wrap-form-context/wrap-form-context.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 
+import { useLidoSDKL2 } from 'modules/web3';
 import { useFormControllerRetry } from 'shared/hook-form/form-controller/use-form-controller-retry-delegate';
 import { useQueryParamsReferralForm } from 'shared/hooks/use-query-values-form';
 import {
@@ -50,6 +51,7 @@ export const useWrapFormData = () => {
 // Data provider
 //
 export const WrapFormProvider: FC<PropsWithChildren> = ({ children }) => {
+  const { isL2 } = useLidoSDKL2();
   const networkData = useWrapFormNetworkData();
   const validationContextPromise = useWrapFormValidationContext({
     networkData,
@@ -128,12 +130,12 @@ export const WrapFormProvider: FC<PropsWithChildren> = ({ children }) => {
       onReset: ({ token }: WrapFormInputType) => {
         reset({
           ...defaultValues,
-          token,
+          token: isL2 ? TOKENS_TO_WRAP.stETH : token,
         });
       },
       retryEvent,
     }),
-    [onSubmit, retryEvent, reset, defaultValues],
+    [onSubmit, retryEvent, reset, defaultValues, isL2],
   );
 
   return (

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -57,7 +57,6 @@ export default defineConfig({
     setupFiles: ['./vitest.setup.ts'],
     coverage: {
       provider: 'v8',
-      // Output goes to /coverage, which is already gitignored (# testing).
       reportsDirectory: './coverage',
       reporter: ['text', 'html', 'lcov'],
       // Report only files actually exercised by tests. The suite is sparse, so


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

- fix bug when setting token eth on l1 wrap and switching to l2 breaks form

### Demo

<!--- If thee are visual changes, attach a link to a specific section on preview stand / add screenshots / record a [loom](https://www.loom.com/). -->

### Code review notes

Also fixed some code style

### Testing notes

<!--- List all possible edge cases and how to test them. -->

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
