### PR TITLE
fix(earn): lido's terms of use link

### DIFF
--- a/features/earn/vault-eth/vault-page.tsx
+++ b/features/earn/vault-eth/vault-page.tsx
@@ -126,7 +126,7 @@ const RISK_DISCLOSURE = (
       Privacy Notice
     </Link>
     ,{' '}
-    <Link href={`${config.rootOrigin}/privacy-notice`}>
+    <Link href={`${config.rootOrigin}/terms-of-use`}>
       Lido&apos;s Terms of Use
     </Link>{' '}
     and the{' '}

--- a/features/earn/vault-usd/vault-page.tsx
+++ b/features/earn/vault-usd/vault-page.tsx
@@ -123,7 +123,7 @@ const RISK_DISCLOSURE = (
       Privacy Notice
     </Link>
     ,{' '}
-    <Link href={`${config.rootOrigin}/privacy-notice`}>
+    <Link href={`${config.rootOrigin}/terms-of-use`}>
       Lido&apos;s Terms of Use
     </Link>{' '}
     and the{' '}


### PR DESCRIPTION
### Description
Fixes Lido's terms of use link on the Earn pages

### Checklist:

- [ ] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
