### PR TITLE
feat: add app shutdown by signals or secrets rotation

### DIFF
--- a/scripts/__tests__/shutdown.test.ts
+++ b/scripts/__tests__/shutdown.test.ts
@@ -1,0 +1,251 @@
+import { mkdtempSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { registerSecretsRotationRestart } from '../shutdown.mjs';
+
+const CONTENT_V1 = 'export PROVIDER_URL="v1"\n';
+const CONTENT_V2 = 'export PROVIDER_URL="v2"\n';
+
+const WATCH_INTERVAL_MS = 20;
+
+// fs.watchFile uses real stat polling. Give it time to take its initial
+// snapshot before changing the file, otherwise the first update can be missed.
+const waitForWatchToStart = async (): Promise<void> => {
+  await new Promise((resolve) => {
+    setTimeout(resolve, WATCH_INTERVAL_MS * 2);
+  });
+};
+
+const waitFor = async (
+  assertion: () => void,
+  timeoutMs = 3_000,
+): Promise<void> => {
+  const deadline = Date.now() + timeoutMs;
+
+  for (;;) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      if (Date.now() > deadline) {
+        throw error;
+      }
+
+      await new Promise((resolve) => {
+        setTimeout(resolve, 25);
+      });
+    }
+  }
+};
+
+// Mirror the OpenBao agent's atomic update: replace the file with a new inode.
+const atomicWrite = (path: string, content: string): void => {
+  const tmp = `${path}.tmp`;
+
+  writeFileSync(tmp, content);
+  renameSync(tmp, path);
+};
+
+type CloseCallback = (error?: Error) => void;
+
+type TestServer = {
+  close: (callback: CloseCallback) => void;
+};
+
+// type SignalHandler = () => void;
+
+describe('registerSecretsRotationRestart', () => {
+  let dir: string;
+  let file: string;
+  let stopWatch: (() => void) | null = null;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'secrets-rotation-'));
+    file = join(dir, 'app');
+    process.env.SECRETS_FILE = file;
+
+    vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    stopWatch?.();
+    stopWatch = null;
+
+    rmSync(dir, {
+      recursive: true,
+      force: true,
+    });
+
+    delete process.env.SECRETS_FILE;
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('is a no-op when the default secrets file is absent', () => {
+    delete process.env.SECRETS_FILE;
+
+    const server: TestServer = {
+      close: vi.fn(),
+    };
+
+    stopWatch = registerSecretsRotationRestart(server, {
+      intervalMs: WATCH_INTERVAL_MS,
+    });
+
+    expect(server.close).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
+  });
+
+  it('throws when SECRETS_FILE is explicitly set but unreadable', () => {
+    process.env.SECRETS_FILE = join(dir, 'missing');
+
+    const server: TestServer = {
+      close: vi.fn(),
+    };
+
+    expect(() => {
+      registerSecretsRotationRestart(server);
+    }).toThrow();
+  });
+
+  it('closes the server and exits 0 after an atomic content change', async () => {
+    writeFileSync(file, CONTENT_V1);
+
+    const exit = vi.fn();
+
+    const server: TestServer = {
+      close: vi.fn((callback: CloseCallback) => {
+        callback();
+      }),
+    };
+
+    stopWatch = registerSecretsRotationRestart(server, {
+      intervalMs: WATCH_INTERVAL_MS,
+      exit,
+    });
+
+    await waitForWatchToStart();
+    atomicWrite(file, CONTENT_V2);
+
+    await waitFor(() => {
+      expect(exit).toHaveBeenCalledWith(0);
+    });
+
+    expect(server.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('still exits 0 when server.close reports an error', async () => {
+    writeFileSync(file, CONTENT_V1);
+
+    const exit = vi.fn();
+
+    const server: TestServer = {
+      close: vi.fn((callback: CloseCallback) => {
+        callback(new Error('close failed'));
+      }),
+    };
+
+    stopWatch = registerSecretsRotationRestart(server, {
+      intervalMs: WATCH_INTERVAL_MS,
+      exit,
+    });
+
+    await waitForWatchToStart();
+    atomicWrite(file, CONTENT_V2);
+
+    await waitFor(() => {
+      expect(exit).toHaveBeenCalledWith(0);
+    });
+
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('force-exits when server.close hangs', async () => {
+    writeFileSync(file, CONTENT_V1);
+
+    const exit = vi.fn();
+
+    const server: TestServer = {
+      close: vi.fn(() => undefined),
+    };
+
+    stopWatch = registerSecretsRotationRestart(server, {
+      intervalMs: WATCH_INTERVAL_MS,
+      forceExitMs: 50,
+      exit,
+    });
+
+    await waitForWatchToStart();
+    atomicWrite(file, CONTENT_V2);
+
+    await waitFor(() => {
+      expect(exit).toHaveBeenCalledWith(0);
+    });
+
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('does not restart when the file is replaced with identical content', async () => {
+    writeFileSync(file, CONTENT_V1);
+
+    const exit = vi.fn();
+
+    const server: TestServer = {
+      close: vi.fn(),
+    };
+
+    stopWatch = registerSecretsRotationRestart(server, {
+      intervalMs: WATCH_INTERVAL_MS,
+      exit,
+    });
+
+    await waitForWatchToStart();
+    atomicWrite(file, CONTENT_V1);
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 250);
+    });
+
+    expect(server.close).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  it('survives a delete and recreate window', async () => {
+    writeFileSync(file, CONTENT_V1);
+
+    const exit = vi.fn();
+
+    const server: TestServer = {
+      close: vi.fn((callback: CloseCallback) => {
+        callback();
+      }),
+    };
+
+    stopWatch = registerSecretsRotationRestart(server, {
+      intervalMs: WATCH_INTERVAL_MS,
+      exit,
+    });
+
+    await waitForWatchToStart();
+
+    rmSync(file);
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 100);
+    });
+
+    expect(exit).not.toHaveBeenCalled();
+
+    writeFileSync(file, CONTENT_V2);
+
+    await waitFor(() => {
+      expect(exit).toHaveBeenCalledWith(0);
+    });
+
+    expect(server.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/scripts/shutdown.mjs
+++ b/scripts/shutdown.mjs
@@ -53,12 +53,18 @@ const closeServerAndExit = ({ server, reason, forceExitMs, exit }) => {
  * default path = no injector (local dev) → no-op; SECRETS_FILE set but
  * unreadable = broken deployment → throw. Returns a stop function (tests).
  */
+/**
+ * @param {{ close: (callback: (error?: Error) => void) => void }} server
+ * @param {SecretsRotationOptions} [options]
+ */
 export const registerSecretsRotationRestart = (
   server,
   {
     intervalMs = POLL_INTERVAL_MS,
     forceExitMs = FORCE_EXIT_TIMEOUT_MS,
-    exit = (code) => process.exit(code),
+    exit = (code) => {
+      process.exit(code);
+    },
   } = {},
 ) => {
   const path = process.env.SECRETS_FILE ?? DEFAULT_SECRETS_FILE;
@@ -111,11 +117,17 @@ export const registerSecretsRotationRestart = (
 
 // SIGTERM and SIGINT are normal process shutdown signals from the
 // orchestrator or terminal. Close the HTTP server before exiting.
+/**
+ * @param {{ close: (callback: (error?: Error) => void) => void }} server
+ * @param {ShutdownOptions} [options]
+ */
 export const registerShutdownSignals = (
   server,
   {
     forceExitMs = FORCE_EXIT_TIMEOUT_MS,
-    exit = (code) => process.exit(code),
+    exit = (code) => {
+      process.exit(code);
+    },
   } = {},
 ) => {
   let shuttingDown = false;

--- a/scripts/shutdown.mjs
+++ b/scripts/shutdown.mjs
@@ -5,6 +5,8 @@ const FORCE_EXIT_TIMEOUT_MS = 10_000;
 const DEFAULT_SECRETS_FILE = '/vault/secrets/app';
 const POLL_INTERVAL_MS = 10_000;
 
+const noop = () => undefined;
+
 const closeServerAndExit = ({ server, reason, forceExitMs, exit }) => {
   let exited = false;
 
@@ -83,7 +85,7 @@ export const registerSecretsRotationRestart = (
     lastContent = readFileSync(path, 'utf8');
   } catch (error) {
     if (process.env.SECRETS_FILE) throw error;
-    return () => undefined;
+    return noop;
   }
 
   console.info(`Watching secrets file ${path} for rotation`);

--- a/scripts/shutdown.mjs
+++ b/scripts/shutdown.mjs
@@ -40,6 +40,15 @@ const closeServerAndExit = ({ server, reason, forceExitMs, exit }) => {
 };
 
 /**
+ * Options for secrets rotation restart.
+ *
+ * @typedef {Object} SecretsRotationOptions
+ * @property {number} [intervalMs] File polling interval in milliseconds.
+ * @property {number} [forceExitMs] Maximum time allowed for graceful shutdown.
+ * @property {(code: number) => void} [exit] Process exit function. Injected in tests.
+ */
+
+/**
  * OpenBao rotation restart. Secrets arrive as an env-export file that the
  * chart's container command sources before exec; the agent sidecar keeps it
  * fresh via atomic rename but has no signal path into this container (no

--- a/scripts/shutdown.mjs
+++ b/scripts/shutdown.mjs
@@ -1,0 +1,137 @@
+import { readFileSync, unwatchFile, watchFile } from 'node:fs';
+import { sanitizeError } from './utils/sanitize-error.mjs';
+
+const FORCE_EXIT_TIMEOUT_MS = 10_000;
+const DEFAULT_SECRETS_FILE = '/vault/secrets/app';
+const POLL_INTERVAL_MS = 10_000;
+
+const closeServerAndExit = ({ server, reason, forceExitMs, exit }) => {
+  let exited = false;
+
+  const exitOnce = (code) => {
+    if (exited) return;
+    exited = true;
+    exit(code);
+  };
+
+  console.info(reason);
+
+  const forceExitTimer = setTimeout(() => {
+    console.error(`Graceful close timed out after ${forceExitMs}ms, forcing exit`);
+    exitOnce(0);
+  }, forceExitMs);
+  forceExitTimer.unref();
+
+  try {
+    server.close((error) => {
+      clearTimeout(forceExitTimer);
+
+      if (error) {
+        console.error('Graceful server close failed', sanitizeError(error));
+      }
+
+      exitOnce(0);
+    });
+  } catch (error) {
+    clearTimeout(forceExitTimer);
+    console.error('Graceful server close failed', sanitizeError(error));
+    exitOnce(0);
+  }
+};
+
+/**
+ * OpenBao rotation restart. Secrets arrive as an env-export file that the
+ * chart's container command sources before exec; the agent sidecar keeps it
+ * fresh via atomic rename but has no signal path into this container (no
+ * shared PID namespace), so the app must detect rotation itself: poll the file
+ * BY PATH (fs.watchFile — inotify would attach to the old inode and go silent
+ * after the first rename) and restart-by-exit on a content change: close the
+ * app gracefully and exit 0; `restartPolicy: Always` brings it back up and
+ * the startup command re-sources the refreshed file.
+ *
+ * Path from SECRETS_FILE, default /vault/secrets/app. File absent at the
+ * default path = no injector (local dev) → no-op; SECRETS_FILE set but
+ * unreadable = broken deployment → throw. Returns a stop function (tests).
+ */
+export const registerSecretsRotationRestart = (
+  server,
+  {
+    intervalMs = POLL_INTERVAL_MS,
+    forceExitMs = FORCE_EXIT_TIMEOUT_MS,
+    exit = (code) => process.exit(code),
+  } = {},
+) => {
+  const path = process.env.SECRETS_FILE ?? DEFAULT_SECRETS_FILE;
+
+  let lastContent;
+  try {
+    lastContent = readFileSync(path, 'utf8');
+  } catch (error) {
+    if (process.env.SECRETS_FILE) throw error;
+    return () => undefined;
+  }
+
+  console.info(`Watching secrets file ${path} for rotation`);
+
+  let restarting = false;
+  const restart = () => {
+    if (restarting) return;
+    restarting = true;
+
+    closeServerAndExit({
+      server,
+      reason: 'Secrets file changed: rotated credentials, restarting to pick up new values',
+      forceExitMs,
+      exit,
+    });
+  };
+
+  const listener = () => {
+    let raw;
+    try {
+      raw = readFileSync(path, 'utf8');
+    } catch (error) {
+      // Transient (sidecar restart / delete+recreate window): retry ourselves —
+      // watchFile won't re-fire for a stat it has already seen, so a failed read
+      // here would otherwise strand the process on stale creds until the NEXT
+      // rotation.
+      console.warn(`Secrets file ${path} unreadable, retrying`, sanitizeError(error));
+      setTimeout(listener, Math.min(intervalMs, 5_000)).unref();
+      return;
+    }
+
+    if (raw === lastContent) return;
+    lastContent = raw;
+    restart();
+  };
+
+  watchFile(path, { interval: intervalMs }, listener).unref();
+  return () => unwatchFile(path, listener);
+};
+
+// SIGTERM and SIGINT are normal process shutdown signals from the
+// orchestrator or terminal. Close the HTTP server before exiting.
+export const registerShutdownSignals = (
+  server,
+  {
+    forceExitMs = FORCE_EXIT_TIMEOUT_MS,
+    exit = (code) => process.exit(code),
+  } = {},
+) => {
+  let shuttingDown = false;
+
+  const shutdown = (signal) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+
+    closeServerAndExit({
+      server,
+      reason: `Received ${signal}: shutting down`,
+      forceExitMs,
+      exit,
+    });
+  };
+
+  process.once('SIGTERM', () => shutdown('SIGTERM'));
+  process.once('SIGINT', () => shutdown('SIGINT'));
+};

--- a/scripts/utils/sanitize-error.mjs
+++ b/scripts/utils/sanitize-error.mjs
@@ -1,0 +1,15 @@
+export const sanitizeError = (error) => {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    };
+  }
+
+  if (typeof error === 'string') {
+    return { name: 'NonError', message: error };
+  }
+
+  return { name: 'NonError', message: `Unexpected thrown value: ${typeof error}` };
+};

--- a/server.mjs
+++ b/server.mjs
@@ -4,6 +4,11 @@ import next from 'next';
 import { getRPCChecks } from './scripts/startup-checks/rpc.mjs';
 import { getValidationFileChecks } from './scripts/startup-checks/validation-file.mjs';
 import { getManifestFileChecks } from './scripts/startup-checks/config-manifest.mjs';
+import {
+  registerSecretsRotationRestart,
+  registerShutdownSignals,
+} from './scripts/shutdown.mjs';
+
 const dev = process.env.NODE_ENV !== 'production';
 const hostname = 'localhost';
 const port = Number(process.env.PORT) || 3000;
@@ -64,4 +69,8 @@ app.prepare().then(async () => {
   server.headersTimeout = 10_000;
   server.requestTimeout = 30_000;
   server.maxHeadersCount = 50;
+
+  // OpenBao secret-rotation
+  registerShutdownSignals(server);
+  registerSecretsRotationRestart(server);
 });


### PR DESCRIPTION
### Description

Adds application restart when OpenBao secrets are rotated.

The app watches the injected secrets file for content changes, gracefully shuts down, and exits so Kubernetes can restart the container with the updated environment variables.

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
