### PR TITLE
Earn – roll up all summary allocations to metavault level

### DIFF
--- a/features/earn/shared/v2/vault-allocation/allocation-table/allocation-group-row.tsx
+++ b/features/earn/shared/v2/vault-allocation/allocation-table/allocation-group-row.tsx
@@ -8,7 +8,6 @@ import { ProtocolIcon } from 'features/earn/shared/vault-allocation/protocol-ico
 import { ReactComponent as ChevronIcon } from 'assets/icons/chevron-gray-right.svg';
 
 import { AllocationGroup } from '../types';
-import { MIN_ALLOCATION_DISPLAY_PERCENT } from '../consts';
 import {
   ChevronWrapper,
   GroupTdStyled,
@@ -66,18 +65,10 @@ export const AllocationGroupRow: FC<AllocationGroupRowProps> = ({ group }) => {
                 mainIcon={item.icon ? <item.icon /> : null}
                 badge={item.chain}
               />
-              <ProtocolNameStyled>
-                {item.label}
-                {item.info && (
-                  <VaultTip placement="right">{item.info}</VaultTip>
-                )}
-              </ProtocolNameStyled>
+              <ProtocolNameStyled>{item.label}</ProtocolNameStyled>
             </NestedTdWithIconStyled>
             <TdNarrowStyled align="right">
-              {(!item.isSummary ||
-                item.allocation >= MIN_ALLOCATION_DISPLAY_PERCENT) && (
-                <FormatPercent value={item.allocation} decimals="percent" />
-              )}
+              <FormatPercent value={item.allocation} decimals="percent" />
             </TdNarrowStyled>
             <TdNarrowStyled align="right">
               <FormatLargeAmount amount={item.tvlUSD} />

--- a/features/earn/shared/v2/vault-allocation/hooks/use-allocation-data.test.tsx
+++ b/features/earn/shared/v2/vault-allocation/hooks/use-allocation-data.test.tsx
@@ -183,7 +183,7 @@ describe('useAllocationData grouping and sorting', () => {
     ]);
   });
 
-  it('moves nested Available to the flat summary row', () => {
+  it('rolls nested Others and Available up to the metavault summary rows', () => {
     const result = getAllocationData(
       createData([
         createFlatAllocation({
@@ -212,17 +212,16 @@ describe('useAllocationData grouping and sorting', () => {
       ]),
     );
 
-    expect(result.groups[0]?.items).toEqual([
-      expect.objectContaining({
-        label: 'Others',
-        isSummary: true,
-        allocation: 0.04,
-      }),
-    ]);
-    expect(result.groups[0]).toEqual(
-      expect.objectContaining({ allocation: 0.9998, tvlUSD: 99.98 }),
-    );
+    expect(result.groups[0]?.items).toEqual([]);
+    expect(result.groups[0]?.allocation).toBeCloseTo(0.9994, 10);
+    expect(result.groups[0]?.tvlUSD).toBeCloseTo(99.94, 10);
     expect(result.flatItems).toEqual([
+      expect.objectContaining({
+        name: 'Others',
+        isSummary: true,
+        allocation: 0.0004,
+        tvlUSD: 0.04,
+      }),
       expect.objectContaining({
         name: 'Available',
         isSummary: true,
@@ -277,6 +276,215 @@ describe('useAllocationData grouping and sorting', () => {
         tvlUSD: 130,
       }),
     );
+  });
+
+  it('merges nested Pending and Others into the metavault summary rows', () => {
+    const result = getAllocationData(
+      createData([
+        createFlatAllocation({
+          type: 'nested',
+          id: 'vault',
+          label: 'Vault',
+          sharePercent: 20,
+          allocations: [
+            createNestedAllocation('large', 50),
+            createNestedAllocation('pending-child', 30, {
+              category: 'pending-deposits',
+              protocol: undefined,
+            }),
+            createNestedAllocation('unknown-position', 20),
+          ],
+        }),
+      ]),
+    );
+
+    expect(result.groups[0]?.items).toEqual([
+      expect.objectContaining({ label: 'large', allocation: 50, tvlUSD: 50 }),
+    ]);
+    expect(result.groups[0]).toEqual(
+      expect.objectContaining({ allocation: 10, tvlUSD: 50 }),
+    );
+    expect(result.flatItems).toEqual([
+      expect.objectContaining({ name: 'Pending', allocation: 6, tvlUSD: 30 }),
+      expect.objectContaining({ name: 'Others', allocation: 4, tvlUSD: 20 }),
+    ]);
+  });
+
+  it('aggregates flat and nested Pending allocations into one final row', () => {
+    const result = getAllocationData(
+      createData([
+        createFlatAllocation({
+          id: 'flat-pending',
+          sharePercent: 5,
+          category: 'pending-deposits',
+          protocol: undefined,
+        }),
+        createFlatAllocation({
+          type: 'nested',
+          id: 'smaller-vault',
+          label: 'Smaller vault',
+          sharePercent: 20,
+          allocations: [
+            createNestedAllocation('nested-pending-1', 10, {
+              category: 'pending-deposits',
+              protocol: undefined,
+            }),
+          ],
+        }),
+        createFlatAllocation({
+          type: 'nested',
+          id: 'larger-vault',
+          label: 'Larger vault',
+          sharePercent: 30,
+          allocations: [
+            createNestedAllocation('nested-pending-2', 20, {
+              category: 'pending-deposits',
+              protocol: undefined,
+            }),
+          ],
+        }),
+      ]),
+    );
+
+    expect(result.groups.every((group) => group.items.length === 0)).toBe(true);
+    expect(result.flatItems).toEqual([
+      expect.objectContaining({
+        name: 'Pending',
+        allocation: 13,
+        tvlUSD: 130,
+      }),
+    ]);
+  });
+
+  it('never emits summary rows inside a subvault', () => {
+    const result = getAllocationData(
+      createData([
+        createFlatAllocation({
+          type: 'nested',
+          id: 'vault',
+          label: 'Vault',
+          sharePercent: 100,
+          allocations: [
+            createNestedAllocation('large', 40),
+            createNestedAllocation('token-child', 20, {
+              category: 'token',
+              protocol: undefined,
+            }),
+            createNestedAllocation('pending-child', 20, {
+              category: 'pending-deposits',
+              protocol: undefined,
+            }),
+            createNestedAllocation('other-child', 20, {
+              category: 'other',
+              protocol: undefined,
+            }),
+          ],
+        }),
+      ]),
+    );
+
+    expect(result.groups[0]?.items.map(({ label }) => label)).toEqual([
+      'large',
+    ]);
+    expect(result.flatItems?.map(({ name }) => name)).toEqual([
+      'Pending',
+      'Others',
+      'Available',
+    ]);
+  });
+
+  it('drops a fully rolled-up subvault without double counting it', () => {
+    const result = getAllocationData(
+      createData([
+        createFlatAllocation({
+          type: 'nested',
+          id: 'vault',
+          label: 'Vault',
+          sharePercent: 20,
+          allocations: [
+            createNestedAllocation('pending-child', 100, {
+              category: 'pending-deposits',
+              protocol: undefined,
+            }),
+          ],
+        }),
+      ]),
+    );
+
+    expect(result.groups).toEqual([]);
+    expect(result.flatItems).toEqual([
+      expect.objectContaining({
+        name: 'Pending',
+        allocation: 20,
+        tvlUSD: 100,
+      }),
+    ]);
+    expect(consoleDebugSpy).not.toHaveBeenCalledWith(
+      '[Vault allocation] Allocation moved to Others',
+      {
+        reason: 'below-min-display-percent',
+        id: 'vault',
+      },
+    );
+  });
+
+  it('moves only the share left after roll-up of a below-threshold subvault to Others', () => {
+    const result = getAllocationData(
+      createData([
+        createFlatAllocation({
+          type: 'nested',
+          id: 'vault',
+          label: 'Vault',
+          sharePercent: 0.15,
+          allocations: [
+            createNestedAllocation('token-child', 50, {
+              category: 'token',
+              protocol: undefined,
+            }),
+            createNestedAllocation('large', 50),
+          ],
+        }),
+      ]),
+    );
+
+    expect(result.groups).toEqual([]);
+    expect(result.flatItems?.map(({ name }) => name)).toEqual([
+      'Others',
+      'Available',
+    ]);
+    expect(result.flatItems?.[0]?.allocation).toBeCloseTo(0.075, 12);
+    expect(result.flatItems?.[0]?.tvlUSD).toBeCloseTo(50, 12);
+    expect(result.flatItems?.[1]?.allocation).toBeCloseTo(0.075, 12);
+    expect(result.flatItems?.[1]?.tvlUSD).toBeCloseTo(50, 12);
+  });
+
+  it('keeps the displayed shares summing to the total vault share', () => {
+    const result = getAllocationData(
+      createData([
+        createFlatAllocation({ id: 'large', label: 'Large', sharePercent: 40 }),
+        createFlatAllocation({
+          type: 'nested',
+          id: 'vault',
+          label: 'Vault',
+          sharePercent: 60,
+          allocations: [
+            createNestedAllocation('medium', 50),
+            createNestedAllocation('pending-child', 30, {
+              category: 'pending-deposits',
+              protocol: undefined,
+            }),
+            createNestedAllocation('unknown-position', 20),
+          ],
+        }),
+      ]),
+    );
+
+    const total = [...result.groups, ...(result.flatItems ?? [])].reduce(
+      (sum, entry) => sum + entry.allocation,
+      0,
+    );
+
+    expect(total).toBeCloseTo(100, 9);
   });
 
   it('shows top-level Others produced by an invisible nested group', () => {
@@ -416,12 +624,21 @@ describe('useAllocationData grouping and sorting', () => {
     );
     const items = result.groups[0]?.items ?? [];
 
-    expect(items).toHaveLength(21);
-    expect(items.slice(0, 20).map(({ allocation }) => allocation)).toEqual(
+    expect(items).toHaveLength(20);
+    expect(items.map(({ allocation }) => allocation)).toEqual(
       Array.from({ length: 20 }, (_, index) => 22 - index),
     );
-    expect(items[20]?.label).toBe('Others');
-    expect(items[20]?.allocation).toBe(3);
+    expect(result.groups[0]).toEqual(
+      expect.objectContaining({ allocation: 97, tvlUSD: 97 }),
+    );
+    expect(result.flatItems).toEqual([
+      expect.objectContaining({
+        name: 'Others',
+        isSummary: true,
+        allocation: 3,
+        tvlUSD: 3,
+      }),
+    ]);
     expect(consoleDebugSpy).toHaveBeenCalledWith(
       '[Vault allocation] Allocation moved to Others',
       {
@@ -458,9 +675,17 @@ describe('useAllocationData grouping and sorting', () => {
         label,
         allocation,
       })),
-    ).toEqual([
-      { label: 'Aave levered wstETH/ETH', allocation: 60 },
-      { label: 'Others', allocation: 40 },
+    ).toEqual([{ label: 'Aave levered wstETH/ETH', allocation: 60 }]);
+    expect(result.groups[0]).toEqual(
+      expect.objectContaining({ allocation: 60, tvlUSD: 60 }),
+    );
+    expect(result.flatItems).toEqual([
+      expect.objectContaining({
+        name: 'Others',
+        isSummary: true,
+        allocation: 40,
+        tvlUSD: 40,
+      }),
     ]);
     expect(consoleDebugSpy).toHaveBeenCalledWith(
       '[Vault allocation] Allocation moved to Others',
@@ -597,7 +822,7 @@ describe('useAllocationData grouping and sorting', () => {
     );
   });
 
-  it('moves a hidden nested allocation to the subvault Others row', () => {
+  it('moves a hidden nested allocation to the metavault Others row', () => {
     const result = getAllocationData(
       createData([
         createFlatAllocation({
@@ -620,9 +845,17 @@ describe('useAllocationData grouping and sorting', () => {
         label,
         allocation,
       })),
-    ).toEqual([
-      { label: 'Allocation', allocation: 60 },
-      { label: 'Others', allocation: 40 },
+    ).toEqual([{ label: 'Allocation', allocation: 60 }]);
+    expect(result.groups[0]).toEqual(
+      expect.objectContaining({ allocation: 60, tvlUSD: 60 }),
+    );
+    expect(result.flatItems).toEqual([
+      expect.objectContaining({
+        name: 'Others',
+        isSummary: true,
+        allocation: 40,
+        tvlUSD: 40,
+      }),
     ]);
     expect(consoleDebugSpy).toHaveBeenCalledWith(
       '[Vault allocation] Allocation moved to Others',

--- a/features/earn/shared/v2/vault-allocation/hooks/use-allocation-data.ts
+++ b/features/earn/shared/v2/vault-allocation/hooks/use-allocation-data.ts
@@ -63,14 +63,10 @@ type DiagnosticAllocationData = {
 };
 
 // Entries that match these categories are accumulated into the
-// Available / Pending / Others rows shown in the allocation table.
-const NESTED_ALLOCATION_SUMMARY_KEYS = ['pending', 'others'] as const;
-const FLAT_ALLOCATION_SUMMARY_KEYS = [
-  'pending',
-  'others',
-  'available',
-] as const;
-type AllocationSummaryKey = (typeof FLAT_ALLOCATION_SUMMARY_KEYS)[number];
+// Available / Pending / Others rows shown at the metavault level. Subvaults
+// never carry summary rows of their own; their contributions are merged here.
+const ALLOCATION_SUMMARY_KEYS = ['pending', 'others', 'available'] as const;
+type AllocationSummaryKey = (typeof ALLOCATION_SUMMARY_KEYS)[number];
 type AllocationSummaryRows = Record<
   AllocationSummaryKey,
   { allocation: number; tvlUSD: number }
@@ -102,16 +98,25 @@ const addToAllocationSummaryRow = (
   summaryRows[key].tvlUSD += tvlUSD;
 };
 
+const logAllocationMovedToOthers = (
+  id: string,
+  reason: DiagnosticAllocationReason,
+): void => {
+  console.debug('[Vault allocation] Allocation moved to Others', {
+    reason,
+    id,
+  });
+};
+
+// Takes an already whole-vault share; nested allocations must be rescaled
+// first, so they roll up through `parseNestedGroup` instead of this helper.
 const moveAllocationToOthers = (
   summaryRows: AllocationSummaryRows,
   allocation: DiagnosticAllocationData,
   tvlUSD: number,
   reason: DiagnosticAllocationReason,
 ): void => {
-  console.debug('[Vault allocation] Allocation moved to Others', {
-    reason,
-    id: allocation.id,
-  });
+  logAllocationMovedToOthers(allocation.id, reason);
 
   if (allocation.sharePercent <= 0) return;
 
@@ -123,29 +128,17 @@ const moveAllocationToOthers = (
   );
 };
 
+// Splits the displayable positions from the overflow. The caller rolls up the
+// overflow, since only it knows how to rescale a nested share.
 const limitNestedItems = (
   items: AllocationSubItem[],
-  summaryRows: AllocationSummaryRows,
-): AllocationSubItem[] => {
+): { items: AllocationSubItem[]; overflow: AllocationSubItem[] } => {
   items.sort(sortByAllocationDescending);
 
-  if (items.length <= MAX_SUBVAULT_POSITIONS) {
-    return items;
-  }
-
-  for (const item of items.slice(MAX_SUBVAULT_POSITIONS)) {
-    moveAllocationToOthers(
-      summaryRows,
-      {
-        id: item.id,
-        sharePercent: item.allocation,
-      },
-      item.tvlUSD,
-      'max-subvault-positions',
-    );
-  }
-
-  return items.slice(0, MAX_SUBVAULT_POSITIONS);
+  return {
+    items: items.slice(0, MAX_SUBVAULT_POSITIONS),
+    overflow: items.slice(MAX_SUBVAULT_POSITIONS),
+  };
 };
 
 const ALLOCATION_SUMMARY_KEY_BY_CATEGORY = {
@@ -209,35 +202,11 @@ const classifyAllocation = (
   return { type: 'ignored' };
 };
 
-const appendNestedSummaryRows = (
-  items: AllocationSubItem[],
-  summaryRows: AllocationSummaryRows,
-): void => {
-  for (const key of NESTED_ALLOCATION_SUMMARY_KEYS) {
-    const summary = summaryRows[key];
-
-    if (summary.allocation > 0) {
-      const meta = ALLOCATION_SUMMARY_META[key];
-
-      items.push({
-        label: meta.label,
-        id: meta.id,
-        isSummary: true,
-        icon: undefined,
-        info: meta.info,
-        chain: '',
-        allocation: summary.allocation,
-        tvlUSD: summary.tvlUSD,
-      });
-    }
-  }
-};
-
-const appendFlatSummaryRows = (
+const appendSummaryRows = (
   items: FlatAllocationItem[],
   summaryRows: AllocationSummaryRows,
 ): void => {
-  for (const key of FLAT_ALLOCATION_SUMMARY_KEYS) {
+  for (const key of ALLOCATION_SUMMARY_KEYS) {
     const summary = summaryRows[key];
 
     if (summary.allocation > 0) {
@@ -261,10 +230,29 @@ const parseNestedGroup = (
   hiddenAllocationIds: ReadonlySet<string>,
   topLevelSummaryRows: AllocationSummaryRows,
 ): AllocationGroup => {
-  const summaryRows = createAllocationSummaryRows();
   const knownItems: AllocationSubItem[] = [];
-  let availableAllocation = 0;
-  let availableTvlUSD = 0;
+  let rolledUpAllocation = 0;
+  let rolledUpTvlUSD = 0;
+
+  // Summary rows exist only at the metavault level, so every nested Available /
+  // Pending / Others contribution is merged there instead of into the subvault.
+  // Assumes a subvault's children sum to 100%, which the API schema does not
+  // enforce; see NESTED_ALLOCATION_SCHEMA in ../apy-data/metavaults-allocation.
+  const rollUpToMetavault = (
+    key: AllocationSummaryKey,
+    subSharePercent: number,
+    subTvl: number,
+  ): void => {
+    if (subSharePercent <= 0) return;
+
+    // A nested share is relative to its parent subvault. Convert it to the
+    // whole-vault share before merging it into the metavault-level row.
+    const topLevelShare = alloc.sharePercent * (subSharePercent / 100);
+
+    addToAllocationSummaryRow(topLevelSummaryRows, key, topLevelShare, subTvl);
+    rolledUpAllocation += topLevelShare;
+    rolledUpTvlUSD += subTvl;
+  };
 
   for (const sub of alloc.allocations) {
     // Nested sub-allocations only carry a share, so derive their TVL from the
@@ -277,29 +265,10 @@ const parseNestedGroup = (
     );
 
     if (disposition.type === 'summary') {
-      if (disposition.key === 'available') {
-        // A nested share is relative to its parent subvault. Convert it to the
-        // whole-vault share before moving it to the flat Available row.
-        const topLevelShare = alloc.sharePercent * (sub.sharePercent / 100);
-
-        addToAllocationSummaryRow(
-          topLevelSummaryRows,
-          'available',
-          topLevelShare,
-          subTvl,
-        );
-        availableAllocation += topLevelShare;
-        availableTvlUSD += subTvl;
-      } else {
-        addToAllocationSummaryRow(
-          summaryRows,
-          disposition.key,
-          sub.sharePercent,
-          subTvl,
-        );
-      }
+      rollUpToMetavault(disposition.key, sub.sharePercent, subTvl);
     } else if (disposition.type === 'others') {
-      moveAllocationToOthers(summaryRows, sub, subTvl, disposition.reason);
+      logAllocationMovedToOthers(sub.id, disposition.reason);
+      rollUpToMetavault('others', sub.sharePercent, subTvl);
     } else if (disposition.type === 'visible') {
       knownItems.push({
         label: sub.label,
@@ -312,14 +281,18 @@ const parseNestedGroup = (
     }
   }
 
-  const limitedItems = limitNestedItems(knownItems, summaryRows);
-  appendNestedSummaryRows(limitedItems, summaryRows);
+  const { items, overflow } = limitNestedItems(knownItems);
+
+  for (const item of overflow) {
+    logAllocationMovedToOthers(item.id, 'max-subvault-positions');
+    rollUpToMetavault('others', item.allocation, item.tvlUSD);
+  }
 
   return {
     name: alloc.label,
-    allocation: alloc.sharePercent - availableAllocation,
-    tvlUSD: tvlUSD - availableTvlUSD,
-    items: limitedItems,
+    allocation: alloc.sharePercent - rolledUpAllocation,
+    tvlUSD: tvlUSD - rolledUpTvlUSD,
+    items,
     info: getOwnProperty(SUBVAULTS_TIP_BY_ID, alloc.id),
   };
 };
@@ -361,7 +334,7 @@ const parseFlatItems = (
   }
 
   items.sort(sortByAllocationDescending);
-  appendFlatSummaryRows(items, summaryRows);
+  appendSummaryRows(items, summaryRows);
 
   return items;
 };
@@ -448,9 +421,11 @@ export const useAllocationData = (
         if (isVisible(group.allocation)) {
           groups.push(group);
         } else if (group.allocation > 0) {
+          // Only the share left after the roll-up, since the rolled-up part is
+          // already counted in the metavault-level summary rows.
           moveAllocationToOthers(
             topLevelSummaryRows,
-            alloc,
+            { id: alloc.id, sharePercent: group.allocation },
             group.tvlUSD,
             'below-min-display-percent',
           );

--- a/features/earn/shared/v2/vault-allocation/types.ts
+++ b/features/earn/shared/v2/vault-allocation/types.ts
@@ -4,11 +4,11 @@ import type { LineDataWithAllocation } from 'features/earn/shared/vault-allocati
 
 export type { LineDataWithAllocation };
 
+// A subvault holds only real protocol positions; Available / Pending / Others
+// are summed into FlatAllocationItem summary rows at the metavault level.
 export type AllocationSubItem = {
   id: string;
   label: string;
-  isSummary?: boolean;
-  info?: ReactNode;
   chain: string;
   allocation: number;
   tvlUSD: number;


### PR DESCRIPTION
### Description

Merge duplicate 'Others' and 'Pending' fields from the subvault level into single summed fields at the metavault level


### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
