### PR TITLE
fix: update references to REMOTE_CONFIG_MANIFEST.json

### DIFF
--- a/consts/external-links.ts
+++ b/consts/external-links.ts
@@ -8,7 +8,6 @@ export const OPEN_OCEAN_REFERRAL_ADDRESS =
 export const GITHUB_RAW_MAIN_PATH =
   'https://raw.githubusercontent.com/lidofinance/ethereum-staking-widget/main';
 
-// TODO: switch to REMOTE_CONFIG_MANIFEST.json once this branch reaches main;
-// until then the new file does not exist on main and the fetch would 404
+// NB: pinned IPFS builds read IPFS.json from main indefinitely — keep both files in sync
 export const REMOTE_CONFIG_MANIFEST_URL =
   GITHUB_RAW_MAIN_PATH + '/REMOTE_CONFIG_MANIFEST.json';

--- a/consts/external-links.ts
+++ b/consts/external-links.ts
@@ -10,4 +10,5 @@ export const GITHUB_RAW_MAIN_PATH =
 
 // TODO: switch to REMOTE_CONFIG_MANIFEST.json once this branch reaches main;
 // until then the new file does not exist on main and the fetch would 404
-export const REMOTE_CONFIG_MANIFEST_URL = GITHUB_RAW_MAIN_PATH + '/IPFS.json';
+export const REMOTE_CONFIG_MANIFEST_URL =
+  GITHUB_RAW_MAIN_PATH + '/REMOTE_CONFIG_MANIFEST.json';

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,7 +61,7 @@ Account Abstraction (safe-global, ERC-4337) supported via reef-knot.
 
 - `config/feature-flags/` — flag definitions
 - External config loaded from IPFS/CDN at runtime
-- `ipfs.json` — static per-chain overrides
+- `REMOTE_CONFIG_MANIFEST.json` — static per-chain overrides
 - Flags can disable entire pages
 
 ### IPFS mode

--- a/docs/config.md
+++ b/docs/config.md
@@ -76,7 +76,7 @@ CONFIG_MANIFEST_PATH=...      # Path to a mounted config manifest file (e.g. k8s
                               # The file is public: never put deployment-private data in it.
 ```
 
-## ipfs.json
+## REMOTE_CONFIG_MANIFEST.json
 
 Static config for IPFS deployment:
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -22,7 +22,7 @@ Project based on Next.js 12. Deployed as a web application and/or on IPFS.
 - `networks/*.json` — contract addresses per network (mainnet, sepolia, holesky)
 - `abi/` — smart contract ABIs
 - `utilsApi/` — server-side utilities for API routes
-- `ipfs.json` — IPFS deployment config (feature flags per chain, vault configs, CIDs)
+- `REMOTE_CONFIG_MANIFEST.json` — REMOTE_CONFIG_MANIFEST deployment config (feature flags per chain, vault configs, CIDs)
 
 ## Detailed docs
 

--- a/scripts/startup-checks/rpc.mjs
+++ b/scripts/startup-checks/rpc.mjs
@@ -94,7 +94,10 @@ export const startupCheckRPCs = async () => {
       return results;
     } catch (err) {
       console.error('[startupCheckRPCs] Error during RPC checks:', err);
-      return null;
+      // Exit process to prevent start with a broken RPC config, same as the other startup checks
+      process.exit(1);
     }
   })();
+
+  return globalStartupRPCChecks.promise;
 };

--- a/server.mjs
+++ b/server.mjs
@@ -1,6 +1,9 @@
 import { createServer } from 'http';
 import { parse } from 'url';
 import next from 'next';
+import { getRPCChecks } from './scripts/startup-checks/rpc.mjs';
+import { getValidationFileChecks } from './scripts/startup-checks/validation-file.mjs';
+import { getManifestFileChecks } from './scripts/startup-checks/config-manifest.mjs';
 const dev = process.env.NODE_ENV !== 'production';
 const hostname = 'localhost';
 const port = Number(process.env.PORT) || 3000;
@@ -30,7 +33,17 @@ const overrideSetHeader = (res) => {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
-app.prepare().then(() => {
+app.prepare().then(async () => {
+  // checks are kicked off in next.config.mjs; a broken config must exit here,
+  // before listen, so the pod never passes readiness
+  if (process.env.RUN_STARTUP_CHECKS === 'true') {
+    await Promise.all([
+      getRPCChecks(),
+      getValidationFileChecks(),
+      getManifestFileChecks(),
+    ]);
+  }
+
   const server = createServer(async (req, res) => {
     // Be sure to pass `true` as the second argument to `url.parse`.
     // This tells it to parse the query portion of the URL.

--- a/utilsApi/__tests__/fetch-external-manifest.test.ts
+++ b/utilsApi/__tests__/fetch-external-manifest.test.ts
@@ -68,7 +68,8 @@ describe('fetchExternalManifest with CONFIG_MANIFEST_PATH', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.CONFIG_MANIFEST_PATH = '/app/runtime-config/IPFS.json';
+    process.env.CONFIG_MANIFEST_PATH =
+      '/app/runtime-config/REMOTE_CONFIG_MANIFEST.json';
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
   });
@@ -86,7 +87,7 @@ describe('fetchExternalManifest with CONFIG_MANIFEST_PATH', () => {
     const { ___prefetch_manifest___ } = await fetchExternalManifest();
 
     expect(readFileMock).toHaveBeenCalledWith(
-      '/app/runtime-config/IPFS.json',
+      '/app/runtime-config/REMOTE_CONFIG_MANIFEST.json',
       'utf-8',
     );
     expect(standardFetcherMock).not.toHaveBeenCalled();
@@ -190,7 +191,9 @@ describe('fetchExternalManifest with CONFIG_MANIFEST_PATH', () => {
 
     expect(infoSpy).toHaveBeenCalledTimes(2);
     expect(infoSpy).toHaveBeenCalledWith(
-      expect.stringContaining('/app/runtime-config/IPFS.json'),
+      expect.stringContaining(
+        '/app/runtime-config/REMOTE_CONFIG_MANIFEST.json',
+      ),
     );
   });
 


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

**Manifest file renaming and usage:**

* Updated the runtime external config manifest filename from `IPFS.json` to `REMOTE_CONFIG_MANIFEST.json` in the main code (`consts/external-links.ts`).
* Updated all references in tests to use the new manifest filename, including environment variable values and file read expectations (`utilsApi/__tests__/fetch-external-manifest.test.ts`). [[1]](diffhunk://#diff-53747efe177237059251f6e412aeaf6dadcecf4fa9b54e4666814556720b27f9L71-R72) [[2]](diffhunk://#diff-53747efe177237059251f6e412aeaf6dadcecf4fa9b54e4666814556720b27f9L89-R90) [[3]](diffhunk://#diff-53747efe177237059251f6e412aeaf6dadcecf4fa9b54e4666814556720b27f9L193-R196)

**Documentation updates:**

* Changed references in architecture, config, and overview documentation to use `REMOTE_CONFIG_MANIFEST.json` instead of `ipfs.json` (`docs/architecture.md`, `docs/config.md`, `docs/overview.md`). [[1]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L64-R64) [[2]](diffhunk://#diff-77b3519370ff48f6caf7c316f0ece966f2f0871c40e9381d451d2c5b1c76b40fL79-R79) [[3]](diffhunk://#diff-f23678b4c439fd130355644fa4c36770a302e257cc841883c4c11d74918e6e32L25-R25)

### Demo

<!--- If thee are visual changes, attach a link to a specific section on preview stand / add screenshots / record a [loom](https://www.loom.com/). -->

### Code review notes

<!--- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

<!--- List all possible edge cases and how to test them. -->

### Checklist:

- [ ] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
