### PR TITLE
[Earn] Geo gating for deposits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,12 @@ CSP_REPORT_URI=https://stake.lido.fi/api/csp-report
 # allow some state overrides from browser console for QA
 ENABLE_QA_HELPERS=false
 
+# ISO 3166-1 alpha-2 country used by /api/geo when the Cloudflare country header
+# is absent, which is the case anywhere that does not sit behind Cloudflare
+# (local dev, most test setups). Without it every visitor there reads as the
+# limited experience. Requires ENABLE_QA_HELPERS=true; leave empty in production.
+QA_GEO_COUNTRY=DE
+
 REWARDS_BACKEND=http://127.0.0.1:4000
 
 # rate limit

--- a/REMOTE_CONFIG_MANIFEST.json
+++ b/REMOTE_CONFIG_MANIFEST.json
@@ -32,6 +32,9 @@
       "labelAllowList": [],
       "hiddenIds": []
     },
+    "geo": {
+      "limited": ["US"]
+    },
     "pages": {
       "/earn": {
         "showNew": true,

--- a/config/external-config/__tests__/validate.test.ts
+++ b/config/external-config/__tests__/validate.test.ts
@@ -630,6 +630,35 @@ describe('ManifestSchema', () => {
     });
   });
 
+  describe('geo', () => {
+    const parseGeo = (geo: unknown) =>
+      parseManifest({ '1': { ...validEntry, config: { geo } } })['1']?.config
+        .geo;
+
+    it('defaults to an empty country list when omitted', () => {
+      const result = parseManifest({ '1': validEntry });
+      expect(result['1']?.config.geo).toEqual({ limited: [] });
+    });
+
+    it('uppercases and trims country codes', () => {
+      expect(parseGeo({ limited: ['us', ' de '] })).toEqual({
+        limited: ['US', 'DE'],
+      });
+    });
+
+    it('deduplicates country codes after normalization', () => {
+      expect(parseGeo({ limited: ['US', 'us'] })).toEqual({
+        limited: ['US'],
+      });
+    });
+
+    it('drops entries that are not alpha-2 codes instead of failing', () => {
+      expect(parseGeo({ limited: ['US', 'USA', '', 42, null] })).toEqual({
+        limited: ['US'],
+      });
+    });
+  });
+
   describe('forward compatibility', () => {
     it('ignores unknown keys on config object without throwing', () => {
       expect(() =>

--- a/config/external-config/frontend-fallback.ts
+++ b/config/external-config/frontend-fallback.ts
@@ -20,6 +20,7 @@ export const overrideManifestConfig = (
       ...config.earnAllocation,
       ...override.earnAllocation,
     },
+    geo: { ...config.geo, ...override.geo },
     pages: { ...config.pages, ...override.pages },
     api: { ...config.api, ...override.api },
   };

--- a/config/external-config/validate.ts
+++ b/config/external-config/validate.ts
@@ -110,6 +110,35 @@ const EarnAllocationSchema = z
   .default({ labelAllowList: [], hiddenIds: [] });
 
 //
+// Geo
+//
+
+// Visitors resolved to one of these countries get the limited experience.
+// Codes are ISO 3166-1 alpha-2; unrecognised entries are dropped rather than
+// failing the whole manifest, so a typo cannot take the config down.
+const GeoCountryListSchema = z.preprocess(
+  (value) =>
+    Array.isArray(value)
+      ? value.filter(
+          (code) =>
+            typeof code === 'string' && /^[A-Za-z]{2}$/.test(code.trim()),
+        )
+      : value,
+  z
+    .array(z.string())
+    .transform((codes) => [
+      ...new Set(codes.map((code) => code.trim().toUpperCase())),
+    ]),
+);
+
+const GeoSchema = z
+  .object({
+    limited: GeoCountryListSchema.optional().default([]),
+  })
+  .optional()
+  .default({ limited: [] });
+
+//
 // Feature flags
 //
 
@@ -260,6 +289,7 @@ const ManifestConfigSchema = z.object({
   earnVaults: EarnVaultListSchema.optional().default([]),
   earnVaultsBanner: EarnVaultsBannerSchema,
   earnAllocation: EarnAllocationSchema,
+  geo: GeoSchema,
   pages: PagesEntrySchema.optional().default({}),
   wallets: WalletsConfigSchema,
   api: ApiSchema.optional().default({}),

--- a/config/groups/cache.ts
+++ b/config/groups/cache.ts
@@ -37,4 +37,8 @@ export const CACHE_REWARDS_HEADERS =
   'public, max-age=30, stale-if-error=1200, stale-while-revalidate=30';
 export const CACHE_VALIDATION_HEADERS =
   'public, max-age=30, stale-if-error=1200, stale-while-revalidate=30';
+// /api/geo answers differ per visitor IP — a shared cache entry would hand one
+// visitor's country to everyone behind the same edge node
+export const CACHE_GEO_HEADERS = 'private, no-store, must-revalidate';
+
 export const CACHE_DEFAULT_ERROR_HEADERS = 'no-store, must-revalidate';

--- a/consts/__tests__/geo.test.ts
+++ b/consts/__tests__/geo.test.ts
@@ -1,0 +1,26 @@
+import { resolveGeoAvailability } from '../geo';
+
+describe('resolveGeoAvailability', () => {
+  it('passes through an explicit full', () => {
+    expect(resolveGeoAvailability('full')).toBe('full');
+  });
+
+  it('passes through an explicit limited', () => {
+    expect(resolveGeoAvailability('limited')).toBe('limited');
+  });
+
+  // fail-closed: everything that is not a literal `full` has to land on
+  // `limited` — a request in flight, a failed one, a truncated body, a value
+  // from a newer API version
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['an unknown value', 'unrestricted'],
+    ['a differently cased value', 'FULL'],
+    ['a padded value', ' full '],
+    ['a truthy non-string', 1],
+    ['an object', { availability: 'full' }],
+  ])('resolves %s to limited', (_label, value) => {
+    expect(resolveGeoAvailability(value)).toBe('limited');
+  });
+});

--- a/consts/api.ts
+++ b/consts/api.ts
@@ -8,7 +8,16 @@ export const enum API_ROUTES {
   CONFIG_MANIFEST = 'api/config-manifest',
   EARN_VAULTS_APR = 'api/earn/vaults-apr',
   EARN_VAULTS_TVL = 'api/earn/vaults-tvl',
+  GEO = 'api/geo',
 }
+
+/**
+ * Absolute path to an own API route. Built from `basePath` instead of a bare
+ * relative string so the URL does not depend on the depth of the page the
+ * request is made from.
+ */
+export const getApiPath = (route: API_ROUTES): string =>
+  `${config.basePath ?? ''}/${route}`;
 
 export const enum ETH_API_ROUTES {
   ETH_APR = '/v1/protocol/eth/apr/last',

--- a/consts/geo.ts
+++ b/consts/geo.ts
@@ -1,0 +1,38 @@
+/**
+ * Contract shared by `/api/geo` and its client hook.
+ *
+ * The wording is deliberately neutral: the API reports which *experience* a
+ * visitor gets, not a verdict about them.
+ *
+ * The resolution is fail-closed. `limited` is the default, and `full` is only
+ * ever reached by positively establishing a trusted region: the edge resolved
+ * the country, the config that names the limited regions was readable, and the
+ * country is not among them. Every other path — no Cloudflare header, an
+ * unreachable route, a malformed body, a build with no API at all — ends at
+ * `limited`.
+ */
+
+export const GEO_AVAILABILITY = {
+  full: 'full',
+  limited: 'limited',
+} as const;
+
+export type GeoAvailability =
+  (typeof GEO_AVAILABILITY)[keyof typeof GEO_AVAILABILITY];
+
+export type GeoResponse = {
+  /** ISO 3166-1 alpha-2, or `null` when the country could not be resolved. */
+  country: string | null;
+  availability: GeoAvailability;
+};
+
+/**
+ * Narrows an untrusted value to an availability, fail-closed: only a literal
+ * `full` yields the full experience. Takes `unknown` on purpose — the API
+ * response is parsed JSON that nothing has validated, so a truncated or
+ * unexpected body has to land on `limited` rather than be trusted.
+ */
+export const resolveGeoAvailability = (value: unknown): GeoAvailability =>
+  value === GEO_AVAILABILITY.full
+    ? GEO_AVAILABILITY.full
+    : GEO_AVAILABILITY.limited;

--- a/consts/geo.ts
+++ b/consts/geo.ts
@@ -9,7 +9,7 @@
  * the country, the config that names the limited regions was readable, and the
  * country is not among them. Every other path — no Cloudflare header, an
  * unreachable route, a malformed body, a build with no API at all — ends at
- * `limited`.
+ * `limited`. The functions that do the resolving live in `utils/geo`.
  */
 
 export const GEO_AVAILABILITY = {
@@ -25,14 +25,3 @@ export type GeoResponse = {
   country: string | null;
   availability: GeoAvailability;
 };
-
-/**
- * Narrows an untrusted value to an availability, fail-closed: only a literal
- * `full` yields the full experience. Takes `unknown` on purpose — the API
- * response is parsed JSON that nothing has validated, so a truncated or
- * unexpected body has to land on `limited` rather than be trusted.
- */
-export const resolveGeoAvailability = (value: unknown): GeoAvailability =>
-  value === GEO_AVAILABILITY.full
-    ? GEO_AVAILABILITY.full
-    : GEO_AVAILABILITY.limited;

--- a/docs/config.md
+++ b/docs/config.md
@@ -52,10 +52,15 @@ CSP_REPORT_URI=...            # CSP violation reporting endpoint
 
 ```
 ENABLE_QA_HELPERS=true        # Debug helpers in the browser console
+QA_GEO_COUNTRY=DE             # Stand-in country for /api/geo without Cloudflare
 IPFS_MODE=true                # IPFS distribution mode
 COLLECT_METRICS=true          # Enable Prometheus metrics
 RUN_STARTUP_CHECKS=true       # Health checks on startup
 ```
+
+With `ENABLE_QA_HELPERS=true` the browser console also gets
+`setMockGeoCountry('US')` — it pins the geo country per browser and outranks
+both `QA_GEO_COUNTRY` and the real Cloudflare header. No argument clears it.
 
 ### Rate limiting
 

--- a/env-dynamics.mjs
+++ b/env-dynamics.mjs
@@ -82,6 +82,15 @@ export const prefillUnsafeElRpcUrls1301 =
 /** @type boolean */
 export const enableQaHelpers = toBoolean(process.env.ENABLE_QA_HELPERS);
 
+/**
+ * Replaces the Cloudflare country header on environments that do not sit
+ * behind Cloudflare (local dev, test setups). Ignored unless
+ * ENABLE_QA_HELPERS is on, so it has no effect in production.
+ *
+ * @type string
+ */
+export const qaGeoCountry = process.env.QA_GEO_COUNTRY;
+
 export const walletconnectProjectId = process.env.WALLETCONNECT_PROJECT_ID;
 
 /** @type string */

--- a/features/earn/shared/hooks/use-earn-geo-gate.ts
+++ b/features/earn/shared/hooks/use-earn-geo-gate.ts
@@ -1,0 +1,23 @@
+import { useGeoAvailability } from 'shared/hooks/use-geo-availability';
+
+/**
+ * The single place holding the rule "new deposits are locked unless the region
+ * positively answered `full`".
+ *
+ * Fail-closed: `isDepositGeoAvailable` stays false while the check is in
+ * flight, so nothing unlocks before the answer lands.
+ *
+ * `isGeoUnresolved` splits the locked case in two: a country that is on the
+ * limited list, and a country nothing could name at all — no Cloudflare header,
+ * a failed request, a build without the route. Both lock deposits; only the
+ * second is worth telling the visitor we could not verify their region.
+ */
+export const useEarnGeoGate = () => {
+  const { isResolving, isLimited, country } = useGeoAvailability();
+
+  return {
+    isGeoChecking: isResolving,
+    isGeoUnresolved: !isResolving && country === null,
+    isDepositGeoAvailable: !isResolving && !isLimited,
+  };
+};

--- a/features/earn/shared/upgrade-card-vault-page/upgrade-card-vault-page.tsx
+++ b/features/earn/shared/upgrade-card-vault-page/upgrade-card-vault-page.tsx
@@ -12,6 +12,7 @@ import { LocalLink } from 'shared/components/local-link';
 import { useUpgradableTokenBalances } from 'features/earn/vault-eth/upgrade-assets/use-upgradable-token-balances';
 import { trackMatomoEvent } from 'utils/track-matomo-event';
 import { MATOMO_EARN_EVENTS_TYPES } from 'consts/matomo/matomo-earn-events';
+import { useEarnGeoGate } from 'features/earn/shared/hooks/use-earn-geo-gate';
 
 import {
   UpgradeCardBlock,
@@ -38,6 +39,11 @@ export const UpgradeCardVaultPage: FC<UpgradeCardProps> = ({
   vaultToken,
 }) => {
   const { balances, isLoading } = useUpgradableTokenBalances();
+  const { isDepositGeoAvailable } = useEarnGeoGate();
+
+  // upgrading is a deposit into EarnETH, so the whole funnel stays hidden
+  // until the region positively answers `full`
+  if (!isDepositGeoAvailable) return null;
 
   // prevents flashing the card content while loading the balances while pre-fetching the data (isLoading: false, balances undefined)
   if (Object.values(balances).some((b) => b === undefined) || isLoading)

--- a/features/earn/shared/upgrade-card-vaults-list/upgrade-card-vaults-list.tsx
+++ b/features/earn/shared/upgrade-card-vaults-list/upgrade-card-vaults-list.tsx
@@ -14,6 +14,7 @@ import { useUpgradableTokenBalances } from 'features/earn/vault-eth/upgrade-asse
 import { ETH_VAULT_DEPOSIT_TOKENS_UPGRADABLE } from 'features/earn/vault-eth/consts';
 import { trackMatomoEvent } from 'utils/track-matomo-event';
 import { MATOMO_EARN_EVENTS_TYPES } from 'consts/matomo/matomo-earn-events';
+import { useEarnGeoGate } from 'features/earn/shared/hooks/use-earn-geo-gate';
 
 import {
   UpgradeCardBlock,
@@ -37,6 +38,11 @@ export const UpgradeCardVaultsList: FC<UpgradeCardProps> = ({
 }) => {
   const { isWalletConnected } = useDappStatus();
   const { balances } = useUpgradableTokenBalances();
+  const { isDepositGeoAvailable } = useEarnGeoGate();
+
+  // upgrading is a deposit into EarnETH, so the whole funnel stays hidden
+  // until the region positively answers `full`
+  if (!isDepositGeoAvailable) return null;
 
   if (!isWalletConnected) return null;
 

--- a/features/earn/shared/v2/geo-notice/consts.tsx
+++ b/features/earn/shared/v2/geo-notice/consts.tsx
@@ -19,6 +19,10 @@ export const GEO_LIMITED_TEXT = (
   </>
 );
 
+export const GEO_LIMITED_CARD_TEXT =
+  'This vault is not available in your region. Withdrawals remain ' +
+  'available for funds deposited earlier.';
+
 export const GEO_UNRESOLVED_TEXT =
   "We couldn't verify your region. Deposits are unavailable until we can " +
   'confirm it. Withdrawals remain available for funds deposited earlier.';

--- a/features/earn/shared/v2/geo-notice/consts.tsx
+++ b/features/earn/shared/v2/geo-notice/consts.tsx
@@ -1,0 +1,33 @@
+import { Link } from '@lidofinance/lido-ui';
+import type { ReactNode } from 'react';
+
+import type { GeoNoticeState } from 'utils/geo';
+
+export const GEO_CHECKING_TEXT =
+  'Checking availability in your region. This usually takes a moment.';
+
+export const GEO_CHECKING_SLOW_TEXT =
+  'Still checking. This is taking longer than usual.';
+
+export const GEO_LIMITED_TEXT = (
+  <>
+    In accordance with the{' '}
+    <Link href="https://mellow.finance/Runtime-Labs-Vault-Legal-Notice.pdf">
+      Terms of Service
+    </Link>
+    , this vault is not available in your current region.
+  </>
+);
+
+export const GEO_UNRESOLVED_TEXT =
+  "We couldn't verify your region. Deposits are unavailable until we can " +
+  'confirm it. Withdrawals remain available for funds deposited earlier.';
+
+export const GEO_SLOW_CHECK_DELAY_MS = 5000;
+
+export const GEO_NOTICE_TEXTS: Record<GeoNoticeState, ReactNode> = {
+  checking: GEO_CHECKING_TEXT,
+  'checking-slow': GEO_CHECKING_SLOW_TEXT,
+  limited: GEO_LIMITED_TEXT,
+  unresolved: GEO_UNRESOLVED_TEXT,
+};

--- a/features/earn/shared/v2/geo-notice/consts.tsx
+++ b/features/earn/shared/v2/geo-notice/consts.tsx
@@ -15,7 +15,8 @@ export const GEO_LIMITED_TEXT = (
     <Link href="https://mellow.finance/Runtime-Labs-Vault-Legal-Notice.pdf">
       Terms of Service
     </Link>
-    , this vault is not available in your current region.
+    , this vault is not available in your current region. Withdrawals remain
+    available for funds deposited earlier.
   </>
 );
 

--- a/features/earn/shared/v2/geo-notice/geo-notice-content.tsx
+++ b/features/earn/shared/v2/geo-notice/geo-notice-content.tsx
@@ -1,0 +1,27 @@
+import type { GeoNoticeState } from 'utils/geo';
+import { VaultWarning } from 'features/earn/shared/vault-warning';
+
+import { GEO_NOTICE_TEXTS } from './consts';
+import { GeoNoticeLoader } from './styles';
+
+type GeoNoticeContentProps = {
+  state: GeoNoticeState;
+  centered?: boolean;
+};
+
+export const GeoNoticeContent = ({
+  state,
+  centered,
+}: GeoNoticeContentProps) => {
+  const isChecking = state === 'checking' || state === 'checking-slow';
+
+  return (
+    <VaultWarning
+      variant="info"
+      centered={centered}
+      icon={isChecking ? <GeoNoticeLoader /> : undefined}
+    >
+      {GEO_NOTICE_TEXTS[state]}
+    </VaultWarning>
+  );
+};

--- a/features/earn/shared/v2/geo-notice/geo-notice-content.tsx
+++ b/features/earn/shared/v2/geo-notice/geo-notice-content.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react';
+
 import type { GeoNoticeState } from 'utils/geo';
 import { VaultWarning } from 'features/earn/shared/vault-warning';
 
@@ -7,13 +9,19 @@ import { GeoNoticeLoader } from './styles';
 type GeoNoticeContentProps = {
   state: GeoNoticeState;
   centered?: boolean;
+  limitedText?: ReactNode;
 };
 
 export const GeoNoticeContent = ({
   state,
   centered,
+  limitedText,
 }: GeoNoticeContentProps) => {
   const isChecking = state === 'checking' || state === 'checking-slow';
+
+  // allows to override text for the "limited" state
+  const text =
+    state === 'limited' && limitedText ? limitedText : GEO_NOTICE_TEXTS[state];
 
   return (
     <VaultWarning
@@ -21,7 +29,7 @@ export const GeoNoticeContent = ({
       centered={centered}
       icon={isChecking ? <GeoNoticeLoader /> : undefined}
     >
-      {GEO_NOTICE_TEXTS[state]}
+      {text}
     </VaultWarning>
   );
 };

--- a/features/earn/shared/v2/geo-notice/geo-notice.tsx
+++ b/features/earn/shared/v2/geo-notice/geo-notice.tsx
@@ -1,40 +1,19 @@
-import { getGeoNoticeState } from 'utils/geo';
-import { useEarnGeoGate } from 'features/earn/shared/hooks/use-earn-geo-gate';
-import { VaultWarning } from 'features/earn/shared/vault-warning';
-
-import { GEO_NOTICE_TEXTS, GEO_SLOW_CHECK_DELAY_MS } from './consts';
-import { useIsDelayExceeded } from './use-is-delay-exceeded';
-import { GeoNoticeLoader, GeoNoticeWrapper } from './styles';
+import { GeoNoticeContent } from './geo-notice-content';
+import { useGeoNoticeState } from './use-geo-notice-state';
+import { GeoNoticeWrapper } from './styles';
 
 type GeoNoticeProps = {
   showLimitedNotice?: boolean;
 };
 
 export const GeoNotice = ({ showLimitedNotice = false }: GeoNoticeProps) => {
-  const { isGeoChecking, isGeoUnresolved, isDepositGeoAvailable } =
-    useEarnGeoGate();
-  const isSlow = useIsDelayExceeded(isGeoChecking, GEO_SLOW_CHECK_DELAY_MS);
-
-  const state = getGeoNoticeState({
-    isChecking: isGeoChecking,
-    isSlow,
-    isLimited: !isDepositGeoAvailable,
-    isUnresolved: isGeoUnresolved,
-    showLimitedNotice,
-  });
+  const state = useGeoNoticeState(showLimitedNotice);
 
   if (!state) return null;
 
-  const isChecking = state === 'checking' || state === 'checking-slow';
-
   return (
     <GeoNoticeWrapper data-testid="geo-notice" data-geo-notice-state={state}>
-      <VaultWarning
-        variant="info"
-        icon={isChecking ? <GeoNoticeLoader /> : undefined}
-      >
-        {GEO_NOTICE_TEXTS[state]}
-      </VaultWarning>
+      <GeoNoticeContent state={state} />
     </GeoNoticeWrapper>
   );
 };

--- a/features/earn/shared/v2/geo-notice/geo-notice.tsx
+++ b/features/earn/shared/v2/geo-notice/geo-notice.tsx
@@ -1,0 +1,40 @@
+import { getGeoNoticeState } from 'utils/geo';
+import { useEarnGeoGate } from 'features/earn/shared/hooks/use-earn-geo-gate';
+import { VaultWarning } from 'features/earn/shared/vault-warning';
+
+import { GEO_NOTICE_TEXTS, GEO_SLOW_CHECK_DELAY_MS } from './consts';
+import { useIsDelayExceeded } from './use-is-delay-exceeded';
+import { GeoNoticeLoader, GeoNoticeWrapper } from './styles';
+
+type GeoNoticeProps = {
+  showLimitedNotice?: boolean;
+};
+
+export const GeoNotice = ({ showLimitedNotice = false }: GeoNoticeProps) => {
+  const { isGeoChecking, isGeoUnresolved, isDepositGeoAvailable } =
+    useEarnGeoGate();
+  const isSlow = useIsDelayExceeded(isGeoChecking, GEO_SLOW_CHECK_DELAY_MS);
+
+  const state = getGeoNoticeState({
+    isChecking: isGeoChecking,
+    isSlow,
+    isLimited: !isDepositGeoAvailable,
+    isUnresolved: isGeoUnresolved,
+    showLimitedNotice,
+  });
+
+  if (!state) return null;
+
+  const isChecking = state === 'checking' || state === 'checking-slow';
+
+  return (
+    <GeoNoticeWrapper data-testid="geo-notice" data-geo-notice-state={state}>
+      <VaultWarning
+        variant="info"
+        icon={isChecking ? <GeoNoticeLoader /> : undefined}
+      >
+        {GEO_NOTICE_TEXTS[state]}
+      </VaultWarning>
+    </GeoNoticeWrapper>
+  );
+};

--- a/features/earn/shared/v2/geo-notice/geo-notice.tsx
+++ b/features/earn/shared/v2/geo-notice/geo-notice.tsx
@@ -6,7 +6,7 @@ type GeoNoticeProps = {
   showLimitedNotice?: boolean;
 };
 
-export const GeoNotice = ({ showLimitedNotice = false }: GeoNoticeProps) => {
+export const GeoNotice = ({ showLimitedNotice = true }: GeoNoticeProps) => {
   const state = useGeoNoticeState(showLimitedNotice);
 
   if (!state) return null;

--- a/features/earn/shared/v2/geo-notice/index.ts
+++ b/features/earn/shared/v2/geo-notice/index.ts
@@ -1,0 +1,1 @@
+export { GeoNotice } from './geo-notice';

--- a/features/earn/shared/v2/geo-notice/index.ts
+++ b/features/earn/shared/v2/geo-notice/index.ts
@@ -1,1 +1,2 @@
 export { GeoNotice } from './geo-notice';
+export { VaultCardGeoCta } from './vault-card-geo-cta';

--- a/features/earn/shared/v2/geo-notice/styles.tsx
+++ b/features/earn/shared/v2/geo-notice/styles.tsx
@@ -10,3 +10,15 @@ export const GeoNoticeWrapper = styled.div`
 export const GeoNoticeLoader = styled(Loader).attrs({ size: 'small' })`
   flex: 0 0 auto;
 `;
+
+// stands in for CardCta, so it keeps that slot's top margin; the notice itself
+// stays under the card's overlay link (the card must remain clickable), only
+// the Terms of Service link is lifted above it
+export const VaultCardGeoNoticeWrapper = styled.div`
+  margin-top: 32px;
+
+  a {
+    position: relative;
+    z-index: 20;
+  }
+`;

--- a/features/earn/shared/v2/geo-notice/styles.tsx
+++ b/features/earn/shared/v2/geo-notice/styles.tsx
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+import { Loader } from '@lidofinance/lido-ui';
+
+// matches SwitchStyled's bottom margin, so the panel spacing is unchanged
+// whether the notice is rendered above it or not
+export const GeoNoticeWrapper = styled.div`
+  margin: 0 0 ${({ theme }) => theme.spaceMap.lg}px;
+`;
+
+export const GeoNoticeLoader = styled(Loader).attrs({ size: 'small' })`
+  flex: 0 0 auto;
+`;

--- a/features/earn/shared/v2/geo-notice/styles.tsx
+++ b/features/earn/shared/v2/geo-notice/styles.tsx
@@ -11,14 +11,7 @@ export const GeoNoticeLoader = styled(Loader).attrs({ size: 'small' })`
   flex: 0 0 auto;
 `;
 
-// stands in for CardCta, so it keeps that slot's top margin; the notice itself
-// stays under the card's overlay link (the card must remain clickable), only
-// the Terms of Service link is lifted above it
+// stands in for CardCta, so it keeps that slot's top margin
 export const VaultCardGeoNoticeWrapper = styled.div`
   margin-top: 32px;
-
-  a {
-    position: relative;
-    z-index: 20;
-  }
 `;

--- a/features/earn/shared/v2/geo-notice/use-geo-notice-state.ts
+++ b/features/earn/shared/v2/geo-notice/use-geo-notice-state.ts
@@ -1,0 +1,21 @@
+import { getGeoNoticeState, type GeoNoticeState } from 'utils/geo';
+import { useEarnGeoGate } from 'features/earn/shared/hooks/use-earn-geo-gate';
+
+import { GEO_SLOW_CHECK_DELAY_MS } from './consts';
+import { useIsDelayExceeded } from './use-is-delay-exceeded';
+
+export const useGeoNoticeState = (
+  showLimitedNotice = false,
+): GeoNoticeState | null => {
+  const { isGeoChecking, isGeoUnresolved, isDepositGeoAvailable } =
+    useEarnGeoGate();
+  const isSlow = useIsDelayExceeded(isGeoChecking, GEO_SLOW_CHECK_DELAY_MS);
+
+  return getGeoNoticeState({
+    isChecking: isGeoChecking,
+    isSlow,
+    isLimited: !isDepositGeoAvailable,
+    isUnresolved: isGeoUnresolved,
+    showLimitedNotice,
+  });
+};

--- a/features/earn/shared/v2/geo-notice/use-is-delay-exceeded.ts
+++ b/features/earn/shared/v2/geo-notice/use-is-delay-exceeded.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * True once `active` has been continuously true for `delayMs`.
+ * Resets as soon as `active` goes false, so a retried query starts over.
+ */
+export const useIsDelayExceeded = (active: boolean, delayMs: number) => {
+  const [isExceeded, setIsExceeded] = useState(false);
+
+  useEffect(() => {
+    if (!active) {
+      setIsExceeded(false);
+      return;
+    }
+
+    const timeoutId = setTimeout(() => setIsExceeded(true), delayMs);
+    return () => clearTimeout(timeoutId);
+  }, [active, delayMs]);
+
+  return isExceeded;
+};

--- a/features/earn/shared/v2/geo-notice/vault-card-geo-cta.tsx
+++ b/features/earn/shared/v2/geo-notice/vault-card-geo-cta.tsx
@@ -1,5 +1,6 @@
 import type { PropsWithChildren } from 'react';
 
+import { GEO_LIMITED_CARD_TEXT } from './consts';
 import { GeoNoticeContent } from './geo-notice-content';
 import { useGeoNoticeState } from './use-geo-notice-state';
 import { VaultCardGeoNoticeWrapper } from './styles';
@@ -14,7 +15,11 @@ export const VaultCardGeoCta = ({ children }: PropsWithChildren) => {
       data-testid="geo-notice"
       data-geo-notice-state={state}
     >
-      <GeoNoticeContent state={state} centered />
+      <GeoNoticeContent
+        state={state}
+        centered
+        limitedText={GEO_LIMITED_CARD_TEXT}
+      />
     </VaultCardGeoNoticeWrapper>
   );
 };

--- a/features/earn/shared/v2/geo-notice/vault-card-geo-cta.tsx
+++ b/features/earn/shared/v2/geo-notice/vault-card-geo-cta.tsx
@@ -1,0 +1,20 @@
+import type { PropsWithChildren } from 'react';
+
+import { GeoNoticeContent } from './geo-notice-content';
+import { useGeoNoticeState } from './use-geo-notice-state';
+import { VaultCardGeoNoticeWrapper } from './styles';
+
+export const VaultCardGeoCta = ({ children }: PropsWithChildren) => {
+  const state = useGeoNoticeState(true);
+
+  if (!state) return <>{children}</>;
+
+  return (
+    <VaultCardGeoNoticeWrapper
+      data-testid="geo-notice"
+      data-geo-notice-state={state}
+    >
+      <GeoNoticeContent state={state} centered />
+    </VaultCardGeoNoticeWrapper>
+  );
+};

--- a/features/earn/shared/v2/vault-card/vault-card.tsx
+++ b/features/earn/shared/v2/vault-card/vault-card.tsx
@@ -31,6 +31,7 @@ import { FormatToken } from 'shared/formatters/format-token';
 import { Badge } from 'features/earn/shared/badge';
 import { getTokenDecimals } from 'utils/token-decimals';
 import { useConfig } from 'config/use-config';
+import { VaultCardGeoCta } from 'features/earn/shared/v2/geo-notice';
 import { InlineLoader } from '../../inline-loader';
 import { VaultTip } from '../../vault-tip';
 import { shouldShowApxUpdateTooltip } from '../apy-update-tooltip-text';
@@ -66,6 +67,8 @@ type VaultCardProps = {
   depositLinkCallback?: () => void;
   protectedBadgeTooltipText?: React.ReactNode;
   warning?: React.ReactNode;
+  // swaps the CTA for the geo notice while the region is unchecked or locked
+  isGeoGated?: boolean;
 };
 
 export const VaultCard: React.FC<VaultCardProps> = ({
@@ -80,6 +83,7 @@ export const VaultCard: React.FC<VaultCardProps> = ({
   depositLinkCallback,
   protectedBadgeTooltipText,
   warning,
+  isGeoGated = false,
 }) => {
   const isDeprecated = useConfig().externalConfig.earnVaults.find(
     (vault) => vault.name === urlSlug,
@@ -90,6 +94,16 @@ export const VaultCard: React.FC<VaultCardProps> = ({
   const isMobile = useBreakpoint('md');
 
   const showApxUpdateTooltip = shouldShowApxUpdateTooltip(stats);
+
+  const cta = (
+    <CardCta data-testid="vault-button">
+      <LocalLink href={depositHref} onClick={depositLinkCallback}>
+        <Button fullwidth variant="translucent">
+          {ctaLabel}
+        </Button>
+      </LocalLink>
+    </CardCta>
+  );
 
   const apxValue = (
     <StatValue $accent $muted={stats.isApxStale} data-testid="apx-value">
@@ -207,13 +221,7 @@ export const VaultCard: React.FC<VaultCardProps> = ({
         )}
       </CardStats>
       {warning && <VaultWarning>{warning}</VaultWarning>}
-      <CardCta data-testid="vault-button">
-        <LocalLink href={depositHref} onClick={depositLinkCallback}>
-          <Button fullwidth variant="translucent">
-            {ctaLabel}
-          </Button>
-        </LocalLink>
-      </CardCta>
+      {isGeoGated ? <VaultCardGeoCta>{cta}</VaultCardGeoCta> : cta}
     </CardWrapper>
   );
 };

--- a/features/earn/shared/vault-position/styles.ts
+++ b/features/earn/shared/vault-position/styles.ts
@@ -6,8 +6,7 @@ export const PositionContainer = styled.div`
   padding: ${({ theme }) => theme.spaceMap.md}px;
   border-radius: ${({ theme }) => theme.borderRadiusesMap.lg}px;
   gap: ${({ theme }) => theme.spaceMap.lg}px;
-  background-color: ${({ theme }) =>
-    theme.name === 'light' ? `#F6F7F8` : 'var(--lido-color-controlBg)'};
+  background-color: var(--custom-color-controlBg);
 
   ${({ theme }) => theme.mediaQueries.md} {
     padding: 12px;

--- a/features/earn/shared/vault-warning.tsx
+++ b/features/earn/shared/vault-warning.tsx
@@ -50,8 +50,7 @@ const WarningContainer = styled.div<VaultWarningStyleProps>`
   ${({ variant }) =>
     variant === 'info' &&
     css`
-      background-color: ${({ theme }) =>
-        theme.name === 'light' ? `#F6F7F8` : 'var(--lido-color-controlBg)'};
+      background-color: var(--custom-color-controlBg);
     `}
 
   ${({ theme }) => theme.mediaQueries.md} {

--- a/features/earn/shared/vault-warning.tsx
+++ b/features/earn/shared/vault-warning.tsx
@@ -6,9 +6,15 @@ type VaultWarningVariantProps = {
   variant?: 'warning' | 'info';
 };
 
+type VaultWarningStyleProps = VaultWarningVariantProps & {
+  $centered?: boolean;
+};
+
 type VaultWarningProps = VaultWarningVariantProps & {
   // replaces the variant's default icon, e.g. with a spinner
   icon?: React.ReactNode;
+  // centers the icon + text group instead of stretching the text to full width
+  centered?: boolean;
 };
 
 export const WarningIcon = styled.img.attrs({
@@ -30,10 +36,11 @@ export const InfoWarningIcon = styled.img.attrs({
   margin: 5px;
 `;
 
-const WarningContainer = styled.div<VaultWarningVariantProps>`
+const WarningContainer = styled.div<VaultWarningStyleProps>`
   display: flex;
   flex-direction: row;
   align-items: center;
+  justify-content: ${({ $centered }) => ($centered ? 'center' : 'flex-start')};
   gap: ${({ theme }) => theme.spaceMap.sm}px;
   padding: ${({ theme }) => theme.spaceMap.md}px;
 
@@ -52,8 +59,8 @@ const WarningContainer = styled.div<VaultWarningVariantProps>`
   }
 `;
 
-const WarningContent = styled.div<VaultWarningVariantProps>`
-  flex: 1;
+const WarningContent = styled.div<VaultWarningStyleProps>`
+  flex: ${({ $centered }) => ($centered ? '0 1 auto' : 1)};
 
   font-size: 12px;
   font-weight: 700;
@@ -76,11 +83,18 @@ export const VaultWarning = ({
   children,
   variant = 'warning',
   icon,
+  centered,
 }: React.PropsWithChildren<VaultWarningProps>) => {
   return (
-    <WarningContainer variant={variant} data-testid="vault-warning">
+    <WarningContainer
+      variant={variant}
+      $centered={centered}
+      data-testid="vault-warning"
+    >
       {icon ?? (variant === 'warning' ? <WarningIcon /> : <InfoWarningIcon />)}
-      <WarningContent variant={variant}>{children}</WarningContent>
+      <WarningContent variant={variant} $centered={centered}>
+        {children}
+      </WarningContent>
     </WarningContainer>
   );
 };

--- a/features/earn/shared/vault-warning.tsx
+++ b/features/earn/shared/vault-warning.tsx
@@ -2,8 +2,13 @@ import styled, { css } from 'styled-components';
 import WarningIconSrc from 'assets/icons/attention-triangle.svg';
 import InfoIconSrc from 'assets/icons/info-warning.svg';
 
-type VaultWarningProps = {
+type VaultWarningVariantProps = {
   variant?: 'warning' | 'info';
+};
+
+type VaultWarningProps = VaultWarningVariantProps & {
+  // replaces the variant's default icon, e.g. with a spinner
+  icon?: React.ReactNode;
 };
 
 export const WarningIcon = styled.img.attrs({
@@ -25,7 +30,7 @@ export const InfoWarningIcon = styled.img.attrs({
   margin: 5px;
 `;
 
-const WarningContainer = styled.div<VaultWarningProps>`
+const WarningContainer = styled.div<VaultWarningVariantProps>`
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -47,7 +52,7 @@ const WarningContainer = styled.div<VaultWarningProps>`
   }
 `;
 
-const WarningContent = styled.div<VaultWarningProps>`
+const WarningContent = styled.div<VaultWarningVariantProps>`
   flex: 1;
 
   font-size: 12px;
@@ -70,11 +75,11 @@ const WarningContent = styled.div<VaultWarningProps>`
 export const VaultWarning = ({
   children,
   variant = 'warning',
+  icon,
 }: React.PropsWithChildren<VaultWarningProps>) => {
   return (
     <WarningContainer variant={variant} data-testid="vault-warning">
-      {variant === 'warning' && <WarningIcon />}
-      {variant === 'info' && <InfoWarningIcon />}
+      {icon ?? (variant === 'warning' ? <WarningIcon /> : <InfoWarningIcon />)}
       <WarningContent variant={variant}>{children}</WarningContent>
     </WarningContainer>
   );

--- a/features/earn/vault-eth/deposit/deposit-form.tsx
+++ b/features/earn/vault-eth/deposit/deposit-form.tsx
@@ -25,7 +25,7 @@ export const EthVaultDepositForm: FC = () => {
     <EthDepositFormProvider>
       <UpgradeAssetsBlock />
       <BlockSidePanel>
-        <GeoNotice showLimitedNotice />
+        <GeoNotice />
         <ActionSwitch />
         <VaultForm data-testid="deposit-form">
           <VaultDepositWarning

--- a/features/earn/vault-eth/deposit/deposit-form.tsx
+++ b/features/earn/vault-eth/deposit/deposit-form.tsx
@@ -5,6 +5,7 @@ import { VaultForm } from 'features/earn/shared/vault-form';
 import { VaultTxInfo } from 'features/earn/shared/vault-tx-info';
 import { BlockSidePanel } from 'features/earn/shared/v2/block-side-panel/block-side-panel';
 import { VaultDepositWarning } from 'features/earn/shared/v2/vault-warning/vault-deposit-warning';
+import { GeoNotice } from 'features/earn/shared/v2/geo-notice';
 
 import { EthDepositFormProvider } from './form-context';
 import { EthVaultDepositInputGroup } from './deposit-input-group';
@@ -24,6 +25,7 @@ export const EthVaultDepositForm: FC = () => {
     <EthDepositFormProvider>
       <UpgradeAssetsBlock />
       <BlockSidePanel>
+        <GeoNotice showLimitedNotice />
         <ActionSwitch />
         <VaultForm data-testid="deposit-form">
           <VaultDepositWarning

--- a/features/earn/vault-eth/deposit/form-context/deposit-form-context.tsx
+++ b/features/earn/vault-eth/deposit/form-context/deposit-form-context.tsx
@@ -10,6 +10,7 @@ import { useFormControllerRetry } from 'shared/hook-form/form-controller/use-for
 import { useQueryParamsReferralForm } from 'shared/hooks/use-query-values-form';
 import { useDappStatus } from 'modules/web3/hooks/use-dapp-status';
 import { TOKEN_SYMBOLS } from 'consts/tokens';
+import { useEarnGeoGate } from 'features/earn/shared/hooks/use-earn-geo-gate';
 
 import type {
   ETHDepositFormDataContextValue,
@@ -42,6 +43,7 @@ export const EthVaultDepositFormProvider: React.FC<{
   // Wallet state
   const { isDappActive, isWalletConnected } = useDappStatus();
   const { isEthVaultAvailable, isDepositEnabled } = useEthVaultAvailable();
+  const { isDepositGeoAvailable } = useEarnGeoGate();
 
   const {
     validationContext,
@@ -59,7 +61,8 @@ export const EthVaultDepositFormProvider: React.FC<{
     defaultValues: { amount: null, token: TOKEN_SYMBOLS.eth, referral: null },
     disabled:
       (isWalletConnected && !isDappActive) ||
-      (isEthVaultAvailable && !isDepositEnabled),
+      (isEthVaultAvailable && !isDepositEnabled) ||
+      !isDepositGeoAvailable,
     criteriaMode: 'firstError',
     mode: 'onChange',
     context: validationContext,

--- a/features/earn/vault-eth/upgrade-assets/upgrade-assets.tsx
+++ b/features/earn/vault-eth/upgrade-assets/upgrade-assets.tsx
@@ -110,7 +110,7 @@ export const UpgradeAssetsBlock: FC = () => {
     [deposit, queryClient, referral, refetchBalances],
   );
 
-  if (!isWalletConnected) return null;
+  if (!isWalletConnected || !isDepositGeoAvailable) return null;
 
   const tokensWithBalance = ETH_VAULT_DEPOSIT_TOKENS_UPGRADABLE.filter(
     (token) => {
@@ -159,7 +159,6 @@ export const UpgradeAssetsBlock: FC = () => {
               })
             }
             loading={isUpgrading}
-            disabled={!isDepositGeoAvailable}
             data-testid="upgrade-button"
           >
             Upgrade

--- a/features/earn/vault-eth/upgrade-assets/upgrade-assets.tsx
+++ b/features/earn/vault-eth/upgrade-assets/upgrade-assets.tsx
@@ -9,6 +9,7 @@ import { trackMatomoEvent } from 'utils/track-matomo-event';
 import { MELLOW_VAULTS_QUERY_SCOPE } from 'modules/mellow-meta-vaults/consts';
 import { overrideWithQAMockBigInt } from 'utils/qa';
 import { useReferralQueryValue } from 'shared/hooks/use-query-values-form';
+import { useEarnGeoGate } from 'features/earn/shared/hooks/use-earn-geo-gate';
 
 import {
   UpgradeAssets,
@@ -58,6 +59,7 @@ export const UpgradeAssetsBlock: FC = () => {
   const { balances, refetchBalances } = useUpgradableTokenBalances();
   const [isUpgrading, setIsUpgrading] = useState(false);
   const referral = useReferralQueryValue();
+  const { isDepositGeoAvailable } = useEarnGeoGate();
   const { openDrawer: openDrawerRight } = useEthVaultDrawer();
 
   const { deposit } = useEthVaultDeposit();
@@ -157,6 +159,7 @@ export const UpgradeAssetsBlock: FC = () => {
               })
             }
             loading={isUpgrading}
+            disabled={!isDepositGeoAvailable}
             data-testid="upgrade-button"
           >
             Upgrade

--- a/features/earn/vault-eth/vault-card.tsx
+++ b/features/earn/vault-eth/vault-card.tsx
@@ -68,6 +68,7 @@ export const EthVaultCard = () => {
       }}
       protectedBadgeTooltipText={<ProtectedTooltip />}
       warning={<VaultListWarning warningText={listWarningText} />}
+      isGeoGated
     />
   );
 };

--- a/features/earn/vault-eth/withdraw/withdraw-form.tsx
+++ b/features/earn/vault-eth/withdraw/withdraw-form.tsx
@@ -8,7 +8,6 @@ import { VaultFormSection } from 'features/earn/shared/vault-form-section';
 import { VaultForm } from 'features/earn/shared/vault-form';
 import { BlockSidePanel } from 'features/earn/shared/v2/block-side-panel/block-side-panel';
 import { VaultWithdrawWarning } from 'features/earn/shared/v2/vault-warning/vault-withdraw-warning';
-import { GeoNotice } from 'features/earn/shared/v2/geo-notice';
 import { WITHDRAWAL_WAITING_TIME_TOOLTIP } from 'modules/mellow-meta-vaults';
 
 import { EthVaultWithdrawFormProvider } from './form-context';
@@ -29,7 +28,6 @@ const EthVaultWithdrawFormContent: FC = () => {
     <>
       <UpgradeAssetsBlock />
       <BlockSidePanel>
-        <GeoNotice />
         <ActionSwitch isWithdraw />
         <VaultForm data-testid="withdraw-form">
           <VaultWithdrawWarning

--- a/features/earn/vault-eth/withdraw/withdraw-form.tsx
+++ b/features/earn/vault-eth/withdraw/withdraw-form.tsx
@@ -8,6 +8,7 @@ import { VaultFormSection } from 'features/earn/shared/vault-form-section';
 import { VaultForm } from 'features/earn/shared/vault-form';
 import { BlockSidePanel } from 'features/earn/shared/v2/block-side-panel/block-side-panel';
 import { VaultWithdrawWarning } from 'features/earn/shared/v2/vault-warning/vault-withdraw-warning';
+import { GeoNotice } from 'features/earn/shared/v2/geo-notice';
 import { WITHDRAWAL_WAITING_TIME_TOOLTIP } from 'modules/mellow-meta-vaults';
 
 import { EthVaultWithdrawFormProvider } from './form-context';
@@ -28,6 +29,7 @@ const EthVaultWithdrawFormContent: FC = () => {
     <>
       <UpgradeAssetsBlock />
       <BlockSidePanel>
+        <GeoNotice />
         <ActionSwitch isWithdraw />
         <VaultForm data-testid="withdraw-form">
           <VaultWithdrawWarning

--- a/features/earn/vault-ggv/withdraw/ggv-withdraw-request/style.ts
+++ b/features/earn/vault-ggv/withdraw/ggv-withdraw-request/style.ts
@@ -7,8 +7,7 @@ export const RequestsContainer = styled.div`
   padding: ${({ theme }) => theme.spaceMap.md}px;
   border-radius: ${({ theme }) => theme.borderRadiusesMap.lg}px;
   gap: 12px;
-  background-color: ${({ theme }) =>
-    theme.name === 'light' ? `#F6F7F8` : 'var(--lido-color-controlBg)'};
+  background-color: var(--custom-color-controlBg);
 `;
 
 export const RequestSectionTitle = styled.h3`

--- a/features/earn/vault-stg/components/stg-request/styles.tsx
+++ b/features/earn/vault-stg/components/stg-request/styles.tsx
@@ -4,8 +4,7 @@ export const RequestsContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 12px;
-  background-color: ${({ theme }) =>
-    theme.name === 'light' ? `#F6F7F8` : 'var(--lido-color-controlBg)'};
+  background-color: var(--custom-color-controlBg);
   padding: ${({ theme }) => theme.spaceMap.md}px;
   margin-bottom: ${({ theme }) => theme.spaceMap.lg}px;
   border-radius: ${({ theme }) => theme.borderRadiusesMap.lg}px;

--- a/features/earn/vault-usd/deposit/form-context/deposit-form-context.tsx
+++ b/features/earn/vault-usd/deposit/form-context/deposit-form-context.tsx
@@ -10,6 +10,7 @@ import { useFormControllerRetry } from 'shared/hook-form/form-controller/use-for
 import { useQueryParamsReferralForm } from 'shared/hooks/use-query-values-form';
 import { useDappStatus } from 'modules/web3/hooks/use-dapp-status';
 import { TOKEN_SYMBOLS } from 'consts/tokens';
+import { useEarnGeoGate } from 'features/earn/shared/hooks/use-earn-geo-gate';
 
 import type {
   USDDepositFormDataContextValue,
@@ -42,6 +43,7 @@ export const UsdVaultDepositFormProvider: React.FC<{
   // Wallet state
   const { isDappActive, isWalletConnected } = useDappStatus();
   const { isUsdVaultAvailable, isDepositEnabled } = useUsdVaultAvailable();
+  const { isDepositGeoAvailable } = useEarnGeoGate();
 
   const {
     validationContext,
@@ -59,7 +61,8 @@ export const UsdVaultDepositFormProvider: React.FC<{
     defaultValues: { amount: null, token: TOKEN_SYMBOLS.usdc, referral: null },
     disabled:
       (isWalletConnected && !isDappActive) ||
-      (isUsdVaultAvailable && !isDepositEnabled),
+      (isUsdVaultAvailable && !isDepositEnabled) ||
+      !isDepositGeoAvailable,
     criteriaMode: 'firstError',
     mode: 'onChange',
     context: validationContext,

--- a/features/earn/vault-usd/position-manager/position-manager.tsx
+++ b/features/earn/vault-usd/position-manager/position-manager.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../consts';
 import { SwitchStyled } from './styles';
 import { BlockSidePanel } from 'features/earn/shared/v2/block-side-panel/block-side-panel';
+import { GeoNotice } from 'features/earn/shared/v2/geo-notice';
 
 const routes = [
   {
@@ -33,6 +34,7 @@ export const UsdVaultPositionManager: FC<{
   const isWithdraw = action === EARN_VAULT_WITHDRAW_SLUG;
   return (
     <BlockSidePanel>
+      <GeoNotice showLimitedNotice={isDeposit} />
       <SwitchStyled routes={routes} checked={isWithdraw} fullwidth />
       {isDeposit && <UsdVaultDepositForm />}
       {isWithdraw && <UsdVaultWithdrawForm />}

--- a/features/earn/vault-usd/position-manager/position-manager.tsx
+++ b/features/earn/vault-usd/position-manager/position-manager.tsx
@@ -34,7 +34,7 @@ export const UsdVaultPositionManager: FC<{
   const isWithdraw = action === EARN_VAULT_WITHDRAW_SLUG;
   return (
     <BlockSidePanel>
-      <GeoNotice showLimitedNotice={isDeposit} />
+      {isDeposit && <GeoNotice />}
       <SwitchStyled routes={routes} checked={isWithdraw} fullwidth />
       {isDeposit && <UsdVaultDepositForm />}
       {isWithdraw && <UsdVaultWithdrawForm />}

--- a/features/earn/vault-usd/vault-card.tsx
+++ b/features/earn/vault-usd/vault-card.tsx
@@ -67,6 +67,7 @@ export const UsdVaultCard = () => {
       }}
       protectedBadgeTooltipText={<ProtectedTooltip />}
       warning={<VaultListWarning warningText={listWarningText} />}
+      isGeoGated
     />
   );
 };

--- a/modules/mellow-meta-vaults/components/request/styles.tsx
+++ b/modules/mellow-meta-vaults/components/request/styles.tsx
@@ -4,8 +4,7 @@ export const RequestsContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 12px;
-  background-color: ${({ theme }) =>
-    theme.name === 'light' ? `#F6F7F8` : 'var(--lido-color-controlBg)'};
+  background-color: var(--custom-color-controlBg);
   padding: ${({ theme }) => theme.spaceMap.md}px;
   margin-bottom: ${({ theme }) => theme.spaceMap.lg}px;
   border-radius: ${({ theme }) => theme.borderRadiusesMap.lg}px;

--- a/pages/api/geo.ts
+++ b/pages/api/geo.ts
@@ -1,0 +1,30 @@
+import {
+  wrapRequest as wrapNextRequest,
+  cacheControl,
+} from '@lidofinance/next-api-wrapper';
+
+import { config } from 'config';
+import { API_ROUTES } from 'consts/api';
+import {
+  defaultErrorHandler,
+  responseTimeMetric,
+  rateLimit,
+  httpMethodGuard,
+  HttpMethod,
+} from 'utilsApi';
+import { geoHandler } from 'utilsApi/geo-handler';
+import Metrics from 'utilsApi/metrics';
+
+// No `cors` wrapper here, unlike the other routes. Those serve public data;
+// this one answers with the caller's own country. Without an
+// `Access-Control-Allow-Origin` header the browser lets only our own pages
+// read the answer, so another site cannot fetch it from a visitor's browser
+// to learn where they are. Embedding still works: inside an iframe the page
+// origin is still ours.
+export default wrapNextRequest([
+  httpMethodGuard([HttpMethod.GET]),
+  rateLimit,
+  responseTimeMetric(Metrics.request.apiTimings, API_ROUTES.GEO),
+  cacheControl({ headers: config.CACHE_GEO_HEADERS }),
+  defaultErrorHandler,
+])(geoHandler);

--- a/scripts/log-environment-variables.mjs
+++ b/scripts/log-environment-variables.mjs
@@ -21,6 +21,7 @@ export const openKeys = [
   'CSP_REPORT_URI',
 
   'ENABLE_QA_HELPERS',
+  'QA_GEO_COUNTRY',
 
   'REWARDS_BACKEND',
   'VALIDATION_SERVICE_BASE_PATH',

--- a/shared/banners/info-banner/styles.tsx
+++ b/shared/banners/info-banner/styles.tsx
@@ -36,8 +36,7 @@ export const BannerContainer = styled.div<BannerProps>`
   ${({ variant }) =>
     variant === 'info' &&
     css`
-      background-color: ${({ theme }) =>
-        theme.name === 'light' ? `#F6F7F8` : 'var(--lido-color-controlBg)'};
+      background-color: var(--custom-color-controlBg);
     `}
 
   ${({ theme }) => theme.mediaQueries.md} {

--- a/shared/hooks/index.ts
+++ b/shared/hooks/index.ts
@@ -4,3 +4,4 @@ export * from './useLidoApr';
 export * from './useStakingLimitInfo';
 export * from './useMatomoEventHandle';
 export * from './useDebouncedValue';
+export * from './use-geo-availability';

--- a/shared/hooks/use-geo-availability.ts
+++ b/shared/hooks/use-geo-availability.ts
@@ -1,19 +1,42 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { config } from 'config';
+import { config, useConfig } from 'config';
 import { API_ROUTES, getApiPath } from 'consts/api';
-import {
-  GEO_AVAILABILITY,
-  resolveGeoAvailability,
-  type GeoResponse,
-} from 'consts/geo';
+import { GEO_AVAILABILITY, type GeoResponse } from 'consts/geo';
 import { STRATEGY_IMMUTABLE } from 'consts/react-query-strategies';
+import { getGeoAvailability, resolveGeoAvailability } from 'utils/geo';
 import { standardFetcher } from 'utils/standardFetcher';
 
 // The IPFS bundle ships without /api/* routes, so there is nothing to ask —
 // and with no region to trust, the fail-closed default applies: that build
 // renders the limited experience for everyone.
 const CAN_RESOLVE_REGION = !config.ipfsMode;
+
+const QA_COUNTRY_KEY = 'mock-qa-helpers-geo-country';
+
+// Pins the country per browser, for stands where the env cannot be changed and
+// for testers behind Cloudflare, who cannot change the country their IP
+// resolves to. Usage: `setMockGeoCountry('US')`, no argument clears it.
+if (config.enableQaHelpers && typeof window !== 'undefined') {
+  (window as any).setMockGeoCountry = (countryCode?: string) => {
+    if (countryCode === undefined) localStorage.removeItem(QA_COUNTRY_KEY);
+    else localStorage.setItem(QA_COUNTRY_KEY, countryCode);
+    window.location.reload();
+  };
+}
+
+// A typo is ignored rather than resolved. Read only inside `queryFn`, which is
+// client-only, so server-rendered output stays identical.
+const getMockedCountry = (): string | null => {
+  if (!config.enableQaHelpers) return null;
+
+  const countryCode = localStorage
+    .getItem(QA_COUNTRY_KEY)
+    ?.trim()
+    .toUpperCase();
+
+  return countryCode && /^[A-Z]{2}$/.test(countryCode) ? countryCode : null;
+};
 
 type UseGeoAvailabilityResult = GeoResponse & {
   isLimited: boolean;
@@ -31,13 +54,35 @@ type UseGeoAvailabilityResult = GeoResponse & {
  * A visitor's country does not change mid-session, so the query is immutable.
  */
 export const useGeoAvailability = (): UseGeoAvailabilityResult => {
+  const { geo } = useConfig().externalConfig;
+
   const { data, isLoading } = useQuery<GeoResponse>({
     queryKey: ['geo-availability'],
-    enabled: CAN_RESOLVE_REGION,
+    // the QA mock lives in localStorage, so the query has to run to read it
+    enabled: CAN_RESOLVE_REGION || config.enableQaHelpers,
     ...STRATEGY_IMMUTABLE,
+    // failing closed means a blip costs the visitor the full experience for the
+    // rest of the session, so retry a little and re-resolve on a recovered link
     retry: 2,
     refetchOnReconnect: true,
-    queryFn: () => standardFetcher<GeoResponse>(getApiPath(API_ROUTES.GEO)),
+    queryFn: async (): Promise<GeoResponse> => {
+      // the mock outranks everything, including a real Cloudflare header: the
+      // route is never asked, the country is resolved here against the same
+      // manifest list the route would have used
+      const mockedCountry = getMockedCountry();
+      if (mockedCountry) {
+        return {
+          country: mockedCountry,
+          availability: getGeoAvailability(mockedCountry, geo.limited),
+        };
+      }
+
+      if (!CAN_RESOLVE_REGION) {
+        return { country: null, availability: GEO_AVAILABILITY.limited };
+      }
+
+      return standardFetcher<GeoResponse>(getApiPath(API_ROUTES.GEO));
+    },
   });
 
   const availability = resolveGeoAvailability(data?.availability);

--- a/shared/hooks/use-geo-availability.ts
+++ b/shared/hooks/use-geo-availability.ts
@@ -38,9 +38,12 @@ const getMockedCountry = (): string | null => {
   return countryCode && /^[A-Z]{2}$/.test(countryCode) ? countryCode : null;
 };
 
+// the QA mock lives in localStorage, so the query has to run to read it
+const IS_QUERY_ENABLED = CAN_RESOLVE_REGION || config.enableQaHelpers;
+
 type UseGeoAvailabilityResult = GeoResponse & {
   isLimited: boolean;
-  isLoading: boolean;
+  isResolving: boolean;
 };
 
 /**
@@ -48,18 +51,24 @@ type UseGeoAvailabilityResult = GeoResponse & {
  *
  * Fail-closed: `limited` holds until the route positively answers `full`, so a
  * request in flight, a failed one, and a build without the route all read as
- * limited. Render against `isLoading` rather than `isLimited` alone if the
+ * limited. Render against `isResolving` rather than `isLimited` alone if the
  * screen should not settle before the answer arrives.
  *
- * A visitor's country does not change mid-session, so the query is immutable.
+ * `isResolving` covers both "the browser has not asked yet" and "the request is
+ * in flight", which is what a statically rendered page needs: the prerendered
+ * HTML must not claim the region is limited before anyone has asked, or it
+ * flashes that claim at every visitor and mismatches on hydration. A build that
+ * never asks is not resolving — it is already answered, fail-closed.
+ *
+ * A visitor's country does not change mid-session, so the query is immutable —
+ * the answer survives client-side navigation between earn pages.
  */
 export const useGeoAvailability = (): UseGeoAvailabilityResult => {
   const { geo } = useConfig().externalConfig;
 
-  const { data, isLoading } = useQuery<GeoResponse>({
+  const { data, isPending } = useQuery<GeoResponse>({
     queryKey: ['geo-availability'],
-    // the QA mock lives in localStorage, so the query has to run to read it
-    enabled: CAN_RESOLVE_REGION || config.enableQaHelpers,
+    enabled: IS_QUERY_ENABLED,
     ...STRATEGY_IMMUTABLE,
     // failing closed means a blip costs the visitor the full experience for the
     // rest of the session, so retry a little and re-resolve on a recovered link
@@ -91,6 +100,6 @@ export const useGeoAvailability = (): UseGeoAvailabilityResult => {
     country: data?.country ?? null,
     availability,
     isLimited: availability === GEO_AVAILABILITY.limited,
-    isLoading,
+    isResolving: IS_QUERY_ENABLED && isPending,
   };
 };

--- a/shared/hooks/use-geo-availability.ts
+++ b/shared/hooks/use-geo-availability.ts
@@ -1,0 +1,51 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { config } from 'config';
+import { API_ROUTES, getApiPath } from 'consts/api';
+import {
+  GEO_AVAILABILITY,
+  resolveGeoAvailability,
+  type GeoResponse,
+} from 'consts/geo';
+import { STRATEGY_IMMUTABLE } from 'consts/react-query-strategies';
+import { standardFetcher } from 'utils/standardFetcher';
+
+// The IPFS bundle ships without /api/* routes, so there is nothing to ask —
+// and with no region to trust, the fail-closed default applies: that build
+// renders the limited experience for everyone.
+const CAN_RESOLVE_REGION = !config.ipfsMode;
+
+type UseGeoAvailabilityResult = GeoResponse & {
+  isLimited: boolean;
+  isLoading: boolean;
+};
+
+/**
+ * Which experience the UI should render for the visitor's country.
+ *
+ * Fail-closed: `limited` holds until the route positively answers `full`, so a
+ * request in flight, a failed one, and a build without the route all read as
+ * limited. Render against `isLoading` rather than `isLimited` alone if the
+ * screen should not settle before the answer arrives.
+ *
+ * A visitor's country does not change mid-session, so the query is immutable.
+ */
+export const useGeoAvailability = (): UseGeoAvailabilityResult => {
+  const { data, isLoading } = useQuery<GeoResponse>({
+    queryKey: ['geo-availability'],
+    enabled: CAN_RESOLVE_REGION,
+    ...STRATEGY_IMMUTABLE,
+    retry: 2,
+    refetchOnReconnect: true,
+    queryFn: () => standardFetcher<GeoResponse>(getApiPath(API_ROUTES.GEO)),
+  });
+
+  const availability = resolveGeoAvailability(data?.availability);
+
+  return {
+    country: data?.country ?? null,
+    availability,
+    isLimited: availability === GEO_AVAILABILITY.limited,
+    isLoading,
+  };
+};

--- a/styles/global.ts
+++ b/styles/global.ts
@@ -1,7 +1,6 @@
 import { createGlobalStyle } from 'styled-components';
 
 import { NAV_MOBILE_HEIGHT, NAV_MOBILE_MAX_WIDTH } from './constants';
-import { ThemeName } from '@lidofinance/lido-ui';
 
 export const devicesHeaderMedia = {
   mobile: `screen and (max-width: ${NAV_MOBILE_MAX_WIDTH}px)`,
@@ -24,8 +23,40 @@ const GlobalStyle = createGlobalStyle`
     --footer-mobile-padding-y: 18px;
     --footer-mobile-margin-bottom: 60px;
     
-    --custom-background-secondary: ${({ theme }) => (theme.name === ThemeName.light ? '#F6F8FA' : '#2D2D35')} ;
     --custom-background-dark: #28282f;
+  }
+
+  /*
+   * Theme-dependent tokens must branch in CSS, not on 'theme.name':
+   * - 'data-lido-theme' is stamped by a blocking script in <head> (LidoUIHead),
+   *   so CSS resolves the right value on the first paint
+   * - 'theme.name' from CookieThemeProvider is 'light' until hydration, so any
+   *   JS-side branch flashes the light value on slow connections
+   *
+   * Selector shape mirrors lido-ui's own --lido-color-* declarations
+   * (element-theme-colors) — the theme has three states, not two:
+   * - no attribute = follow system; the head script deletes it when no cookie
+   * - 'html' (0,0,1), not ':root' (0,1,0), keeps the light base strictly
+   *   weaker than [data-lido-theme='dark'] instead of tying with it
+   * - unqualified [data-lido-theme='light'] also matches nested
+   *   ThemeProvider wrappers, which stamp the attribute on a <div>
+   * - :not([data-lido-theme='light']) inside the media query stops an
+   *   explicit light cookie from losing to the system-dark rule
+   */
+  html,
+  [data-lido-theme='light'] {
+    --custom-color-controlBg: #f6f7f8;
+    --custom-background-secondary: #F6F8FA;
+  }
+  @media (prefers-color-scheme: dark) {
+    html:not([data-lido-theme='light']) {
+      --custom-color-controlBg: var(--lido-color-controlBg);
+      --custom-background-secondary: #2D2D35;
+    }
+  }
+  [data-lido-theme='dark'] {
+    --custom-color-controlBg: var(--lido-color-controlBg);
+    --custom-background-secondary: #2D2D35;
   }
   * {
     margin: 0;

--- a/utils/__tests__/geo.test.ts
+++ b/utils/__tests__/geo.test.ts
@@ -1,4 +1,4 @@
-import { resolveGeoAvailability } from '../geo';
+import { getGeoAvailability, resolveGeoAvailability } from '../geo';
 
 describe('resolveGeoAvailability', () => {
   it('passes through an explicit full', () => {
@@ -22,5 +22,29 @@ describe('resolveGeoAvailability', () => {
     ['an object', { availability: 'full' }],
   ])('resolves %s to limited', (_label, value) => {
     expect(resolveGeoAvailability(value)).toBe('limited');
+  });
+});
+
+describe('getGeoAvailability', () => {
+  it('reports limited for a listed country', () => {
+    expect(getGeoAvailability('US', ['US'])).toBe('limited');
+  });
+
+  it('reports full for a country that is not listed', () => {
+    expect(getGeoAvailability('DE', ['US'])).toBe('full');
+  });
+
+  it('reports full when the list is empty', () => {
+    expect(getGeoAvailability('US', [])).toBe('full');
+  });
+
+  // the schema uppercases both sides, but the handler and the QA mock must not
+  // start disagreeing if that ever changes
+  it.each([
+    ['us', ['US']],
+    ['US', ['us']],
+    ['us', ['us']],
+  ])('matches %o against %o regardless of case', (country, limited) => {
+    expect(getGeoAvailability(country, limited)).toBe('limited');
   });
 });

--- a/utils/__tests__/geo.test.ts
+++ b/utils/__tests__/geo.test.ts
@@ -1,4 +1,8 @@
-import { getGeoAvailability, resolveGeoAvailability } from '../geo';
+import {
+  getGeoAvailability,
+  getGeoNoticeState,
+  resolveGeoAvailability,
+} from '../geo';
 
 describe('resolveGeoAvailability', () => {
   it('passes through an explicit full', () => {
@@ -46,5 +50,110 @@ describe('getGeoAvailability', () => {
     ['us', ['us']],
   ])('matches %o against %o regardless of case', (country, limited) => {
     expect(getGeoAvailability(country, limited)).toBe('limited');
+  });
+});
+
+const BASE = {
+  isChecking: false,
+  isSlow: false,
+  // the hook is fail-closed, so an in-flight check already reads as limited
+  isLimited: true,
+  // the common case is a country that resolved and turned out to be listed
+  isUnresolved: false,
+  showLimitedNotice: false,
+};
+
+describe('getGeoNoticeState', () => {
+  it('reports the short copy while the check is in flight', () => {
+    expect(getGeoNoticeState({ ...BASE, isChecking: true })).toBe('checking');
+  });
+
+  it('switches to the slow copy once the delay is exceeded', () => {
+    expect(getGeoNoticeState({ ...BASE, isChecking: true, isSlow: true })).toBe(
+      'checking-slow',
+    );
+  });
+
+  // the deposit page mounts with `showLimitedNotice`, but the checking copy has
+  // to win until the answer lands. This is also the prerender case: these pages
+  // are statically generated, and a build that claimed "not available in your
+  // region" would flash that at every visitor and mismatch on hydration
+  it('prefers the checking copy over the limited one', () => {
+    expect(
+      getGeoNoticeState({
+        ...BASE,
+        isChecking: true,
+        showLimitedNotice: true,
+      }),
+    ).toBe('checking');
+  });
+
+  it('reports the limited copy on a deposit page once the answer lands', () => {
+    expect(getGeoNoticeState({ ...BASE, showLimitedNotice: true })).toBe(
+      'limited',
+    );
+  });
+
+  // withdraw and claim stay available in a limited region, so the message must
+  // not appear there
+  it('renders nothing for a limited region when the notice is not requested', () => {
+    expect(getGeoNoticeState(BASE)).toBeNull();
+  });
+
+  it.each([[false], [true]])(
+    'renders nothing for a full region (showLimitedNotice: %s)',
+    (showLimitedNotice) => {
+      expect(
+        getGeoNoticeState({ ...BASE, isLimited: false, showLimitedNotice }),
+      ).toBeNull();
+    },
+  );
+
+  // isSlow is stale state left over from a previous check; it must not resurrect
+  // the checking copy after the answer arrives
+  it('ignores a stale slow flag once the check is done', () => {
+    expect(
+      getGeoNoticeState({ ...BASE, isSlow: true, isLimited: false }),
+    ).toBeNull();
+  });
+
+  // no Cloudflare header, a failed request or a build without the route: the
+  // region was never named, so the copy must not claim it is a restricted one
+  it('reports the unresolved copy when no country came back', () => {
+    expect(
+      getGeoNoticeState({
+        ...BASE,
+        isUnresolved: true,
+        showLimitedNotice: true,
+      }),
+    ).toBe('unresolved');
+  });
+
+  it('prefers the unresolved copy over the limited one', () => {
+    expect(
+      getGeoNoticeState({
+        ...BASE,
+        isUnresolved: true,
+        isLimited: true,
+        showLimitedNotice: true,
+      }),
+    ).toBe('unresolved');
+  });
+
+  it('prefers the checking copy over the unresolved one', () => {
+    expect(
+      getGeoNoticeState({
+        ...BASE,
+        isChecking: true,
+        isUnresolved: true,
+        showLimitedNotice: true,
+      }),
+    ).toBe('checking');
+  });
+
+  // withdraw stays available, and the copy talks about deposits, so it belongs
+  // to the deposit page only
+  it('renders nothing for an unresolved region when the notice is not requested', () => {
+    expect(getGeoNoticeState({ ...BASE, isUnresolved: true })).toBeNull();
   });
 });

--- a/utils/geo.ts
+++ b/utils/geo.ts
@@ -1,0 +1,26 @@
+import { GEO_AVAILABILITY, type GeoAvailability } from 'consts/geo';
+
+/**
+ * Narrows an untrusted value to an availability, fail-closed: only a literal
+ * `full` yields the full experience. Takes `unknown` on purpose — the API
+ * response is parsed JSON that nothing has validated, so a truncated or
+ * unexpected body has to land on `limited` rather than be trusted.
+ */
+export const resolveGeoAvailability = (value: unknown): GeoAvailability =>
+  value === GEO_AVAILABILITY.full
+    ? GEO_AVAILABILITY.full
+    : GEO_AVAILABILITY.limited;
+
+/**
+ * The one place that decides whether a country gets the limited experience.
+ * Shared by `/api/geo` and the QA mock in the client hook, so both answer the
+ * same way. The schema already uppercases the list; compared defensively in
+ * case that ever changes.
+ */
+export const getGeoAvailability = (
+  country: string,
+  limitedCountries: string[],
+): GeoAvailability =>
+  limitedCountries.some((code) => code.toUpperCase() === country.toUpperCase())
+    ? GEO_AVAILABILITY.limited
+    : GEO_AVAILABILITY.full;

--- a/utils/geo.ts
+++ b/utils/geo.ts
@@ -24,3 +24,38 @@ export const getGeoAvailability = (
   limitedCountries.some((code) => code.toUpperCase() === country.toUpperCase())
     ? GEO_AVAILABILITY.limited
     : GEO_AVAILABILITY.full;
+
+export type GeoNoticeState =
+  'checking' | 'checking-slow' | 'limited' | 'unresolved';
+
+type GetGeoNoticeStateArgs = {
+  /** the region is not resolved yet — the browser has not asked, or is asking */
+  isChecking: boolean;
+  isSlow: boolean;
+  isLimited: boolean;
+  /** the check finished without a country — the region could not be verified */
+  isUnresolved: boolean;
+  /** withdraw stays available in a limited region, so only deposit surfaces it */
+  showLimitedNotice: boolean;
+};
+
+/**
+ * Which region notice a vault page shows, if any.
+ */
+export const getGeoNoticeState = ({
+  isChecking,
+  isSlow,
+  isLimited,
+  isUnresolved,
+  showLimitedNotice,
+}: GetGeoNoticeStateArgs): GeoNoticeState | null => {
+  // `isLimited` is fail-closed, so it is already true while the check runs —
+  // the checking copy has to win until the answer actually lands
+  if (isChecking) return isSlow ? 'checking-slow' : 'checking';
+  if (!showLimitedNotice) return null;
+  // an unverified region is locked the same way, but it is not a verdict about
+  // the visitor's country, so it gets its own copy
+  if (isUnresolved) return 'unresolved';
+  if (isLimited) return 'limited';
+  return null;
+};

--- a/utilsApi/__tests__/geo-handler.test.ts
+++ b/utilsApi/__tests__/geo-handler.test.ts
@@ -1,0 +1,145 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type { MockInstance } from 'vitest';
+
+import type { ManifestConfig } from 'config/external-config';
+
+import { getExternalConfig } from '../get-external-config';
+import { geoHandler } from '../geo-handler';
+
+vi.mock('../get-external-config', () => ({
+  getExternalConfig: vi.fn(),
+}));
+
+const getExternalConfigMock = vi.mocked(getExternalConfig);
+
+type MockRes = NextApiResponse & {
+  _status: number;
+  _sent: unknown;
+};
+
+const makeRes = (): MockRes => {
+  const res: any = {
+    _status: 0,
+    _sent: undefined,
+    status(code: number) {
+      this._status = code;
+      return this;
+    },
+    json(body: unknown) {
+      this._sent = body;
+      return this;
+    },
+  };
+  return res as MockRes;
+};
+
+const makeReq = (headers: Record<string, string | string[]>): NextApiRequest =>
+  ({
+    method: 'GET',
+    headers,
+    query: {},
+  }) as unknown as NextApiRequest;
+
+// typed against the manifest so a renamed config field fails here rather than
+// leaving the handler reading `undefined` through a loosely cast mock
+const setLimitedCountries = (limited: string[]) => {
+  const geo: ManifestConfig['geo'] = { limited };
+  getExternalConfigMock.mockResolvedValue({ geo } as ManifestConfig);
+};
+
+const call = async (headers: Record<string, string | string[]> = {}) => {
+  const res = makeRes();
+  await geoHandler(makeReq(headers), res);
+  return res;
+};
+
+describe('geoHandler', () => {
+  let errorSpy: MockInstance;
+
+  beforeEach(() => {
+    setLimitedCountries(['US']);
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it('reports the limited experience for a listed country', async () => {
+    const res = await call({ 'cf-ipcountry': 'US' });
+
+    expect(res._status).toBe(200);
+    expect(res._sent).toEqual({ country: 'US', availability: 'limited' });
+  });
+
+  it('reports the full experience for any other country', async () => {
+    const res = await call({ 'cf-ipcountry': 'DE' });
+
+    expect(res._sent).toEqual({ country: 'DE', availability: 'full' });
+  });
+
+  it('normalizes the case of the header before matching', async () => {
+    const res = await call({ 'cf-ipcountry': ' us ' });
+
+    expect(res._sent).toEqual({ country: 'US', availability: 'limited' });
+  });
+
+  it('matches case-insensitively against the manifest list', async () => {
+    setLimitedCountries(['us']);
+    const res = await call({ 'cf-ipcountry': 'US' });
+
+    expect(res._sent).toEqual({ country: 'US', availability: 'limited' });
+  });
+
+  it('reads the first value when the header arrives repeated', async () => {
+    const res = await call({ 'cf-ipcountry': ['US', 'DE'] });
+
+    expect(res._sent).toEqual({ country: 'US', availability: 'limited' });
+  });
+
+  it('reports the full experience when the manifest lists no countries', async () => {
+    setLimitedCountries([]);
+    const res = await call({ 'cf-ipcountry': 'US' });
+
+    expect(res._sent).toEqual({ country: 'US', availability: 'full' });
+  });
+
+  describe('fail-closed', () => {
+    it('answers limited when the header is missing', async () => {
+      const res = await call();
+
+      expect(res._status).toBe(200);
+      expect(res._sent).toEqual({ country: null, availability: 'limited' });
+    });
+
+    // 'XX' is what Cloudflare sends when it cannot resolve the address, 'T1'
+    // for Tor exit nodes; the rest are not alpha-2 codes at all
+    it.each(['XX', 'T1', 'USA', 'U', '', '  ', '1S'])(
+      'answers limited for the unresolvable country %o',
+      async (value) => {
+        const res = await call({ 'cf-ipcountry': value });
+
+        expect(res._sent).toEqual({ country: null, availability: 'limited' });
+      },
+    );
+
+    it('answers limited when the config cannot be read', async () => {
+      getExternalConfigMock.mockRejectedValue(
+        new Error('manifest unavailable'),
+      );
+      const res = await call({ 'cf-ipcountry': 'DE' });
+
+      expect(res._status).toBe(200);
+      expect(res._sent).toEqual({ country: 'DE', availability: 'limited' });
+      expect(errorSpy).toHaveBeenCalled();
+    });
+
+    it('never answers full without a resolved country', async () => {
+      setLimitedCountries([]);
+      const res = await call();
+
+      expect(res._sent).toEqual({ country: null, availability: 'limited' });
+    });
+  });
+});

--- a/utilsApi/__tests__/geo-handler.test.ts
+++ b/utilsApi/__tests__/geo-handler.test.ts
@@ -10,6 +10,14 @@ vi.mock('../get-external-config', () => ({
   getExternalConfig: vi.fn(),
 }));
 
+// the handler only reads these two, and both need to vary per test
+const configMock = vi.hoisted(() => ({
+  enableQaHelpers: false,
+  qaGeoCountry: undefined as string | undefined,
+}));
+
+vi.mock('config', () => ({ config: configMock }));
+
 const getExternalConfigMock = vi.mocked(getExternalConfig);
 
 type MockRes = NextApiResponse & {
@@ -56,13 +64,19 @@ const call = async (headers: Record<string, string | string[]> = {}) => {
 describe('geoHandler', () => {
   let errorSpy: MockInstance;
 
+  let infoSpy: MockInstance;
+
   beforeEach(() => {
     setLimitedCountries(['US']);
+    configMock.enableQaHelpers = false;
+    configMock.qaGeoCountry = undefined;
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
   });
 
   afterEach(() => {
     errorSpy.mockRestore();
+    infoSpy.mockRestore();
     vi.clearAllMocks();
   });
 
@@ -141,5 +155,49 @@ describe('geoHandler', () => {
 
       expect(res._sent).toEqual({ country: null, availability: 'limited' });
     });
+  });
+
+  describe('QA_GEO_COUNTRY', () => {
+    it('is ignored while QA helpers are off', async () => {
+      configMock.qaGeoCountry = 'DE';
+      const res = await call();
+
+      expect(res._sent).toEqual({ country: null, availability: 'limited' });
+    });
+
+    it('stands in for a missing header when QA helpers are on', async () => {
+      configMock.enableQaHelpers = true;
+      configMock.qaGeoCountry = 'DE';
+      const res = await call();
+
+      expect(res._sent).toEqual({ country: 'DE', availability: 'full' });
+    });
+
+    it('runs the manifest lookup on the stand-in like any other country', async () => {
+      configMock.enableQaHelpers = true;
+      configMock.qaGeoCountry = 'us';
+      const res = await call();
+
+      expect(res._sent).toEqual({ country: 'US', availability: 'limited' });
+    });
+
+    it('never overrides a header Cloudflare did set', async () => {
+      configMock.enableQaHelpers = true;
+      configMock.qaGeoCountry = 'DE';
+      const res = await call({ 'cf-ipcountry': 'US' });
+
+      expect(res._sent).toEqual({ country: 'US', availability: 'limited' });
+    });
+
+    it.each(['XX', 'T1', 'USA', '', 'not-a-code'])(
+      'falls back to limited for the unusable value %o',
+      async (value) => {
+        configMock.enableQaHelpers = true;
+        configMock.qaGeoCountry = value;
+        const res = await call();
+
+        expect(res._sent).toEqual({ country: null, availability: 'limited' });
+      },
+    );
   });
 });

--- a/utilsApi/geo-handler.ts
+++ b/utilsApi/geo-handler.ts
@@ -1,6 +1,8 @@
 import type { API } from '@lidofinance/next-api-wrapper';
 
+import { config } from 'config';
 import { GEO_AVAILABILITY, type GeoResponse } from 'consts/geo';
+import { getGeoAvailability } from 'utils/geo';
 
 import { getExternalConfig } from './get-external-config';
 
@@ -10,20 +12,30 @@ import { getExternalConfig } from './get-external-config';
 const CF_COUNTRY_HEADER = 'cf-ipcountry';
 const UNRESOLVED_COUNTRY_CODES = new Set(['XX', 'T1']);
 
-const readCountry = (raw: string | string[] | undefined): string | null => {
-  const value = (Array.isArray(raw) ? raw[0] : raw)?.trim().toUpperCase();
+const getCountryCode = (raw: string | string[] | undefined): string | null => {
+  const countryCode = (Array.isArray(raw) ? raw[0] : raw)?.trim().toUpperCase();
 
-  if (!value || !/^[A-Z]{2}$/.test(value)) return null;
-  if (UNRESOLVED_COUNTRY_CODES.has(value)) return null;
+  if (!countryCode || !/^[A-Z]{2}$/.test(countryCode)) return null;
+  if (UNRESOLVED_COUNTRY_CODES.has(countryCode)) return null;
 
-  return value;
+  return countryCode;
 };
 
-// Log once per process: the header is either missing on every request or on
-// none of them, so logging each one is just noise. Error level, because in
-// production it means every visitor now gets the limited experience.
-let hasReportedUnresolvedCountry = false;
+// Without Cloudflare (local dev, test setups) the header never arrives, so
+// `experience` is always `limited`. `QA_GEO_COUNTRY` stands in for it:
+// - fallback, not override — a real header always wins
+// - only the header is faked, the rest of the logic runs as usual
+// - needs ENABLE_QA_HELPERS, which production does not set
+const getQaCountryCode = (): string | null =>
+  config.enableQaHelpers ? getCountryCode(config.qaGeoCountry) : null;
 
+// Both reports fire once per process: the header is either missing on every
+// request or on none of them, so logging each one is just noise.
+let hasReportedUnresolvedCountry = false;
+let hasReportedQaCountry = false;
+
+// Error level, because in production a missing header means every visitor now
+// gets the limited experience.
 const reportUnresolvedCountry = () => {
   if (hasReportedUnresolvedCountry) return;
   hasReportedUnresolvedCountry = true;
@@ -36,6 +48,18 @@ const reportUnresolvedCountry = () => {
   );
 };
 
+// Not an error: someone configured this deliberately. Still worth one line, so
+// a surprising answer is traceable to the env var rather than to the edge.
+const reportQaCountry = (country: string) => {
+  if (hasReportedQaCountry) return;
+  hasReportedQaCountry = true;
+
+  console.info(
+    `[geoHandler] no "${CF_COUNTRY_HEADER}" header — standing in for it with ` +
+      `QA_GEO_COUNTRY=${country}`,
+  );
+};
+
 /**
  * Handler for `/api/geo`. Tells the UI which experience to render.
  *
@@ -45,9 +69,15 @@ const reportUnresolvedCountry = () => {
  *   3. the country is not on that list
  *
  * Anything else answers availability: limited.
+ *
+ * Without Cloudflare, `QA_GEO_COUNTRY` can stand in for step 1 — see `getQaCountryCode`.
  */
 export const geoHandler: API = async (req, res) => {
-  const country = readCountry(req.headers[CF_COUNTRY_HEADER]);
+  const headerCountry = getCountryCode(req.headers[CF_COUNTRY_HEADER]);
+  const qaCountry = headerCountry ? null : getQaCountryCode();
+  const country = headerCountry ?? qaCountry;
+
+  if (qaCountry) reportQaCountry(qaCountry);
 
   if (!country) {
     reportUnresolvedCountry();
@@ -78,15 +108,9 @@ export const geoHandler: API = async (req, res) => {
     return;
   }
 
-  // the schema already uppercases the list, but compare case-insensitively
-  // anyway so this keeps working if that ever changes
-  const isListed = limitedCountries.some(
-    (code) => code.toUpperCase() === country,
-  );
-
   const response: GeoResponse = {
     country,
-    availability: isListed ? GEO_AVAILABILITY.limited : GEO_AVAILABILITY.full,
+    availability: getGeoAvailability(country, limitedCountries),
   };
 
   res.status(200).json(response);

--- a/utilsApi/geo-handler.ts
+++ b/utilsApi/geo-handler.ts
@@ -1,0 +1,93 @@
+import type { API } from '@lidofinance/next-api-wrapper';
+
+import { GEO_AVAILABILITY, type GeoResponse } from 'consts/geo';
+
+import { getExternalConfig } from './get-external-config';
+
+// Cloudflare sets this on every request once IP Geolocation is enabled for the
+// zone. Values are ISO 3166-1 alpha-2 plus two specials: `XX` when the address
+// could not be resolved and `T1` for Tor exit nodes.
+const CF_COUNTRY_HEADER = 'cf-ipcountry';
+const UNRESOLVED_COUNTRY_CODES = new Set(['XX', 'T1']);
+
+const readCountry = (raw: string | string[] | undefined): string | null => {
+  const value = (Array.isArray(raw) ? raw[0] : raw)?.trim().toUpperCase();
+
+  if (!value || !/^[A-Z]{2}$/.test(value)) return null;
+  if (UNRESOLVED_COUNTRY_CODES.has(value)) return null;
+
+  return value;
+};
+
+// Log once per process: the header is either missing on every request or on
+// none of them, so logging each one is just noise. Error level, because in
+// production it means every visitor now gets the limited experience.
+let hasReportedUnresolvedCountry = false;
+
+const reportUnresolvedCountry = () => {
+  if (hasReportedUnresolvedCountry) return;
+  hasReportedUnresolvedCountry = true;
+
+  console.error(
+    `[geoHandler] no usable "${CF_COUNTRY_HEADER}" header — requests without ` +
+      'it fall back to the limited experience. Expected when the origin is ' +
+      'reached directly (local dev, health probes); in production it means IP ' +
+      'Geolocation is off for the Cloudflare zone',
+  );
+};
+
+/**
+ * Handler for `/api/geo`. Tells the UI which experience to render.
+ *
+ * Answers availability: full only when all three are true:
+ *   1. Cloudflare resolved the country (the country comes from the `cf-ipcountry` header)
+ *   2. the config with the country list loaded
+ *   3. the country is not on that list
+ *
+ * Anything else answers availability: limited.
+ */
+export const geoHandler: API = async (req, res) => {
+  const country = readCountry(req.headers[CF_COUNTRY_HEADER]);
+
+  if (!country) {
+    reportUnresolvedCountry();
+    const response: GeoResponse = {
+      country: null,
+      availability: GEO_AVAILABILITY.limited,
+    };
+    res.status(200).json(response);
+    return;
+  }
+
+  let limitedCountries: string[];
+
+  try {
+    const { geo } = await getExternalConfig();
+    limitedCountries = geo.limited;
+  } catch (error) {
+    // no list means we cannot tell whether the country is on it
+    console.error(
+      '[geoHandler] could not read the geo config, answering with the limited experience',
+      error,
+    );
+    const response: GeoResponse = {
+      country,
+      availability: GEO_AVAILABILITY.limited,
+    };
+    res.status(200).json(response);
+    return;
+  }
+
+  // the schema already uppercases the list, but compare case-insensitively
+  // anyway so this keeps working if that ever changes
+  const isListed = limitedCountries.some(
+    (code) => code.toUpperCase() === country,
+  );
+
+  const response: GeoResponse = {
+    country,
+    availability: isListed ? GEO_AVAILABILITY.limited : GEO_AVAILABILITY.full,
+  };
+
+  res.status(200).json(response);
+};


### PR DESCRIPTION
### Testing notes

#### Option 1
- override `/api/geo` request, possible values:
  * region: 'US', 'DE'
  * availability: 'full', 'limited'
- throttle `/api/geo` using 1kbit/s speed

#### Option 2
- override REMOTE_CONFIG_MANIFEST.json, set `baseConfig.geo.limited: ["US"]`
- `setMockGeoCountry('US')`   // page reload → limited
- `setMockGeoCountry('DE')`   // page reload → full
- `setMockGeoCountry()`       // reset

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
