### PR TITLE
Earn – update fees

### DIFF
--- a/features/earn/shared/drawer-right/drawer-table/drawer-table.tsx
+++ b/features/earn/shared/drawer-right/drawer-table/drawer-table.tsx
@@ -69,8 +69,8 @@ const DATA = [
       {
         cells: [
           'Fees',
-          ['1 % management fee', '10 % performance fee'],
-          ['1 % management fee', '10 % performance fee'],
+          ['1 % platform (AUM) fee', '10 % performance fee'],
+          ['flexible, capped at:', '0.5 % AUM fee', '20 % performance fee'],
         ],
       },
     ],

--- a/features/earn/shared/v2/active-fees-value.tsx
+++ b/features/earn/shared/v2/active-fees-value.tsx
@@ -1,0 +1,13 @@
+import { DATA_UNAVAILABLE } from 'consts/text';
+import { InlineLoader } from 'features/earn/shared/inline-loader';
+
+type Props = {
+  value?: string;
+  isLoading?: boolean;
+};
+
+export const ActiveFeesValue = ({ value, isLoading }: Props) => (
+  <InlineLoader isLoading={isLoading} width={180}>
+    {value ?? DATA_UNAVAILABLE}
+  </InlineLoader>
+);

--- a/features/earn/shared/v2/vault-page/styles.tsx
+++ b/features/earn/shared/v2/vault-page/styles.tsx
@@ -58,6 +58,9 @@ export const InfoRow = styled.div`
 export const InfoRowLabel = styled.span`
   color: var(--lido-color-textSecondary);
   font-weight: 400;
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spaceMap.xs}px;
 `;
 
 export const InfoRowValue = styled.span`

--- a/features/earn/shared/v2/vault-page/vault-page.tsx
+++ b/features/earn/shared/v2/vault-page/vault-page.tsx
@@ -172,7 +172,14 @@ export const VaultPage: FC<Props> = (props) => {
               <Metrics>
                 {fees.map((fee, index) => (
                   <InfoRow key={index} data-testid="fee">
-                    <InfoRowLabel>{fee.label}</InfoRowLabel>
+                    <InfoRowLabel>
+                      {fee.label}
+                      {fee.tooltip && (
+                        <Tooltip title={fee.tooltip}>
+                          <Question />
+                        </Tooltip>
+                      )}
+                    </InfoRowLabel>
                     {fee.value != null && (
                       <InfoRowValue>{fee.value}</InfoRowValue>
                     )}

--- a/features/earn/vault-eth/faq/list/what-fees-are-applied.tsx
+++ b/features/earn/vault-eth/faq/list/what-fees-are-applied.tsx
@@ -14,16 +14,21 @@ export const WhatFeesAreApplied: FC<{ id?: string }> = ({ id }) => {
       </p>
       <ul>
         <li>
-          <strong>Platform fee (AUM fee):</strong> 1% annually, pro-rated for
-          the time your deposited tokens remain in the vault, and built into the
-          earnETH token price.
+          <strong>Platform fee (AUM fee):</strong> flexible and capped at 0.5%
+          of total holdings, pro-rated for the time your deposited tokens remain
+          in the vault, and built into the earnETH token price.
         </li>
         <li>
-          <strong>Performance fee (allocated to subVault curators):</strong> 10%
-          of accrued rewards is deducted from gains before those gains are
-          reflected in the earnETH token price.
+          <strong>Performance fee:</strong> flexible and capped at 20% of
+          accrued rewards, deducted from gains before those gains are reflected
+          in the earnETH token price.
         </li>
       </ul>
+      <p>
+        Fees may change to reflect market conditions, but they can never exceed
+        these caps. You can always see the vault&apos;s current fees on the
+        vault page.
+      </p>
       <p>
         As a result, your earnETH token balance stays the same, while the value
         per token adjusts over time to account for fees and performance.

--- a/features/earn/vault-eth/hooks/use-active-fees.ts
+++ b/features/earn/vault-eth/hooks/use-active-fees.ts
@@ -1,0 +1,16 @@
+import invariant from 'tiny-invariant';
+import { useMemo } from 'react';
+import { useActiveFees } from 'modules/mellow-meta-vaults/hooks/use-active-fees';
+import { useMainnetOnlyWagmi } from 'modules/web3';
+import { getVaultContract } from '../contracts';
+
+export const useEthVaultActiveFees = () => {
+  const { publicClientMainnet } = useMainnetOnlyWagmi();
+  invariant(publicClientMainnet, 'Public client is not available');
+  const vault = useMemo(
+    () => getVaultContract(publicClientMainnet),
+    [publicClientMainnet],
+  );
+
+  return useActiveFees({ vault });
+};

--- a/features/earn/vault-eth/vault-page.tsx
+++ b/features/earn/vault-eth/vault-page.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@lidofinance/lido-ui';
-import type { FC, ReactNode } from 'react';
+import { useMemo, type FC, type ReactNode } from 'react';
 
 import { config } from 'config';
 import { PartnerNethermindIconCircle, VaultEthIcon } from 'assets/earn-v2';
@@ -12,18 +12,19 @@ import { MATOMO_EARN_EVENTS_TYPES } from 'consts/matomo/matomo-earn-events';
 import { TOKEN_SYMBOLS } from 'consts/tokens';
 import {
   ACTIVE_FEES_TOOLTIP,
-  ACTIVE_FEES_VALUE,
   WITHDRAWAL_WAITING_TIME_TOOLTIP,
 } from 'modules/mellow-meta-vaults';
 
 import { DrawerRight } from '../shared/drawer-right';
 import { ApyUpdateTooltipText } from '../shared/v2/apy-update-tooltip-text';
+import { ActiveFeesValue } from '../shared/v2/active-fees-value';
 
 import { EthVaultPositionManager } from './position-manager/position-manager';
 import { EarnEthFaq } from './faq/faq';
 import { useEthVaultStats } from './hooks/use-vault-stats';
 import { useEthVaultApy } from './hooks/use-vault-apy';
 import { useEthVaultPosition } from './hooks/use-position';
+import { useEthVaultActiveFees } from './hooks/use-active-fees';
 import { EARN_VAULT_DEPOSIT_SLUG, EARN_VAULT_WITHDRAW_SLUG } from '../consts';
 import { EthVaultApyHint } from './components/apy-hint';
 import {
@@ -33,14 +34,6 @@ import {
 } from './consts';
 import { ProtectedTooltip } from './protected-tooltip';
 import { EthVaultDrawerProvider, useEthVaultDrawer } from './drawer-context';
-
-const FEES: InfoItem[] = [
-  {
-    label: 'Active fees',
-    value: ACTIVE_FEES_VALUE,
-    tooltip: ACTIVE_FEES_TOOLTIP,
-  },
-];
 
 const GENERAL_INFO_LEFT: InfoItem[] = [
   {
@@ -165,7 +158,6 @@ const DATA = {
   title: ETH_VAULT_TITLE,
   description: ETH_VAULT_DESCRIPTION,
   logo: VaultEthIcon,
-  fees: FEES,
   generalInfoLeft: GENERAL_INFO_LEFT,
   generalInfoRight: GENERAL_INFO_RIGHT,
   riskDisclosure: RISK_DISCLOSURE,
@@ -189,13 +181,32 @@ const EthVaultPageContent: FC<{
     ethAmount,
     usdBalance,
   } = useEthVaultPosition();
+  const { value: activeFeesValue, isLoading: isActiveFeesLoading } =
+    useEthVaultActiveFees();
 
   const sharesBalance = earnethPositionData?.earnethSharesBalance;
+
+  const fees = useMemo<InfoItem[]>(
+    () => [
+      {
+        label: 'Active fees',
+        value: (
+          <ActiveFeesValue
+            value={activeFeesValue}
+            isLoading={isActiveFeesLoading}
+          />
+        ),
+        tooltip: ACTIVE_FEES_TOOLTIP,
+      },
+    ],
+    [activeFeesValue, isActiveFeesLoading],
+  );
 
   return (
     <>
       <VaultPage
         {...DATA}
+        fees={fees}
         apx={apy}
         tvlUsd={tvlUsd}
         isApxLoading={isApyLoading}

--- a/features/earn/vault-eth/vault-page.tsx
+++ b/features/earn/vault-eth/vault-page.tsx
@@ -10,7 +10,11 @@ import { Disclaimers } from 'features/earn/shared/v2/disclaimers';
 import { VaultAllocation } from 'features/earn/shared/v2/vault-allocation/vault-allocation';
 import { MATOMO_EARN_EVENTS_TYPES } from 'consts/matomo/matomo-earn-events';
 import { TOKEN_SYMBOLS } from 'consts/tokens';
-import { WITHDRAWAL_WAITING_TIME_TOOLTIP } from 'modules/mellow-meta-vaults';
+import {
+  ACTIVE_FEES_TOOLTIP,
+  ACTIVE_FEES_VALUE,
+  WITHDRAWAL_WAITING_TIME_TOOLTIP,
+} from 'modules/mellow-meta-vaults';
 
 import { DrawerRight } from '../shared/drawer-right';
 import { ApyUpdateTooltipText } from '../shared/v2/apy-update-tooltip-text';
@@ -30,9 +34,12 @@ import {
 import { ProtectedTooltip } from './protected-tooltip';
 import { EthVaultDrawerProvider, useEthVaultDrawer } from './drawer-context';
 
-const FEES = [
-  { label: 'Performance fee', value: '10%' },
-  { label: 'Platform fee', value: '1%' },
+const FEES: InfoItem[] = [
+  {
+    label: 'Active fees',
+    value: ACTIVE_FEES_VALUE,
+    tooltip: ACTIVE_FEES_TOOLTIP,
+  },
 ];
 
 const GENERAL_INFO_LEFT: InfoItem[] = [

--- a/features/earn/vault-usd/faq/list/what-fees-are-applied.tsx
+++ b/features/earn/vault-usd/faq/list/what-fees-are-applied.tsx
@@ -8,24 +8,29 @@ export const WhatFeesAreApplied: FC<{ id?: string }> = ({ id }) => {
       id={id}
     >
       <p>
-        When you deposit, you receive earnUSD tokens that represent your share
-        of the vault. Your earnUSD token balance does not decrease to pay fees.
-        Instead, fees are reflected in the value of each earnUSD token:
+        When you deposit, you receive earnETH tokens that represent your share
+        of the vault. Your earnETH token balance does not decrease to pay fees.
+        Instead, fees are reflected in the value of each earnETH token:
       </p>
       <ul>
         <li>
-          <strong>Platform fee (AUM fee):</strong> 1% annually, pro-rated for
-          the time your deposited tokens remain in the vault, and built into the
-          earnUSD token price.
+          <strong>Platform fee (AUM fee):</strong> flexible and capped at 0.5%
+          of total holdings, pro-rated for the time your deposited tokens remain
+          in the vault, and built into the earnETH token price.
         </li>
         <li>
-          <strong>Performance fee (allocated to subVault curators):</strong> 10%
-          of accrued rewards is deducted from gains before those gains are
-          reflected in the earnUSD token price.
+          <strong>Performance fee:</strong> flexible and capped at 20% of
+          accrued rewards, deducted from gains before those gains are reflected
+          in the earnETH token price.
         </li>
       </ul>
       <p>
-        As a result, your earnUSD token balance stays the same, while the value
+        Fees may change to reflect market conditions, but they can never exceed
+        these caps. You can always see the vault&apos;s current fees on the
+        vault page.
+      </p>
+      <p>
+        As a result, your earnETH token balance stays the same, while the value
         per token adjusts over time to account for fees and performance.
       </p>
     </FaqItem>

--- a/features/earn/vault-usd/faq/list/what-fees-are-applied.tsx
+++ b/features/earn/vault-usd/faq/list/what-fees-are-applied.tsx
@@ -14,21 +14,16 @@ export const WhatFeesAreApplied: FC<{ id?: string }> = ({ id }) => {
       </p>
       <ul>
         <li>
-          <strong>Platform fee (AUM fee):</strong> flexible and capped at 0.5%
-          of total holdings, pro-rated for the time your deposited tokens remain
-          in the vault, and built into the earnUSD token price.
+          <strong>Platform fee (AUM fee):</strong> 1% annually, pro-rated for
+          the time your deposited tokens remain in the vault, and built into the
+          earnUSD token price.
         </li>
         <li>
-          <strong>Performance fee:</strong> flexible and capped at 20% of
-          accrued rewards, deducted from gains before those gains are reflected
-          in the earnUSD token price.
+          <strong>Performance fee (allocated to subVault curators):</strong> 10%
+          of accrued rewards is deducted from gains before those gains are
+          reflected in the earnUSD token price.
         </li>
       </ul>
-      <p>
-        Fees may change to reflect market conditions, but they can never exceed
-        these caps. You can always see the vault&apos;s current fees on the
-        vault page.
-      </p>
       <p>
         As a result, your earnUSD token balance stays the same, while the value
         per token adjusts over time to account for fees and performance.

--- a/features/earn/vault-usd/faq/list/what-fees-are-applied.tsx
+++ b/features/earn/vault-usd/faq/list/what-fees-are-applied.tsx
@@ -8,20 +8,20 @@ export const WhatFeesAreApplied: FC<{ id?: string }> = ({ id }) => {
       id={id}
     >
       <p>
-        When you deposit, you receive earnETH tokens that represent your share
-        of the vault. Your earnETH token balance does not decrease to pay fees.
-        Instead, fees are reflected in the value of each earnETH token:
+        When you deposit, you receive earnUSD tokens that represent your share
+        of the vault. Your earnUSD token balance does not decrease to pay fees.
+        Instead, fees are reflected in the value of each earnUSD token:
       </p>
       <ul>
         <li>
           <strong>Platform fee (AUM fee):</strong> flexible and capped at 0.5%
           of total holdings, pro-rated for the time your deposited tokens remain
-          in the vault, and built into the earnETH token price.
+          in the vault, and built into the earnUSD token price.
         </li>
         <li>
           <strong>Performance fee:</strong> flexible and capped at 20% of
           accrued rewards, deducted from gains before those gains are reflected
-          in the earnETH token price.
+          in the earnUSD token price.
         </li>
       </ul>
       <p>
@@ -30,7 +30,7 @@ export const WhatFeesAreApplied: FC<{ id?: string }> = ({ id }) => {
         vault page.
       </p>
       <p>
-        As a result, your earnETH token balance stays the same, while the value
+        As a result, your earnUSD token balance stays the same, while the value
         per token adjusts over time to account for fees and performance.
       </p>
     </FaqItem>

--- a/features/earn/vault-usd/hooks/use-active-fees.ts
+++ b/features/earn/vault-usd/hooks/use-active-fees.ts
@@ -1,0 +1,16 @@
+import invariant from 'tiny-invariant';
+import { useMemo } from 'react';
+import { useActiveFees } from 'modules/mellow-meta-vaults/hooks/use-active-fees';
+import { useMainnetOnlyWagmi } from 'modules/web3';
+import { getVaultContract } from '../contracts';
+
+export const useUsdVaultActiveFees = () => {
+  const { publicClientMainnet } = useMainnetOnlyWagmi();
+  invariant(publicClientMainnet, 'Public client is not available');
+  const vault = useMemo(
+    () => getVaultContract(publicClientMainnet),
+    [publicClientMainnet],
+  );
+
+  return useActiveFees({ vault });
+};

--- a/features/earn/vault-usd/vault-page.tsx
+++ b/features/earn/vault-usd/vault-page.tsx
@@ -192,7 +192,8 @@ export const VaultPageUSD: FC<{
   const fees = useMemo<InfoItem[]>(
     () => [
       {
-        label: 'Active fees',
+        // label: 'Active fees', TEMP – uncomment with useUsdVaultActiveFees restoration
+        label: 'Fees',
         value: <ActiveFeesValue value={FROZEN_ACTIVE_FEES_VALUE} />,
       },
     ],

--- a/features/earn/vault-usd/vault-page.tsx
+++ b/features/earn/vault-usd/vault-page.tsx
@@ -5,9 +5,14 @@ import { config } from 'config';
 import { PartnerNethermindIconCircle, VaultUsdIcon } from 'assets/earn-v2';
 import { PartnerMellowIcon } from 'assets/earn';
 import { VaultPage } from 'features/earn/shared/v2/vault-page/vault-page';
+import type { InfoItem } from 'features/earn/shared/v2/vault-page/vault-page';
 import { MATOMO_EARN_EVENTS_TYPES } from 'consts/matomo';
 import { TOKEN_SYMBOLS } from 'consts/tokens';
-import { WITHDRAWAL_WAITING_TIME_TOOLTIP } from 'modules/mellow-meta-vaults';
+import {
+  ACTIVE_FEES_TOOLTIP,
+  ACTIVE_FEES_VALUE,
+  WITHDRAWAL_WAITING_TIME_TOOLTIP,
+} from 'modules/mellow-meta-vaults';
 
 import { VaultAllocation } from '../shared/v2/vault-allocation/vault-allocation';
 import { Disclaimers } from '../shared/v2/disclaimers';
@@ -27,9 +32,12 @@ import {
 } from './consts';
 import { ProtectedTooltip } from './protected-tooltip';
 
-const FEES = [
-  { label: 'Performance fee', value: '10%' },
-  { label: 'Platform fee', value: '1%' },
+const FEES: InfoItem[] = [
+  {
+    label: 'Active fees',
+    value: ACTIVE_FEES_VALUE,
+    tooltip: ACTIVE_FEES_TOOLTIP,
+  },
 ];
 
 const GENERAL_INFO_LEFT = [

--- a/features/earn/vault-usd/vault-page.tsx
+++ b/features/earn/vault-usd/vault-page.tsx
@@ -1,4 +1,4 @@
-import type { FC, ReactNode } from 'react';
+import { useMemo, type FC, type ReactNode } from 'react';
 import { Link } from '@lidofinance/lido-ui';
 
 import { config } from 'config';
@@ -10,13 +10,13 @@ import { MATOMO_EARN_EVENTS_TYPES } from 'consts/matomo';
 import { TOKEN_SYMBOLS } from 'consts/tokens';
 import {
   ACTIVE_FEES_TOOLTIP,
-  ACTIVE_FEES_VALUE,
   WITHDRAWAL_WAITING_TIME_TOOLTIP,
 } from 'modules/mellow-meta-vaults';
 
 import { VaultAllocation } from '../shared/v2/vault-allocation/vault-allocation';
 import { Disclaimers } from '../shared/v2/disclaimers';
 import { ApyUpdateTooltipText } from '../shared/v2/apy-update-tooltip-text';
+import { ActiveFeesValue } from '../shared/v2/active-fees-value';
 
 import { UsdVaultPositionManager } from './position-manager/position-manager';
 import { EarnUsdFaq } from './faq/faq';
@@ -24,6 +24,7 @@ import { EARN_VAULT_DEPOSIT_SLUG, EARN_VAULT_WITHDRAW_SLUG } from '../consts';
 import { useUsdVaultStats } from './hooks/use-vault-stats';
 import { useUsdVaultApy } from './hooks/use-vault-apy';
 import { useUsdVaultPosition } from './hooks/use-position';
+import { useUsdVaultActiveFees } from './hooks/use-active-fees';
 import { UsdVaultApyHint } from './components/apy-hint';
 import {
   USD_VAULT_DESCRIPTION,
@@ -31,14 +32,6 @@ import {
   USD_VAULT_TOKEN_SYMBOL,
 } from './consts';
 import { ProtectedTooltip } from './protected-tooltip';
-
-const FEES: InfoItem[] = [
-  {
-    label: 'Active fees',
-    value: ACTIVE_FEES_VALUE,
-    tooltip: ACTIVE_FEES_TOOLTIP,
-  },
-];
 
 const GENERAL_INFO_LEFT = [
   {
@@ -163,7 +156,6 @@ const DATA = {
   title: USD_VAULT_TITLE,
   description: USD_VAULT_DESCRIPTION,
   logo: VaultUsdIcon,
-  fees: FEES,
   generalInfoLeft: GENERAL_INFO_LEFT,
   generalInfoRight: GENERAL_INFO_RIGHT,
   riskDisclosure: RISK_DISCLOSURE,
@@ -184,13 +176,32 @@ export const VaultPageUSD: FC<{
     isLoading: isPositionLoading,
     usdcAmount,
   } = useUsdVaultPosition();
+  const { value: activeFeesValue, isLoading: isActiveFeesLoading } =
+    useUsdVaultActiveFees();
 
   const sharesBalance = earnusdPositionData?.earnusdSharesBalance;
+
+  const fees = useMemo<InfoItem[]>(
+    () => [
+      {
+        label: 'Active fees',
+        value: (
+          <ActiveFeesValue
+            value={activeFeesValue}
+            isLoading={isActiveFeesLoading}
+          />
+        ),
+        tooltip: ACTIVE_FEES_TOOLTIP,
+      },
+    ],
+    [activeFeesValue, isActiveFeesLoading],
+  );
 
   return (
     <>
       <VaultPage
         {...DATA}
+        fees={fees}
         apx={apy}
         tvlUsd={tvlUsd}
         isApxLoading={isApyLoading}

--- a/features/earn/vault-usd/vault-page.tsx
+++ b/features/earn/vault-usd/vault-page.tsx
@@ -9,7 +9,7 @@ import type { InfoItem } from 'features/earn/shared/v2/vault-page/vault-page';
 import { MATOMO_EARN_EVENTS_TYPES } from 'consts/matomo';
 import { TOKEN_SYMBOLS } from 'consts/tokens';
 import {
-  ACTIVE_FEES_TOOLTIP,
+  // ACTIVE_FEES_TOOLTIP,
   WITHDRAWAL_WAITING_TIME_TOOLTIP,
 } from 'modules/mellow-meta-vaults';
 
@@ -24,7 +24,8 @@ import { EARN_VAULT_DEPOSIT_SLUG, EARN_VAULT_WITHDRAW_SLUG } from '../consts';
 import { useUsdVaultStats } from './hooks/use-vault-stats';
 import { useUsdVaultApy } from './hooks/use-vault-apy';
 import { useUsdVaultPosition } from './hooks/use-position';
-import { useUsdVaultActiveFees } from './hooks/use-active-fees';
+// TEMP — see FROZEN_ACTIVE_FEES_VALUE
+// import { useUsdVaultActiveFees } from './hooks/use-active-fees';
 import { UsdVaultApyHint } from './components/apy-hint';
 import {
   USD_VAULT_DESCRIPTION,
@@ -152,6 +153,12 @@ const RISK_DISCLOSURE = (
 const VAULT_ALLOCATION_FOOTER =
   'Data is provided by Mellow’s API and reflects the most recent snapshot at the time of update. As a result, the TVL shown here may differ from the vault’s TVL due to the data timestamp';
 
+// TEMP (SI-2771)
+// Show the fees the vault advertised before this branch until the new schedule is announced.
+// To unfreeze: uncomment the import + hook call, pass value/isLoading through,
+// and restore `tooltip: ACTIVE_FEES_TOOLTIP`.
+const FROZEN_ACTIVE_FEES_VALUE = '1% AUM + 10% performance';
+
 const DATA = {
   title: USD_VAULT_TITLE,
   description: USD_VAULT_DESCRIPTION,
@@ -176,8 +183,9 @@ export const VaultPageUSD: FC<{
     isLoading: isPositionLoading,
     usdcAmount,
   } = useUsdVaultPosition();
-  const { value: activeFeesValue, isLoading: isActiveFeesLoading } =
-    useUsdVaultActiveFees();
+  // TEMP — see FROZEN_ACTIVE_FEES_VALUE
+  // const { value: activeFeesValue, isLoading: isActiveFeesLoading } =
+  //   useUsdVaultActiveFees();
 
   const sharesBalance = earnusdPositionData?.earnusdSharesBalance;
 
@@ -185,16 +193,10 @@ export const VaultPageUSD: FC<{
     () => [
       {
         label: 'Active fees',
-        value: (
-          <ActiveFeesValue
-            value={activeFeesValue}
-            isLoading={isActiveFeesLoading}
-          />
-        ),
-        tooltip: ACTIVE_FEES_TOOLTIP,
+        value: <ActiveFeesValue value={FROZEN_ACTIVE_FEES_VALUE} />,
       },
     ],
-    [activeFeesValue, isActiveFeesLoading],
+    [],
   );
 
   return (

--- a/modules/mellow-meta-vaults/abi/fee-manager.ts
+++ b/modules/mellow-meta-vaults/abi/fee-manager.ts
@@ -1,0 +1,93 @@
+// Read-only surface of Mellow's FeeManager (implementation behind the per-vault proxy).
+// Write functions, events and errors are intentionally omitted.
+export const FEE_MANAGER_ABI = [
+  {
+    inputs: [{ internalType: 'address', name: 'vault', type: 'address' }],
+    name: 'baseAsset',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'uint256', name: 'shares', type: 'uint256' }],
+    name: 'calculateDepositFee',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'address', name: 'vault', type: 'address' },
+      { internalType: 'address', name: 'asset', type: 'address' },
+      { internalType: 'uint256', name: 'priceD18', type: 'uint256' },
+      { internalType: 'uint256', name: 'totalShares', type: 'uint256' },
+    ],
+    name: 'calculateFee',
+    outputs: [{ internalType: 'uint256', name: 'shares', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'uint256', name: 'shares', type: 'uint256' }],
+    name: 'calculateRedeemFee',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'depositFeeD6',
+    outputs: [{ internalType: 'uint24', name: '', type: 'uint24' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'feeRecipient',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'vault', type: 'address' }],
+    name: 'minPriceD18',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'owner',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'performanceFeeD6',
+    outputs: [{ internalType: 'uint24', name: '', type: 'uint24' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'protocolFeeD6',
+    outputs: [{ internalType: 'uint24', name: '', type: 'uint24' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'redeemFeeD6',
+    outputs: [{ internalType: 'uint24', name: '', type: 'uint24' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'vault', type: 'address' }],
+    name: 'timestamps',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const;

--- a/modules/mellow-meta-vaults/abi/index.ts
+++ b/modules/mellow-meta-vaults/abi/index.ts
@@ -5,3 +5,4 @@ export * from './sync-redeem-queue';
 export * from './share-manager';
 export * from './collector';
 export * from './vault-contract';
+export * from './fee-manager';

--- a/modules/mellow-meta-vaults/consts.tsx
+++ b/modules/mellow-meta-vaults/consts.tsx
@@ -8,3 +8,9 @@ export const MELLOW_VAULTS_QUERY_SCOPE = 'mellow-meta-vault';
 
 export const WITHDRAWAL_WAITING_TIME_TOOLTIP =
   'Withdrawals are instant when the buffer has enough liquidity to cover your request. Larger requests go to the withdrawal queue, usually settled within 72 hours but occasionally longer depending on size.';
+
+// current fees, hardcoded until a live fee read exists
+export const ACTIVE_FEES_VALUE = '0.2% AUM + 15% performance';
+
+export const ACTIVE_FEES_TOOLTIP =
+  "Displays the vault's current fees. Fees are flexible and may change to reflect market conditions. The AUM fee (a percentage of total holdings) cannot exceed 0.5%, and the performance fee (a percentage of yield earned) cannot exceed 20%.";

--- a/modules/mellow-meta-vaults/consts.tsx
+++ b/modules/mellow-meta-vaults/consts.tsx
@@ -9,8 +9,5 @@ export const MELLOW_VAULTS_QUERY_SCOPE = 'mellow-meta-vault';
 export const WITHDRAWAL_WAITING_TIME_TOOLTIP =
   'Withdrawals are instant when the buffer has enough liquidity to cover your request. Larger requests go to the withdrawal queue, usually settled within 72 hours but occasionally longer depending on size.';
 
-// current fees, hardcoded until a live fee read exists
-export const ACTIVE_FEES_VALUE = '0.2% AUM + 15% performance';
-
 export const ACTIVE_FEES_TOOLTIP =
   "Displays the vault's current fees. Fees are flexible and may change to reflect market conditions. The AUM fee (a percentage of total holdings) cannot exceed 0.5%, and the performance fee (a percentage of yield earned) cannot exceed 20%.";

--- a/modules/mellow-meta-vaults/hooks/index.ts
+++ b/modules/mellow-meta-vaults/hooks/index.ts
@@ -1,3 +1,4 @@
+export * from './use-active-fees';
 export * from './use-deposit-cancel';
 export * from './use-deposit-claim';
 export * from './use-deposit-eth-gas-limit';

--- a/modules/mellow-meta-vaults/hooks/use-active-fees.ts
+++ b/modules/mellow-meta-vaults/hooks/use-active-fees.ts
@@ -39,12 +39,11 @@ export const useActiveFees = ({ vault }: { vault: VaultContract }) => {
 
       return { protocolFeeD6, performanceFeeD6 };
     },
+    select: formatActiveFees,
   });
 
   return {
     isLoading: query.isLoading,
-    value: query.data ? formatActiveFees(query.data) : undefined,
-    protocolFeeD6: query.data?.protocolFeeD6,
-    performanceFeeD6: query.data?.performanceFeeD6,
+    value: query.data,
   };
 };

--- a/modules/mellow-meta-vaults/hooks/use-active-fees.ts
+++ b/modules/mellow-meta-vaults/hooks/use-active-fees.ts
@@ -1,0 +1,50 @@
+import { useQuery } from '@tanstack/react-query';
+import { getContract } from 'viem';
+import invariant from 'tiny-invariant';
+
+import { STRATEGY_CONSTANT } from 'consts/react-query-strategies';
+import { useMainnetOnlyWagmi } from 'modules/web3';
+
+import { FEE_MANAGER_ABI } from '../abi';
+import { MELLOW_VAULTS_QUERY_SCOPE } from '../consts';
+import { VaultContract } from '../types/contracts';
+import { formatActiveFees } from '../utils/format-fee-d6';
+
+export const useActiveFees = ({ vault }: { vault: VaultContract }) => {
+  const { publicClientMainnet } = useMainnetOnlyWagmi();
+
+  const query = useQuery({
+    queryKey: [
+      MELLOW_VAULTS_QUERY_SCOPE,
+      'active-fees',
+      vault.address,
+    ] as const,
+    ...STRATEGY_CONSTANT,
+    queryFn: async () => {
+      invariant(publicClientMainnet, 'Public client is not available');
+
+      // Resolved on-chain rather than from config
+      const feeManagerAddress = await vault.read.feeManager();
+
+      const feeManager = getContract({
+        abi: FEE_MANAGER_ABI,
+        address: feeManagerAddress,
+        client: { public: publicClientMainnet },
+      });
+
+      const [protocolFeeD6, performanceFeeD6] = await Promise.all([
+        feeManager.read.protocolFeeD6(),
+        feeManager.read.performanceFeeD6(),
+      ]);
+
+      return { protocolFeeD6, performanceFeeD6 };
+    },
+  });
+
+  return {
+    isLoading: query.isLoading,
+    value: query.data ? formatActiveFees(query.data) : undefined,
+    protocolFeeD6: query.data?.protocolFeeD6,
+    performanceFeeD6: query.data?.performanceFeeD6,
+  };
+};

--- a/modules/mellow-meta-vaults/types/contracts.ts
+++ b/modules/mellow-meta-vaults/types/contracts.ts
@@ -7,6 +7,7 @@ import {
   ASYNC_REDEEM_QUEUE_ABI,
   SYNC_REDEEM_QUEUE_ABI,
   SHARE_MANAGER_ABI,
+  FEE_MANAGER_ABI,
 } from '../abi';
 
 export type Contract<TAbi extends Abi = Abi> = GetContractReturnType<
@@ -65,3 +66,5 @@ export type SyncRedeemQueueWritableContract = Contract<
 >;
 
 export type ShareManagerContract = Contract<typeof SHARE_MANAGER_ABI>;
+
+export type FeeManagerContract = ContractReadonly<typeof FEE_MANAGER_ABI>;

--- a/modules/mellow-meta-vaults/utils/format-fee-d6.test.ts
+++ b/modules/mellow-meta-vaults/utils/format-fee-d6.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatActiveFees, formatFeeD6 } from './format-fee-d6';
+
+describe('formatFeeD6', () => {
+  it('formats the current EarnETH fees', () => {
+    expect(formatFeeD6(2000)).toBe('0.2');
+    expect(formatFeeD6(150000)).toBe('15');
+  });
+
+  it('formats zero without decimals', () => {
+    expect(formatFeeD6(0)).toBe('0');
+  });
+
+  it('formats the contract caps', () => {
+    expect(formatFeeD6(5000)).toBe('0.5');
+    expect(formatFeeD6(200000)).toBe('20');
+  });
+
+  it('formats 100%', () => {
+    expect(formatFeeD6(1_000_000)).toBe('100');
+  });
+
+  it('keeps sub-basis-point precision', () => {
+    expect(formatFeeD6(1)).toBe('0.0001');
+    expect(formatFeeD6(1234)).toBe('0.1234');
+  });
+
+  it('trims trailing zeros', () => {
+    expect(formatFeeD6(100000)).toBe('10');
+    expect(formatFeeD6(10500)).toBe('1.05');
+  });
+});
+
+describe('formatActiveFees', () => {
+  it('joins both fees into the display string', () => {
+    expect(
+      formatActiveFees({ protocolFeeD6: 2000, performanceFeeD6: 150000 }),
+    ).toBe('0.2% AUM + 15% performance');
+  });
+
+  it('renders zero fees literally', () => {
+    expect(formatActiveFees({ protocolFeeD6: 0, performanceFeeD6: 0 })).toBe(
+      '0% AUM + 0% performance',
+    );
+  });
+});

--- a/modules/mellow-meta-vaults/utils/format-fee-d6.ts
+++ b/modules/mellow-meta-vaults/utils/format-fee-d6.ts
@@ -1,0 +1,16 @@
+// D6 precision: 1e6 == 100%, so percent = feeD6 / 10_000.
+// toFixed(4) is lossless for any uint24 (D6 granularity is 0.0001%);
+// Number() then drops trailing zeros: 2000 -> '0.2', 150000 -> '15', 0 -> '0'.
+export const formatFeeD6 = (feeD6: number): string =>
+  String(Number((feeD6 / 10_000).toFixed(4)));
+
+export type ActiveFeesD6 = {
+  protocolFeeD6: number;
+  performanceFeeD6: number;
+};
+
+export const formatActiveFees = ({
+  protocolFeeD6,
+  performanceFeeD6,
+}: ActiveFeesD6): string =>
+  `${formatFeeD6(protocolFeeD6)}% AUM + ${formatFeeD6(performanceFeeD6)}% performance`;


### PR DESCRIPTION
### Description

EarnETH and EarnUSD fees are no longer contractually fixed at 1% AUM / 10% performance — curators can now adjust them within caps of 0.5% and 20%. This PR updates the UI to match that reality in two steps:

1. **Copy & UX** (`015e04da`) — replaces the two static `Platform fee` / `Performance fee` rows with a single `Active fees` row plus an explanatory tooltip, and rewords the FAQ and the vault-comparison drawer to describe the fees as flexible-with-caps.
2. **Live values** (`f1d60ad8`) — reads the current fees straight from each vault's `FeeManager` contract instead of hardcoding them, so the row can't drift out of date when a curator changes a fee.

### How it works

Each Mellow meta-vault points at its own `FeeManager`. Rather than adding the addresses to `networks/mainnet.json`, the hook resolves them on-chain via the `feeManager()` getter that already exists in `VAULT_ABI` — so a FeeManager swap needs no redeploy:

```
vault.feeManager()  →  FeeManager.protocolFeeD6()     // AUM fee
                       FeeManager.performanceFeeD6()  // performance fee
```

Both getters are no-arg and return `uint24` in D6 precision (`1e6` = 100%), so `percent = feeD6 / 10_000`. The two reads are issued together with `Promise.all` inside one `queryFn` — the established pattern in this module, since multicall is disabled in both wagmi configs and RPC-level HTTP batching handles it. Cached with `STRATEGY_CONSTANT` (fees change rarely).

Current mainnet state:

| Vault | FeeManager | `protocolFeeD6` | `performanceFeeD6` | Renders as |
|---|---|---|---|---|
| EarnETH | [`0xed4Fac…0488E1`](https://etherscan.io/address/0xed4Fac879eE86F3aB0101993A3713e7cAA0488E1) | `2000` | `150000` | `0.2% AUM + 15% performance` |
| EarnUSD | [`0x72fa23…47e8Dc`](https://etherscan.io/address/0x72fa23f40e08eB9E45953233b2Dd9665E347e8Dc) | `0` | `0` | `0% AUM + 0% performance` |


While loading, the row shows an `InlineLoader` skeleton; if the read fails it shows `N/A` rather than a stale number.

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
