### PR TITLE
Earn Allocation – set vault-tip placement to right

### DIFF
--- a/features/earn/shared/v2/vault-allocation/allocation-table/allocation-group-row.tsx
+++ b/features/earn/shared/v2/vault-allocation/allocation-table/allocation-group-row.tsx
@@ -43,7 +43,9 @@ export const AllocationGroupRow: FC<AllocationGroupRowProps> = ({ group }) => {
                 <FormatPercent value={group.allocation} decimals="percent" />
               </ProtocolNamePercent>
               {group.name}
-              {group.info && <VaultTip>{group.info}</VaultTip>}
+              {group.info && (
+                <VaultTip placement="right">{group.info}</VaultTip>
+              )}
             </ProtocolNameStyled>
           </GroupNameStyled>
         </GroupTdStyled>
@@ -66,7 +68,9 @@ export const AllocationGroupRow: FC<AllocationGroupRowProps> = ({ group }) => {
               />
               <ProtocolNameStyled>
                 {item.label}
-                {item.info && <VaultTip>{item.info}</VaultTip>}
+                {item.info && (
+                  <VaultTip placement="right">{item.info}</VaultTip>
+                )}
               </ProtocolNameStyled>
             </NestedTdWithIconStyled>
             <TdNarrowStyled align="right">

--- a/features/earn/shared/v2/vault-allocation/allocation-table/allocation-table.tsx
+++ b/features/earn/shared/v2/vault-allocation/allocation-table/allocation-table.tsx
@@ -65,7 +65,9 @@ export const AllocationTable: FC<AllocationTableV2Props> = ({
                   </ProtocolNamePercent>
                 )}
                 {item.name}
-                {item.info && <VaultTip>{item.info}</VaultTip>}
+                {item.info && (
+                  <VaultTip placement="right">{item.info}</VaultTip>
+                )}
               </ProtocolNameStyled>
             </TdWithIconStyled>
             <TdNarrowStyled align="right"></TdNarrowStyled>


### PR DESCRIPTION
### Demo

<img width="455" height="265" alt="image" src="https://github.com/user-attachments/assets/bfd7a2c0-f874-4dfc-8cf8-c9b7b483751d" />


### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
