### PR TITLE
Earn – update active fees

### DIFF
--- a/features/earn/shared/drawer-right/drawer-table/drawer-table.tsx
+++ b/features/earn/shared/drawer-right/drawer-table/drawer-table.tsx
@@ -70,7 +70,11 @@ const DATA = [
         cells: [
           'Fees',
           ['1 % management fee', '10 % performance fee'],
-          ['0.2 % management fee', '15 % performance fee'],
+          [
+            'flexible, capped at:',
+            '0.5 % management fee',
+            '20 % performance fee',
+          ],
         ],
       },
     ],

--- a/features/earn/shared/drawer-right/drawer-table/drawer-table.tsx
+++ b/features/earn/shared/drawer-right/drawer-table/drawer-table.tsx
@@ -70,7 +70,7 @@ const DATA = [
         cells: [
           'Fees',
           ['1 % management fee', '10 % performance fee'],
-          ['1 % management fee', '10 % performance fee'],
+          ['0.2 % management fee', '15 % performance fee'],
         ],
       },
     ],

--- a/features/earn/shared/drawer-right/drawer-table/drawer-table.tsx
+++ b/features/earn/shared/drawer-right/drawer-table/drawer-table.tsx
@@ -69,12 +69,8 @@ const DATA = [
       {
         cells: [
           'Fees',
-          ['1 % management fee', '10 % performance fee'],
-          [
-            'flexible, capped at:',
-            '0.5 % management fee',
-            '20 % performance fee',
-          ],
+          ['1 % platform (AUM) fee', '10 % performance fee'],
+          ['flexible, capped at:', '0.5 % AUM fee', '20 % performance fee'],
         ],
       },
     ],

--- a/features/earn/shared/v2/vault-page/styles.tsx
+++ b/features/earn/shared/v2/vault-page/styles.tsx
@@ -58,6 +58,9 @@ export const InfoRow = styled.div`
 export const InfoRowLabel = styled.span`
   color: var(--lido-color-textSecondary);
   font-weight: 400;
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spaceMap.xs}px;
 `;
 
 export const InfoRowValue = styled.span`

--- a/features/earn/shared/v2/vault-page/vault-page.tsx
+++ b/features/earn/shared/v2/vault-page/vault-page.tsx
@@ -172,7 +172,14 @@ export const VaultPage: FC<Props> = (props) => {
               <Metrics>
                 {fees.map((fee, index) => (
                   <InfoRow key={index} data-testid="fee">
-                    <InfoRowLabel>{fee.label}</InfoRowLabel>
+                    <InfoRowLabel>
+                      {fee.label}
+                      {fee.tooltip && (
+                        <Tooltip title={fee.tooltip}>
+                          <Question />
+                        </Tooltip>
+                      )}
+                    </InfoRowLabel>
                     {fee.value != null && (
                       <InfoRowValue>{fee.value}</InfoRowValue>
                     )}

--- a/features/earn/vault-eth/faq/list/what-fees-are-applied.tsx
+++ b/features/earn/vault-eth/faq/list/what-fees-are-applied.tsx
@@ -14,16 +14,21 @@ export const WhatFeesAreApplied: FC<{ id?: string }> = ({ id }) => {
       </p>
       <ul>
         <li>
-          <strong>Platform fee (AUM fee):</strong> 1% annually, pro-rated for
-          the time your deposited tokens remain in the vault, and built into the
-          earnETH token price.
+          <strong>Platform fee (AUM fee):</strong> flexible and capped at 0.5%
+          of total holdings, pro-rated for the time your deposited tokens remain
+          in the vault, and built into the earnETH token price.
         </li>
         <li>
-          <strong>Performance fee (allocated to subVault curators):</strong> 10%
-          of accrued rewards is deducted from gains before those gains are
-          reflected in the earnETH token price.
+          <strong>Performance fee:</strong> flexible and capped at 20% of
+          accrued rewards, deducted from gains before those gains are reflected
+          in the earnETH token price.
         </li>
       </ul>
+      <p>
+        Fees may change to reflect market conditions, but they can never exceed
+        these caps. You can always see the vault&apos;s current fees on the
+        vault page.
+      </p>
       <p>
         As a result, your earnETH token balance stays the same, while the value
         per token adjusts over time to account for fees and performance.

--- a/features/earn/vault-eth/vault-page.tsx
+++ b/features/earn/vault-eth/vault-page.tsx
@@ -10,7 +10,11 @@ import { Disclaimers } from 'features/earn/shared/v2/disclaimers';
 import { VaultAllocation } from 'features/earn/shared/v2/vault-allocation/vault-allocation';
 import { MATOMO_EARN_EVENTS_TYPES } from 'consts/matomo/matomo-earn-events';
 import { TOKEN_SYMBOLS } from 'consts/tokens';
-import { WITHDRAWAL_WAITING_TIME_TOOLTIP } from 'modules/mellow-meta-vaults';
+import {
+  ACTIVE_FEES_TOOLTIP,
+  ACTIVE_FEES_VALUE,
+  WITHDRAWAL_WAITING_TIME_TOOLTIP,
+} from 'modules/mellow-meta-vaults';
 
 import { DrawerRight } from '../shared/drawer-right';
 import { ApyUpdateTooltipText } from '../shared/v2/apy-update-tooltip-text';
@@ -30,9 +34,12 @@ import {
 import { ProtectedTooltip } from './protected-tooltip';
 import { EthVaultDrawerProvider, useEthVaultDrawer } from './drawer-context';
 
-const FEES = [
-  { label: 'Performance fee', value: '10%' },
-  { label: 'Platform fee', value: '1%' },
+const FEES: InfoItem[] = [
+  {
+    label: 'Active fees',
+    value: ACTIVE_FEES_VALUE,
+    tooltip: ACTIVE_FEES_TOOLTIP,
+  },
 ];
 
 const GENERAL_INFO_LEFT: InfoItem[] = [

--- a/features/earn/vault-usd/faq/list/what-fees-are-applied.tsx
+++ b/features/earn/vault-usd/faq/list/what-fees-are-applied.tsx
@@ -8,24 +8,29 @@ export const WhatFeesAreApplied: FC<{ id?: string }> = ({ id }) => {
       id={id}
     >
       <p>
-        When you deposit, you receive earnUSD tokens that represent your share
-        of the vault. Your earnUSD token balance does not decrease to pay fees.
-        Instead, fees are reflected in the value of each earnUSD token:
+        When you deposit, you receive earnETH tokens that represent your share
+        of the vault. Your earnETH token balance does not decrease to pay fees.
+        Instead, fees are reflected in the value of each earnETH token:
       </p>
       <ul>
         <li>
-          <strong>Platform fee (AUM fee):</strong> 1% annually, pro-rated for
-          the time your deposited tokens remain in the vault, and built into the
-          earnUSD token price.
+          <strong>Platform fee (AUM fee):</strong> flexible and capped at 0.5%
+          of total holdings, pro-rated for the time your deposited tokens remain
+          in the vault, and built into the earnETH token price.
         </li>
         <li>
-          <strong>Performance fee (allocated to subVault curators):</strong> 10%
-          of accrued rewards is deducted from gains before those gains are
-          reflected in the earnUSD token price.
+          <strong>Performance fee:</strong> flexible and capped at 20% of
+          accrued rewards, deducted from gains before those gains are reflected
+          in the earnETH token price.
         </li>
       </ul>
       <p>
-        As a result, your earnUSD token balance stays the same, while the value
+        Fees may change to reflect market conditions, but they can never exceed
+        these caps. You can always see the vault&apos;s current fees on the
+        vault page.
+      </p>
+      <p>
+        As a result, your earnETH token balance stays the same, while the value
         per token adjusts over time to account for fees and performance.
       </p>
     </FaqItem>

--- a/features/earn/vault-usd/vault-page.tsx
+++ b/features/earn/vault-usd/vault-page.tsx
@@ -5,9 +5,14 @@ import { config } from 'config';
 import { PartnerNethermindIconCircle, VaultUsdIcon } from 'assets/earn-v2';
 import { PartnerMellowIcon } from 'assets/earn';
 import { VaultPage } from 'features/earn/shared/v2/vault-page/vault-page';
+import type { InfoItem } from 'features/earn/shared/v2/vault-page/vault-page';
 import { MATOMO_EARN_EVENTS_TYPES } from 'consts/matomo';
 import { TOKEN_SYMBOLS } from 'consts/tokens';
-import { WITHDRAWAL_WAITING_TIME_TOOLTIP } from 'modules/mellow-meta-vaults';
+import {
+  ACTIVE_FEES_TOOLTIP,
+  ACTIVE_FEES_VALUE,
+  WITHDRAWAL_WAITING_TIME_TOOLTIP,
+} from 'modules/mellow-meta-vaults';
 
 import { VaultAllocation } from '../shared/v2/vault-allocation/vault-allocation';
 import { Disclaimers } from '../shared/v2/disclaimers';
@@ -27,9 +32,12 @@ import {
 } from './consts';
 import { ProtectedTooltip } from './protected-tooltip';
 
-const FEES = [
-  { label: 'Performance fee', value: '10%' },
-  { label: 'Platform fee', value: '1%' },
+const FEES: InfoItem[] = [
+  {
+    label: 'Active fees',
+    value: ACTIVE_FEES_VALUE,
+    tooltip: ACTIVE_FEES_TOOLTIP,
+  },
 ];
 
 const GENERAL_INFO_LEFT = [

--- a/modules/mellow-meta-vaults/consts.tsx
+++ b/modules/mellow-meta-vaults/consts.tsx
@@ -8,3 +8,9 @@ export const MELLOW_VAULTS_QUERY_SCOPE = 'mellow-meta-vault';
 
 export const WITHDRAWAL_WAITING_TIME_TOOLTIP =
   'Withdrawals are instant when the buffer has enough liquidity to cover your request. Larger requests go to the withdrawal queue, usually settled within 72 hours but occasionally longer depending on size.';
+
+// current fees, hardcoded until a live fee read exists
+export const ACTIVE_FEES_VALUE = '0.2% AUM + 15% performance';
+
+export const ACTIVE_FEES_TOOLTIP =
+  "Displays the vault's current fees. Fees are flexible and may change to reflect market conditions. The AUM fee (a percentage of total holdings) cannot exceed 0.5%, and the performance fee (a percentage of yield earned) cannot exceed 20%.";


### PR DESCRIPTION
### Description
- display currently 'Active fees' instead of 'Performance fee' and 'Platform fee'
- hardcode the values: 0.2% AUM + 15% performance
- add a dedicated tooltip (max values will live there)
- update FAQ

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
