### PR TITLE
[Earn] Add id-based protocol icon resolution

### DIFF
--- a/features/earn/shared/v2/vault-allocation/hooks/use-allocation-data.ts
+++ b/features/earn/shared/v2/vault-allocation/hooks/use-allocation-data.ts
@@ -304,7 +304,7 @@ const parseNestedGroup = (
       knownItems.push({
         label: sub.label,
         id: sub.id,
-        icon: getAllocationProtocolIcon(sub.protocol),
+        icon: getAllocationProtocolIcon(sub.protocol, sub.id),
         chain: sub.chain,
         allocation: sub.sharePercent,
         tvlUSD: subTvl,
@@ -353,7 +353,7 @@ const parseFlatItems = (
       items.push({
         name: alloc.label,
         chain: alloc.chain,
-        icon: getAllocationProtocolIcon(alloc.protocol),
+        icon: getAllocationProtocolIcon(alloc.protocol, alloc.id),
         allocation: alloc.sharePercent,
         tvlUSD,
       });

--- a/features/earn/shared/vault-allocation/protocol-icon/icon-library.ts
+++ b/features/earn/shared/vault-allocation/protocol-icon/icon-library.ts
@@ -67,8 +67,15 @@ export const ALLOCATION_PROTOCOL_ICONS = createIconLibrary({
 
 export const getAllocationProtocolIcon = (
   protocol?: string,
+  id?: string,
 ): AllocationIcon => {
   const key = protocol?.trim().toLowerCase();
+  const normalizedId = id?.trim().toLowerCase();
+
+  if (key === 'mellow-core-vault' && normalizedId === 'earnusd') {
+    return EarnusdIcon;
+  }
+
   return (
     (key ? getOwnProperty(ALLOCATION_PROTOCOL_ICONS, key) : undefined) ??
     FallbackIcon


### PR DESCRIPTION
### Description

If the Mellow API response contains "protocol": "mellow-core-vault", also check the id field. When "id": "earnusd", show the earnUSD token icon.

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
