### PR TITLE
fix: bound log payload and RPC request body size

### DIFF
--- a/next-logger.config.cjs
+++ b/next-logger.config.cjs
@@ -4,6 +4,8 @@ const pino = require('pino'); // It's ok that pino is transit dependency, it's r
 const { satanizer, commonPatterns } = require('@lidofinance/satanizer');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const loadEnvConfig = require('@next/env').loadEnvConfig;
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { clampArgs } = require('./utilsApi/clamp-log-args.cjs');
 
 // Must load env first
 const projectDir = process.cwd();
@@ -41,8 +43,10 @@ const logger = (defaultConfig) =>
       },
     },
     hooks: {
+      // Cap arguments before masking — masking cost grows faster than linearly
+      // with payload size. See utilsApi/clamp-log-args.cjs for the limits.
       logMethod(inputArgs, method) {
-        return method.apply(this, mask(inputArgs));
+        return method.apply(this, mask(clampArgs(inputArgs)));
       },
     },
   });

--- a/pages/api/rpc.ts
+++ b/pages/api/rpc.ts
@@ -2,7 +2,8 @@ import { wrapRequest as wrapNextRequest } from '@lidofinance/next-api-wrapper';
 import { trackedFetchRpcFactory } from '@lidofinance/api-rpc';
 import { rpcFactory } from '@lidofinance/next-pages';
 
-import { config, secretConfig } from 'config';
+// Aliased: `config` is reserved below for Next's route config export.
+import { config as appConfig, secretConfig } from 'config';
 import { API_ROUTES } from 'consts/api';
 import { CHAINS } from 'consts/chains';
 import { METRICS_PREFIX } from 'consts/metrics';
@@ -73,7 +74,7 @@ const rpc =
       prefix: METRICS_PREFIX,
       registry: Metrics.registry,
     },
-    defaultChain: `${config.defaultChain}`,
+    defaultChain: `${appConfig.defaultChain}`,
     providers: {
       [CHAINS.Mainnet]: secretConfig.rpcUrls_1,
       [CHAINS.Holesky]: secretConfig.rpcUrls_17000,
@@ -88,7 +89,7 @@ const rpc =
       allowedRPCMethods,
       allowedCallAddresses,
       allowedLogsAddresses,
-      maxBatchCount: config.PROVIDER_MAX_BATCH,
+      maxBatchCount: appConfig.PROVIDER_MAX_BATCH,
       blockEmptyAddressGetLogs: true,
       maxGetLogsRange: 20_000, // only 20k blocks size historical queries
       maxResponseSize: 1_000_000, // 1mb max response
@@ -96,6 +97,21 @@ const rpc =
   });
 
 if (!g.__rpcSingleton__) g.__rpcSingleton__ = rpc;
+
+// Cap the request body below Next's 1MB default, sized off the largest batches
+// this app actually sends. Withdrawal reads pass request-id arrays, and the
+// transport packs up to PROVIDER_MAX_BATCH calls per POST:
+//   getClaimableEther, MAX_SHOWN_REQUEST_PER_TYPE (1024) x 2 arrays  128kb
+//   findCheckpointHints, 1024 ids                                     64kb
+//   getWithdrawalStatus, STATUS_BATCH_SIZE (500) ids                  32kb
+//   claimWithdrawals, MAX_REQUESTS_COUNT (256)                        32kb
+// Two large reads in one batch window reach ~193kb, ~225kb with a claim gas
+// estimate alongside. 512kb keeps ~2.3x headroom — re-measure before lowering.
+export const config = {
+  api: {
+    bodyParser: { sizeLimit: '512kb' },
+  },
+};
 
 export default wrapNextRequest([
   httpMethodGuard([HttpMethod.POST]),

--- a/utilsApi/__tests__/clamp-log-args.test.ts
+++ b/utilsApi/__tests__/clamp-log-args.test.ts
@@ -1,0 +1,105 @@
+import { createRequire } from 'node:module';
+
+import { commonPatterns, satanizer } from '@lidofinance/satanizer';
+
+// `createRequire` because the module is `.cjs` (next-logger preloads the logger
+// config without a build step) and the project is `"type": "module"`.
+const requireCjs = createRequire(import.meta.url);
+const { clampArgs, MAX_TOTAL_CHARS } = requireCjs('../clamp-log-args.cjs') as {
+  clampArgs: (args: unknown[]) => unknown[];
+  MAX_TOTAL_CHARS: number;
+};
+
+const countChars = (value: unknown): number => {
+  if (typeof value === 'string') return value.length;
+  if (Array.isArray(value))
+    return value.reduce<number>((n, v) => n + countChars(v), 0);
+  if (value && typeof value === 'object') {
+    return Object.entries(value).reduce(
+      (n, [key, v]) => n + key.length + countChars(v),
+      0,
+    );
+  }
+  return 0;
+};
+
+// Slack over the budget: each clamped string may add a "[truncated N chars]"
+// suffix, and keys are counted too.
+const BUDGET_CEILING = MAX_TOTAL_CHARS * 2;
+
+const makeWideObject = (keys: number) =>
+  Object.fromEntries(Array.from({ length: keys }, (_, i) => [`k${i}`, 'v']));
+
+describe('clampArgs', () => {
+  it('bounds a single oversized string', () => {
+    const [clamped] = clampArgs(['a'.repeat(1024 * 1024)]);
+    expect(countChars(clamped)).toBeLessThan(BUDGET_CEILING);
+    expect(String(clamped)).toContain('truncated');
+  });
+
+  it('bounds an object with many keys', () => {
+    const clamped = clampArgs([makeWideObject(20_000)]);
+    expect(countChars(clamped)).toBeLessThan(BUDGET_CEILING);
+  });
+
+  it('bounds many oversized strings across one log line', () => {
+    const args = Array.from({ length: 50 }, () => 'a'.repeat(64 * 1024));
+    expect(countChars(clampArgs(args))).toBeLessThan(BUDGET_CEILING);
+  });
+
+  it('keeps short payloads byte-identical', () => {
+    const args = [
+      { type: 'CSP Violation', violation: { 'document-uri': '/x' } },
+    ];
+    expect(clampArgs(args)).toEqual(args);
+  });
+
+  it('flattens an Error and clamps its message', () => {
+    const error = new Error('x'.repeat(64 * 1024), {
+      cause: new Error('root'),
+    });
+    const [clamped] = clampArgs([error]) as [Record<string, unknown>];
+    expect(clamped.name).toBe('Error');
+    expect(String(clamped.message)).toContain('truncated');
+    expect(countChars(clamped)).toBeLessThan(BUDGET_CEILING);
+    expect(clamped.cause).toMatchObject({ message: 'root' });
+  });
+
+  it('survives cycles, deep nesting and throwing getters', () => {
+    const cyclic: Record<string, unknown> = { name: 'x' };
+    cyclic.self = cyclic;
+    Object.defineProperty(cyclic, 'boom', {
+      enumerable: true,
+      get() {
+        throw new Error('nope');
+      },
+    });
+
+    let deep: Record<string, unknown> = { end: true };
+    for (let i = 0; i < 100; i++) deep = { deep };
+
+    expect(() => clampArgs([cyclic, deep])).not.toThrow();
+  });
+
+  it('does not report a repeated object as a cycle', () => {
+    const shared = { a: 1 };
+    expect(clampArgs([{ x: shared, y: shared }])).toEqual([
+      { x: { a: 1 }, y: { a: 1 } },
+    ]);
+  });
+
+  it('keeps masking cost bounded for an oversized payload', () => {
+    const mask = satanizer(commonPatterns);
+    const oversized = {
+      documentUri: 'a'.repeat(1024 * 1024),
+      wide: makeWideObject(20_000),
+    };
+
+    const startedAt = Date.now();
+    mask(clampArgs([oversized]));
+    const elapsed = Date.now() - startedAt;
+
+    // Generous ceiling: this guards the order of magnitude, not a target.
+    expect(elapsed).toBeLessThan(1000);
+  });
+});

--- a/utilsApi/__tests__/clamp-log-args.test.ts
+++ b/utilsApi/__tests__/clamp-log-args.test.ts
@@ -5,9 +5,12 @@ import { commonPatterns, satanizer } from '@lidofinance/satanizer';
 // `createRequire` because the module is `.cjs` (next-logger preloads the logger
 // config without a build step) and the project is `"type": "module"`.
 const requireCjs = createRequire(import.meta.url);
-const { clampArgs, MAX_TOTAL_CHARS } = requireCjs('../clamp-log-args.cjs') as {
+const { clampArgs, MAX_TOTAL_CHARS, MAX_STRING_LENGTH } = requireCjs(
+  '../clamp-log-args.cjs',
+) as {
   clampArgs: (args: unknown[]) => unknown[];
   MAX_TOTAL_CHARS: number;
+  MAX_STRING_LENGTH: number;
 };
 
 const countChars = (value: unknown): number => {
@@ -23,9 +26,28 @@ const countChars = (value: unknown): number => {
   return 0;
 };
 
+const longestString = (value: unknown): number => {
+  if (typeof value === 'string') return value.length;
+  if (Array.isArray(value))
+    return value.reduce<number>((n, v) => Math.max(n, longestString(v)), 0);
+  if (value && typeof value === 'object') {
+    return Object.entries(value).reduce(
+      (n, [key, v]) => Math.max(n, key.length, longestString(v)),
+      0,
+    );
+  }
+  return 0;
+};
+
 // Slack over the budget: each clamped string may add a "[truncated N chars]"
 // suffix, and keys are counted too.
 const BUDGET_CEILING = MAX_TOTAL_CHARS * 2;
+
+// Absolute ceilings, deliberately NOT derived from the module's own constants:
+// masking cost grows quickly with string length, so raising a limit must fail
+// this test and force a conscious decision rather than silently widening it.
+const ABSOLUTE_STRING_CEILING = 4 * 1024;
+const ABSOLUTE_TOTAL_CEILING = 32 * 1024;
 
 const makeWideObject = (keys: number) =>
   Object.fromEntries(Array.from({ length: keys }, (_, i) => [`k${i}`, 'v']));
@@ -95,11 +117,14 @@ describe('clampArgs', () => {
       wide: makeWideObject(20_000),
     };
 
-    const startedAt = Date.now();
-    mask(clampArgs([oversized]));
-    const elapsed = Date.now() - startedAt;
+    const clamped = clampArgs([oversized]);
 
-    // Generous ceiling: this guards the order of magnitude, not a target.
-    expect(elapsed).toBeLessThan(1000);
+    // Masking cost is driven by the longest single string and by the total
+    // payload size, so assert both directly instead of wall-clock time.
+    expect(MAX_STRING_LENGTH).toBeLessThanOrEqual(ABSOLUTE_STRING_CEILING);
+    expect(MAX_TOTAL_CHARS).toBeLessThanOrEqual(ABSOLUTE_TOTAL_CEILING);
+    expect(longestString(clamped)).toBeLessThanOrEqual(ABSOLUTE_STRING_CEILING);
+    expect(countChars(clamped)).toBeLessThanOrEqual(ABSOLUTE_TOTAL_CEILING);
+    expect(() => mask(clamped)).not.toThrow();
   });
 });

--- a/utilsApi/__tests__/collect-request-address-metric.test.ts
+++ b/utilsApi/__tests__/collect-request-address-metric.test.ts
@@ -134,4 +134,40 @@ describe('collectRequestAddressMetric', () => {
     });
     expect(recorded.length).toBe(1);
   });
+
+  // Log lines must stay bounded regardless of entry size: parser errors can
+  // quote their whole input back.
+  it('never logs an oversized `to` value, and keeps processing the batch', async () => {
+    const { counter, recorded } = makeCounterMock();
+    const oversizedTo = `0x${'a'.repeat(128 * 1024)}`;
+
+    await collectRequestAddressMetric({
+      calls: [makeEthCall(oversizedTo), makeEthCall(VALID_UNKNOWN_TO)],
+      chainId: CHAINS.Mainnet,
+      metrics: counter,
+    });
+
+    expect(recorded.length).toBe(1);
+    for (const args of warnSpy.mock.calls) {
+      const line = args.map(String).join(' ');
+      expect(line.length).toBeLessThan(1024);
+      expect(line).not.toContain('aaaaaaaaaa');
+    }
+  });
+
+  it('bounds the logged text when a call throws', async () => {
+    const { counter } = makeCounterMock();
+    // 42-char `to` passes the length guard but fails checksum parsing, so this
+    // exercises the catch branch.
+    await collectRequestAddressMetric({
+      calls: [makeEthCall(`0x${'z'.repeat(40)}`)],
+      chainId: CHAINS.Mainnet,
+      metrics: counter,
+    });
+
+    expect(warnSpy).toHaveBeenCalled();
+    for (const args of warnSpy.mock.calls) {
+      expect(args.map(String).join(' ').length).toBeLessThan(512);
+    }
+  });
 });

--- a/utilsApi/clamp-log-args.cjs
+++ b/utilsApi/clamp-log-args.cjs
@@ -1,0 +1,104 @@
+// Caps the size and shape of log arguments before they are masked in
+// next-logger.config.cjs. Log-line cost grows faster than linearly with payload
+// size, so keep payloads bounded and predictable.
+// `.cjs` because next-logger preloads the logger config without a build step,
+// and the project is `"type": "module"`.
+
+// Per-string cap is the main knob. Sized above the longest strings this app
+// logs — a CSP report's `original-policy` (~700 chars) and a viem error `.stack`
+// (~800 chars) — with room for both to grow.
+// The total cap bounds a whole log line; per-string and per-key caps alone
+// don't, since nesting multiplies node count.
+const MAX_STRING_LENGTH = 2 * 1024;
+const MAX_TOTAL_CHARS = 16 * 1024;
+const MAX_OBJECT_KEYS = 64;
+const MAX_ARRAY_ITEMS = 64;
+const MAX_DEPTH = 6;
+
+const clampArgs = (args) => {
+  const budget = { chars: MAX_TOTAL_CHARS };
+
+  const clampString = (value) => {
+    if (budget.chars <= 0) return '[log budget exceeded]';
+
+    const limit = Math.min(MAX_STRING_LENGTH, budget.chars);
+
+    if (value.length <= limit) {
+      budget.chars -= value.length;
+      return value;
+    }
+
+    budget.chars -= limit;
+
+    return `${value.slice(0, limit)}…[truncated ${value.length - limit} chars]`;
+  };
+
+  const clamp = (value, depth, seen) => {
+    if (typeof value === 'string') return clampString(value);
+    if (value === null || typeof value !== 'object') return value;
+    if (seen.has(value)) return '[Circular]';
+    if (depth >= MAX_DEPTH) return '[MaxDepth]';
+
+    seen.add(value);
+
+    try {
+      // Masking walks an Error's own `message`/`stack`, so cap them too. Errors
+      // already reach the sink as plain objects — no behaviour change here.
+      if (value instanceof Error) {
+        const clamped = {
+          name: value.name,
+          message: clampString(String(value.message ?? '')),
+          stack: clampString(String(value.stack ?? '')),
+        };
+        // undici and viem hide the actionable errno here.
+        if (value.cause !== undefined) {
+          clamped.cause = clamp(value.cause, depth + 1, seen);
+        }
+
+        return clamped;
+      }
+
+      if (Array.isArray(value)) {
+        const items = value
+          .slice(0, MAX_ARRAY_ITEMS)
+          .map((item) => clamp(item, depth + 1, seen));
+
+        if (value.length > MAX_ARRAY_ITEMS) {
+          items.push(`[truncated ${value.length - MAX_ARRAY_ITEMS} items]`);
+        }
+
+        return items;
+      }
+
+      const keys = Object.keys(value);
+      const clamped = {};
+
+      for (const key of keys.slice(0, MAX_OBJECT_KEYS)) {
+        clamped[clampString(key)] = clamp(value[key], depth + 1, seen);
+      }
+
+      if (keys.length > MAX_OBJECT_KEYS) {
+        clamped['[truncated]'] = `${keys.length - MAX_OBJECT_KEYS} more keys`;
+      }
+
+      return clamped;
+    } catch {
+      // A throwing getter must never break logging.
+      return '[unserializable]';
+    } finally {
+      // Drop on the way out so a repeated object isn't misreported as a cycle.
+      seen.delete(value);
+    }
+  };
+
+  return args.map((arg) => clamp(arg, 0, new Set()));
+};
+
+module.exports = {
+  clampArgs,
+  MAX_STRING_LENGTH,
+  MAX_TOTAL_CHARS,
+  MAX_OBJECT_KEYS,
+  MAX_ARRAY_ITEMS,
+  MAX_DEPTH,
+};

--- a/utilsApi/collect-request-address-metric.ts
+++ b/utilsApi/collect-request-address-metric.ts
@@ -10,6 +10,17 @@ import {
 import { getFunctionNameFromAbi } from './get-function-name-from-abi';
 
 const UNKNOWN_LABEL = 'unknown';
+const ADDRESS_LENGTH = 42; // '0x' + 40 hex chars
+const LOG_ERROR_MAX_LENGTH = 200;
+
+// Parser errors can quote their whole input, so keep log lines bounded.
+const shortError = (error: unknown) => {
+  const text =
+    error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+  return text.length > LOG_ERROR_MAX_LENGTH
+    ? `${text.slice(0, LOG_ERROR_MAX_LENGTH)}…`
+    : text;
+};
 
 /**
  * Increments the eth_call Counter per batch entry. Labels bounded:
@@ -43,6 +54,9 @@ export const collectRequestAddressMetric = async ({
       }
 
       const { to, data } = call.params[0];
+      // Metrics collection is independent of the route's own checks, so verify
+      // the shape here rather than assuming a well-formed address.
+      if (typeof to !== 'string' || to.length !== ADDRESS_LENGTH) return;
       const address = getAddress(to);
       const contractName = METRIC_CONTRACT_ADDRESSES?.[chainId]?.[address];
       const methodEncoded = data?.slice(0, 10); // `0x` and 8 next symbols
@@ -72,7 +86,9 @@ export const collectRequestAddressMetric = async ({
         .inc(1);
     } catch (error) {
       console.warn(
-        `[collectRequestAddressMetric] skipping malformed call: ${error}`,
+        `[collectRequestAddressMetric] skipping malformed call: ${shortError(
+          error,
+        )}`,
       );
     }
   });


### PR DESCRIPTION


<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

**Log argument clamping and logging improvements:**

* Added a new utility `clamp-log-args.cjs` that enforces limits on log argument size, depth, and structure, ensuring no single log line or argument can grow unbounded. This includes per-string, total character, object key, array item, and nesting depth caps, and handles errors, cycles, and unserializable values gracefully. (`utilsApi/clamp-log-args.cjs`)
* Integrated `clampArgs` into the logger configuration so that all log arguments are clamped before masking, significantly reducing masking cost and bounding log line size. (`next-logger.config.cjs`) [[1]](diffhunk://#diff-2ee2c2b2c77ded2c7dac9a48b40295912e8cc276d0af2bf339f64cc5333ad205R7-R8) [[2]](diffhunk://#diff-2ee2c2b2c77ded2c7dac9a48b40295912e8cc276d0af2bf339f64cc5333ad205R46-R49)
* Added extensive tests for `clampArgs` to ensure correct behavior on large, nested, cyclic, and error-containing payloads, and to verify that masking remains performant on oversized inputs. (`utilsApi/__tests__/clamp-log-args.test.ts`)

**API and metrics logging safety:**

* Implemented a stricter request body size limit for the API endpoint, capping it at 512kb based on actual usage patterns to prevent abuse and accidental overload. (`pages/api/rpc.ts`)
* Improved metrics collection and logging by bounding the size of logged error messages and addresses, ensuring that even malformed or malicious input cannot result in oversized log lines. (`utilsApi/collect-request-address-metric.ts`, `utilsApi/__tests__/collect-request-address-metric.test.ts`) [[1]](diffhunk://#diff-621c893ee5edde243ec51899f55e5b79dad2f5c6a05e09a60f6d6cdbce409f60R13-R23) [[2]](diffhunk://#diff-621c893ee5edde243ec51899f55e5b79dad2f5c6a05e09a60f6d6cdbce409f60R57-R59) [[3]](diffhunk://#diff-621c893ee5edde243ec51899f55e5b79dad2f5c6a05e09a60f6d6cdbce409f60L75-R91) [[4]](diffhunk://#diff-262acdd2d587331a2364176c9781d716b8ee5a37f661a0d1e5b1bfc9342e3822R137-R172)

**General code quality improvements:**

* Renamed the imported `config` in `pages/api/rpc.ts` to `appConfig` to avoid conflicts with Next.js route config, and updated all references accordingly. (`pages/api/rpc.ts`) [[1]](diffhunk://#diff-fe4b39e5d398292be6a135d0090d316defa82b7224e8c882667dfc6cada1f462L5-R6) [[2]](diffhunk://#diff-fe4b39e5d398292be6a135d0090d316defa82b7224e8c882667dfc6cada1f462L76-R77) [[3]](diffhunk://#diff-fe4b39e5d398292be6a135d0090d316defa82b7224e8c882667dfc6cada1f462L91-R92)

Behaviour changes worth noting:
- /api/rpc returns 413 for bodies over 512kb
- malformed `to` values no longer emit a warn line
- serialized errors gained `name` and `cause` fields

### Demo

<!--- If thee are visual changes, attach a link to a specific section on preview stand / add screenshots / record a [loom](https://www.loom.com/). -->

### Code review notes

<!--- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

<!--- List all possible edge cases and how to test them. -->

### Checklist:

- [ ] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
