### PR TITLE
[Fix]  transaction flow, DEX guard, data freshness, and API hardening

### DIFF
--- a/config/external-config/__tests__/disabled-path.test.ts
+++ b/config/external-config/__tests__/disabled-path.test.ts
@@ -1,0 +1,32 @@
+import { isDisabledPath } from '../utils';
+
+const disabled = { shouldDisable: true, showNew: false, sections: [] };
+const enabled = { shouldDisable: false, showNew: false, sections: [] };
+
+// SW-ROUTE-ADMIT-02: `/` matches every path and must not mask disabled keys
+describe('isDisabledPath', () => {
+  it('disables a route when `/` is listed first', () => {
+    const pages = { '/': enabled, '/withdrawals': disabled };
+    expect(isDisabledPath('/withdrawals/request', pages)).toBe(true);
+  });
+
+  it('disables a route when `/` is listed last', () => {
+    const pages = { '/withdrawals': disabled, '/': enabled };
+    expect(isDisabledPath('/withdrawals/request', pages)).toBe(true);
+  });
+
+  it('disables an IPFS hash path with a query string', () => {
+    const pages = { '/': enabled, '/earn': disabled };
+    expect(isDisabledPath('/earn/vault?tab=deposit', pages)).toBe(true);
+  });
+
+  it('allows enabled routes and unrelated disabled keys', () => {
+    const pages = { '/': enabled, '/rewards': disabled, '/wrap': enabled };
+    expect(isDisabledPath('/wrap/unwrap', pages)).toBe(false);
+    expect(isDisabledPath('/', pages)).toBe(false);
+  });
+
+  it('allows everything when no pages are configured', () => {
+    expect(isDisabledPath('/withdrawals/request', {})).toBe(false);
+  });
+});

--- a/config/external-config/__tests__/disabled-path.test.ts
+++ b/config/external-config/__tests__/disabled-path.test.ts
@@ -15,15 +15,44 @@ describe('isDisabledPath', () => {
     expect(isDisabledPath('/withdrawals/request', pages)).toBe(true);
   });
 
+  it('disables the exact page and its children', () => {
+    const pages = { '/': enabled, '/earn': disabled };
+    expect(isDisabledPath('/earn', pages)).toBe(true);
+    expect(isDisabledPath('/earn/', pages)).toBe(true);
+    expect(isDisabledPath('/earn/vault/deposit', pages)).toBe(true);
+  });
+
   it('disables an IPFS hash path with a query string', () => {
     const pages = { '/': enabled, '/earn': disabled };
     expect(isDisabledPath('/earn/vault?tab=deposit', pages)).toBe(true);
+    expect(isDisabledPath('/earn/?tab=deposit', pages)).toBe(true);
+    expect(isDisabledPath('/earn#section', pages)).toBe(true);
+  });
+
+  it('ignores a disabled page key that only appears in the query', () => {
+    const pages = { '/': enabled, '/earn': disabled, '/wrap': enabled };
+    expect(isDisabledPath('/wrap?next=/earn', pages)).toBe(false);
+    expect(isDisabledPath('/wrap?ref=earn/vault', pages)).toBe(false);
+    expect(isDisabledPath('/?redirect=%2Fearn&x=/earn', pages)).toBe(false);
+    expect(isDisabledPath('/wrap#/earn', pages)).toBe(false);
+  });
+
+  it('does not match a route that merely starts with the key text', () => {
+    const pages = { '/': enabled, '/earn': disabled };
+    expect(isDisabledPath('/earnings', pages)).toBe(false);
+    expect(isDisabledPath('/wrap/earn', pages)).toBe(false);
   });
 
   it('allows enabled routes and unrelated disabled keys', () => {
     const pages = { '/': enabled, '/rewards': disabled, '/wrap': enabled };
     expect(isDisabledPath('/wrap/unwrap', pages)).toBe(false);
     expect(isDisabledPath('/', pages)).toBe(false);
+  });
+
+  it('only matches `/` exactly even if it were disabled', () => {
+    const pages = { '/': disabled, '/wrap': enabled };
+    expect(isDisabledPath('/', pages)).toBe(true);
+    expect(isDisabledPath('/wrap', pages)).toBe(false);
   });
 
   it('allows everything when no pages are configured', () => {

--- a/config/external-config/__tests__/manifest-refetch.test.ts
+++ b/config/external-config/__tests__/manifest-refetch.test.ts
@@ -1,0 +1,51 @@
+// query-core disables refetchInterval when `window` is undefined (isServer);
+// stub it before the module is evaluated so the browser code path runs
+vi.hoisted(() => vi.stubGlobal('window', globalThis));
+
+import { QueryClient, QueryObserver } from '@tanstack/react-query';
+
+import {
+  STRATEGY_LAZY,
+  STRATEGY_MANIFEST,
+} from 'consts/react-query-strategies';
+
+const MINUTE = 60 * 1000;
+
+// Mounts one query with the given strategy, lets `duration` pass and reports
+// how many times the queryFn ran
+const countFetches = async (strategy: object, duration: number) => {
+  const queryFn = vi.fn(async () => 'manifest');
+  const observer = new QueryObserver(new QueryClient(), {
+    queryKey: ['external-config'],
+    queryFn,
+    ...strategy,
+  });
+  const unsubscribe = observer.subscribe(() => undefined);
+  await vi.advanceTimersByTimeAsync(duration);
+  unsubscribe();
+  return queryFn.mock.calls.length;
+};
+
+// SW-ROUTE-ADMIT-01: a mounted manifest query must pick up remote changes on
+// its own — going stale is not enough, only an interval refetches
+describe('manifest query refetching', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+  afterAll(() => vi.unstubAllGlobals());
+
+  it('without an interval the query fetches once and never again', async () => {
+    const { refetchInterval: _, ...staleOnly } = STRATEGY_LAZY;
+    expect(await countFetches(staleOnly, 30 * MINUTE)).toBe(1);
+  });
+
+  it('STRATEGY_MANIFEST refetches on every interval tick', async () => {
+    const { refetchInterval } = STRATEGY_MANIFEST;
+    expect(await countFetches(STRATEGY_MANIFEST, 3 * refetchInterval)).toBe(4);
+  });
+
+  it('STRATEGY_MANIFEST polls faster than the lazy default', () => {
+    expect(STRATEGY_MANIFEST.refetchInterval).toBeLessThan(
+      STRATEGY_LAZY.refetchInterval,
+    );
+  });
+});

--- a/config/external-config/index.ts
+++ b/config/external-config/index.ts
@@ -15,6 +15,7 @@ export {
   getManifestKey,
   getLocalFallbackManifest,
   shouldRedirectToRoot,
+  isDisabledPath,
 } from './utils';
 export {
   ManifestSchema,

--- a/config/external-config/use-external-config-context.ts
+++ b/config/external-config/use-external-config-context.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import { config } from 'config';
-import { STRATEGY_LAZY } from 'consts/react-query-strategies';
+import { STRATEGY_MANIFEST } from 'consts/react-query-strategies';
 import { REMOTE_CONFIG_MANIFEST_URL } from 'consts/external-links';
 import { API_ROUTES } from 'consts/api';
 import { standardFetcher } from 'utils/standardFetcher';
@@ -48,7 +48,7 @@ export const useExternalConfigContext = (
       'external-config',
       { defaultChain, manifestOverride, manifestUrl },
     ],
-    ...STRATEGY_LAZY,
+    ...STRATEGY_MANIFEST,
     enabled: !!defaultChain,
     queryFn: async () => {
       try {

--- a/config/external-config/utils.ts
+++ b/config/external-config/utils.ts
@@ -40,12 +40,24 @@ export const shouldRedirectToRoot = (
   return isDisabled && !isBuild;
 };
 
-// A path is disabled when it contains any disabled page key. `/` is contained
-// in every path, but the schema guarantees the stake page is never disabled
+// Route part of a router path or IPFS hash path: no query, no hash and no
+// trailing slash, so `/earn/?tab=deposit` and `/earn` compare equal
+const normalizePath = (path: string): string => {
+  const route = path.split(/[?#]/u, 1)[0] ?? '';
+  return route.replace(/\/+$/u, '') || '/';
+};
+
+// A path is disabled when its route is a disabled page key or a child of one.
+// Query values are ignored: `/wrap?next=/earn` is the wrap page. `/` is only
+// matched exactly, and the schema guarantees the stake page is never disabled
 export const isDisabledPath = (
   path: string,
   pages: ManifestConfig['pages'],
-): boolean =>
-  Object.entries(pages).some(
-    ([pathKey, page]) => page?.shouldDisable && path.includes(pathKey),
-  );
+): boolean => {
+  const route = normalizePath(path);
+  return Object.entries(pages).some(([pathKey, page]) => {
+    if (!page?.shouldDisable) return false;
+    const key = normalizePath(pathKey);
+    return route === key || (key !== '/' && route.startsWith(`${key}/`));
+  });
+};

--- a/config/external-config/utils.ts
+++ b/config/external-config/utils.ts
@@ -1,13 +1,9 @@
 import invariant from 'tiny-invariant';
 import { config } from 'config';
 
-import {
-  ManifestSchema,
-  ManifestConfigPages,
-  type ManifestKey,
-} from './validate';
+import { ManifestSchema, type ManifestKey } from './validate';
 
-import type { Manifest, ManifestConfigPage } from './types';
+import type { Manifest, ManifestConfig, ManifestConfigPage } from './types';
 
 import FallbackLocalManifest from 'REMOTE_CONFIG_MANIFEST.json';
 
@@ -41,5 +37,15 @@ export const shouldRedirectToRoot = (
   // https://nextjs.org/docs/messages/gsp-redirect-during-prerender
   const isBuild = process.env.npm_lifecycle_event === 'build';
 
-  return currentPath !== ManifestConfigPages.Stake && isDisabled && !isBuild;
+  return isDisabled && !isBuild;
 };
+
+// A path is disabled when it contains any disabled page key. `/` is contained
+// in every path, but the schema guarantees the stake page is never disabled
+export const isDisabledPath = (
+  path: string,
+  pages: ManifestConfig['pages'],
+): boolean =>
+  Object.entries(pages).some(
+    ([pathKey, page]) => page?.shouldDisable && path.includes(pathKey),
+  );

--- a/config/user-config/context-hook.tsx
+++ b/config/user-config/context-hook.tsx
@@ -1,20 +1,23 @@
-import { useMemo, useState, useCallback } from 'react';
+import { useMemo, useState, useCallback, useRef } from 'react';
 
 import { CHAINS } from 'consts/chains';
 import { useLocalStorage } from 'shared/hooks/use-local-storage';
 
 import { getUserConfigDefault } from './utils';
 import { UserConfigDefaultType } from './types';
+import { assignRpcUrl, type RpcUrls } from './rpc-urls';
 
 const STORAGE_USER_CONFIG = 'lido-user-config';
 
 type SavedUserConfig = {
-  rpcUrls: Partial<Record<CHAINS, string>>;
+  rpcUrls: RpcUrls;
 };
 
 export type UserConfigContextType = UserConfigDefaultType & {
   savedUserConfig: SavedUserConfig;
   setSavedUserConfig: (config: SavedUserConfig) => void;
+  /** Sets or, with an empty url, clears one chain's custom RPC, keeping the others */
+  setRpcUrl: (chainId: CHAINS, rpcUrl?: string) => void;
   isWalletConnectionAllowed: boolean;
   setIsWalletConnectionAllowed: (isAllowed: boolean) => void;
 };
@@ -43,6 +46,24 @@ export const useUserConfigContext = () => {
     [setLocalStorage],
   );
 
+  // Latest saved config for the chain-scoped setter, so two quick saves for
+  // different chains never overwrite each other with a stale closure
+  const savedUserConfigRef = useRef(savedUserConfig);
+  savedUserConfigRef.current = savedUserConfig;
+
+  const setRpcUrl = useCallback(
+    (chainId: CHAINS, rpcUrl?: string) => {
+      setSavedConfigAndRemember({
+        rpcUrls: assignRpcUrl(
+          savedUserConfigRef.current.rpcUrls,
+          chainId,
+          rpcUrl,
+        ),
+      });
+    },
+    [setSavedConfigAndRemember],
+  );
+
   return useMemo(() => {
     const userConfigDefault = getUserConfigDefault();
 
@@ -50,8 +71,14 @@ export const useUserConfigContext = () => {
       ...userConfigDefault,
       savedUserConfig,
       setSavedUserConfig: setSavedConfigAndRemember,
+      setRpcUrl,
       isWalletConnectionAllowed,
       setIsWalletConnectionAllowed,
     };
-  }, [isWalletConnectionAllowed, savedUserConfig, setSavedConfigAndRemember]);
+  }, [
+    isWalletConnectionAllowed,
+    savedUserConfig,
+    setSavedConfigAndRemember,
+    setRpcUrl,
+  ]);
 };

--- a/config/user-config/rpc-urls.test.ts
+++ b/config/user-config/rpc-urls.test.ts
@@ -1,0 +1,41 @@
+import { CHAINS } from 'consts/chains';
+
+import { assignRpcUrl } from './rpc-urls';
+
+const saved = {
+  [CHAINS.Mainnet]: 'https://l1.example',
+  [CHAINS.Optimism]: 'https://l2.example',
+};
+
+// SETTINGS-RPC-PERSIST-01: saving or resetting one chain must keep the others
+describe('assignRpcUrl', () => {
+  it('replaces only the given chain', () => {
+    expect(assignRpcUrl(saved, CHAINS.Optimism, 'https://new.example')).toEqual(
+      {
+        [CHAINS.Mainnet]: 'https://l1.example',
+        [CHAINS.Optimism]: 'https://new.example',
+      },
+    );
+  });
+
+  it('adds a chain without touching existing entries', () => {
+    expect(assignRpcUrl(saved, CHAINS.Hoodi, 'https://hoodi.example')).toEqual({
+      ...saved,
+      [CHAINS.Hoodi]: 'https://hoodi.example',
+    });
+  });
+
+  it('removes only the given chain on reset', () => {
+    expect(assignRpcUrl(saved, CHAINS.Optimism)).toEqual({
+      [CHAINS.Mainnet]: 'https://l1.example',
+    });
+    expect(assignRpcUrl(saved, CHAINS.Optimism, '')).toEqual({
+      [CHAINS.Mainnet]: 'https://l1.example',
+    });
+  });
+
+  it('does not mutate the input', () => {
+    assignRpcUrl(saved, CHAINS.Mainnet);
+    expect(saved[CHAINS.Mainnet]).toBe('https://l1.example');
+  });
+});

--- a/config/user-config/rpc-urls.ts
+++ b/config/user-config/rpc-urls.ts
@@ -1,0 +1,16 @@
+import type { CHAINS } from 'consts/chains';
+
+export type RpcUrls = Partial<Record<CHAINS, string>>;
+
+/**
+ * Returns the map with one chain's custom RPC replaced (or removed when
+ * `rpcUrl` is empty), leaving every other chain's entry untouched.
+ */
+export const assignRpcUrl = (
+  rpcUrls: RpcUrls,
+  chainId: CHAINS,
+  rpcUrl?: string,
+): RpcUrls => {
+  const { [chainId]: _current, ...otherRpcUrls } = rpcUrls;
+  return rpcUrl ? { ...otherRpcUrls, [chainId]: rpcUrl } : otherRpcUrls;
+};

--- a/consts/matomo/matomo-error-events.ts
+++ b/consts/matomo/matomo-error-events.ts
@@ -15,6 +15,7 @@ export const enum MATOMO_ERROR_EVENTS_TYPES {
   SITE_BLOCKED = 'SITE_BLOCKED',
   PROVIDER_DISCONNECTED = 'PROVIDER_DISCONNECTED',
   CHAIN_DISCONNECTED = 'CHAIN_DISCONNECTED',
+  TX_SETTLED_DATA_UNAVAILABLE = 'TX_SETTLED_DATA_UNAVAILABLE',
   SOMETHING_WRONG = 'SOMETHING_WRONG',
 }
 
@@ -91,6 +92,11 @@ export const MATOMO_ERROR_EVENTS: Record<
     'Ethereum_Staking_Widget_Errors',
     'Your wallet is not connected to the selected network.',
     'eth_widget_errors_chain_disconnected',
+  ],
+  [MATOMO_ERROR_EVENTS_TYPES.TX_SETTLED_DATA_UNAVAILABLE]: [
+    'Ethereum_Staking_Widget_Errors',
+    'Transaction settled but follow-up data could not be loaded',
+    'eth_widget_errors_tx_settled_data_unavailable',
   ],
   [MATOMO_ERROR_EVENTS_TYPES.SOMETHING_WRONG]: [
     'Ethereum_Staking_Widget_Errors',

--- a/consts/react-query-strategies.ts
+++ b/consts/react-query-strategies.ts
@@ -7,14 +7,22 @@ export const STRATEGY_IMMUTABLE = {
 export const STRATEGY_CONSTANT = {
   staleTime: Infinity,
   refetchOnWindowFocus: false,
-  refetchOnReconnect: false,
+  refetchOnReconnect: true,
   refetchInterval: 10 * 60 * 1000, // 10 minutes
 };
 
 export const STRATEGY_LAZY = {
-  staleTime: 5 * 60 * 1000, // 5 minutes
+  staleTime: 2 * 60 * 1000, // 2 minutes
   refetchOnWindowFocus: false,
   refetchOnReconnect: true,
+  refetchInterval: 5 * 60 * 1000, // 5 minutes
+};
+
+// Runtime manifest: remote page/vault disables must reach already-open tabs
+// without a reload, so the mounted query polls instead of only going stale
+export const STRATEGY_MANIFEST = {
+  ...STRATEGY_LAZY,
+  refetchInterval: 60 * 1000, // 1 minute
 };
 
 export const STRATEGY_EAGER = {

--- a/features/dex-withdrawals/cowswap/consts.ts
+++ b/features/dex-withdrawals/cowswap/consts.ts
@@ -25,6 +25,7 @@ export const COWSWAP_WIDGET_ALLOWED_RPC_METHODS = new Set([
   'wallet_getCallsStatus',
 ]);
 
+export const SLIPPAGE_TOTAL_BPS = 10_000; // 100% (bps)
 export const MAX_SLIPPAGE = 300; // 3% (bps)
 export const PARTNER_FEE_BPS = 30; // 0.3% — Lido DAO treasury
 export const WHEN_PRICE_IMPACT_IS_HIGH_THAN = 3; // 3%

--- a/features/dex-withdrawals/cowswap/trade-guard/__tests__/utils.test.ts
+++ b/features/dex-withdrawals/cowswap/trade-guard/__tests__/utils.test.ts
@@ -99,6 +99,70 @@ describe('resolveLevel', () => {
 // analyzeParams
 // ---------------------------------------------------------------------------
 describe('analyzeParams', () => {
+  describe('minimum receive vs quote (STW-COW-QUOTE-01)', () => {
+    it('blocks when min receive is far below the quoted buy amount', () => {
+      const payload = makePayload({
+        buyToken: { address: USDC, symbol: 'USDC' },
+        buyTokenAmount: { units: '29910' },
+        minimumReceiveBuyAmount: { units: '1' },
+      } as Partial<OnTradeParamsPayload>);
+      const result = analyzeParams(payload);
+      expect(result.level).toBe('blocked');
+      expect(result.isStructural).toBe(true);
+    });
+
+    it('blocks when min receive implies more than max slippage', () => {
+      const payload = makePayload({
+        minimumReceiveBuyAmount: { units: '9.69' }, // 3.1% below quote
+      } as Partial<OnTradeParamsPayload>);
+      expect(analyzeParams(payload).level).toBe('blocked');
+    });
+
+    it.each(['.5', '1.', '1.0000000000000000001', 'abc'])(
+      'fails closed on an unparseable min receive %p',
+      (units) => {
+        const payload = makePayload({
+          buyToken: { address: USDC, symbol: 'USDC' },
+          buyTokenAmount: { units: '29910' },
+          minimumReceiveBuyAmount: { units },
+        } as Partial<OnTradeParamsPayload>);
+        expect(analyzeParams(payload).level).toBe('blocked');
+      },
+    );
+
+    it('fails closed when the quote itself is unparseable', () => {
+      const payload = makePayload({
+        buyTokenAmount: { units: 'abc' },
+        minimumReceiveBuyAmount: { units: '1' },
+      } as Partial<OnTradeParamsPayload>);
+      expect(analyzeParams(payload).level).toBe('blocked');
+    });
+
+    it('skips the check when no quote is present (approval pre-check)', () => {
+      const payload = makePayload({
+        buyTokenAmount: undefined,
+        minimumReceiveBuyAmount: undefined,
+      });
+      expect(analyzeParams(payload).level).toBe('safe');
+    });
+
+    it('allows min receive at exactly max slippage', () => {
+      const payload = makePayload({
+        minimumReceiveBuyAmount: { units: '9.7' }, // 3.0% below quote
+      } as Partial<OnTradeParamsPayload>);
+      expect(analyzeParams(payload).level).toBe('safe');
+    });
+
+    it('allows truncated atoms at max slippage (6-decimal token)', () => {
+      const payload = makePayload({
+        buyToken: { address: USDC, symbol: 'USDC' },
+        buyTokenAmount: { units: '29910.123457' },
+        minimumReceiveBuyAmount: { units: '29012.819753' }, // floor(x * 0.97)
+      } as Partial<OnTradeParamsPayload>);
+      expect(analyzeParams(payload).level).toBe('safe');
+    });
+  });
+
   describe('token presence', () => {
     it('returns blocked when sell token is missing', () => {
       const payload = makePayload({ sellToken: undefined });

--- a/features/dex-withdrawals/cowswap/trade-guard/__tests__/verify-order.test.ts
+++ b/features/dex-withdrawals/cowswap/trade-guard/__tests__/verify-order.test.ts
@@ -84,6 +84,14 @@ describe('verifyOrderAmounts', () => {
     expect(verifyOrderAmounts(makeOrder(), snapshot)).toBeDefined();
   });
 
+  it.each(['.5', '1.', '1.0000000000000000001'])(
+    'rejects lenient decimal formats parseUnits would accept (%p)',
+    (units) => {
+      const snapshot = makeSnapshot({ buyAmountMinUnits: units });
+      expect(verifyOrderAmounts(makeOrder(), snapshot)).toBeDefined();
+    },
+  );
+
   describe('USDC (6 decimals)', () => {
     const usdcOrder = makeOrder({
       sellToken: STETH,

--- a/features/dex-withdrawals/cowswap/trade-guard/utils/analyze-params.ts
+++ b/features/dex-withdrawals/cowswap/trade-guard/utils/analyze-params.ts
@@ -6,6 +6,7 @@ import {
   type Thresholds,
 } from '../consts';
 import type { TradeGuardLevel, OnTradeParamsPayload } from '../types';
+import { MAX_SLIPPAGE, SLIPPAGE_TOTAL_BPS } from '../../consts';
 
 import { safeParseDecimal } from './safe-parse-decimal';
 
@@ -25,6 +26,10 @@ export const analyzeParams = (
   const sellAddr = params.sellToken?.address.toLowerCase();
   const buyAddr = params.buyToken?.address.toLowerCase();
   const sellUnits = safeParseDecimal(params.sellTokenAmount?.units?.toString());
+  const buyUnits = safeParseDecimal(params.buyTokenAmount?.units?.toString());
+  const minReceiveUnits = safeParseDecimal(
+    params.minimumReceiveBuyAmount?.units?.toString(),
+  );
   const symbol = params.sellToken?.symbol;
 
   if (
@@ -48,6 +53,22 @@ export const analyzeParams = (
     return {
       level: 'blocked',
       messages: [TRADE_SIZE_ERROR(t.maxAllowedSellAmount, symbol)],
+      isStructural: true,
+    };
+  }
+
+  // +1 bps absorbs the widget's atom-level truncation.
+  const ADJUSTED_MAX_SLIPPAGE = MAX_SLIPPAGE + 1;
+  if (
+    params.minimumReceiveBuyAmount !== undefined &&
+    (buyUnits === null ||
+      minReceiveUnits === null ||
+      minReceiveUnits <
+        buyUnits * (1 - ADJUSTED_MAX_SLIPPAGE / SLIPPAGE_TOTAL_BPS))
+  ) {
+    return {
+      level: 'blocked',
+      messages: [TRADE_BUILD_ERROR(1008)],
       isStructural: true,
     };
   }

--- a/features/dex-withdrawals/cowswap/trade-guard/utils/verify-order.ts
+++ b/features/dex-withdrawals/cowswap/trade-guard/utils/verify-order.ts
@@ -4,6 +4,7 @@ import mainnetConfig from 'networks/mainnet.json';
 
 import type { OrderData } from '../../validate-tx';
 import { TRADE_VERIFICATION_ERROR } from '../consts';
+import { safeParseDecimal } from './safe-parse-decimal';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -45,6 +46,7 @@ const TOKEN_DECIMALS: Record<string, number> = {
 const unitsToRaw = (units: string, tokenAddress: string): bigint | null => {
   const decimals = TOKEN_DECIMALS[tokenAddress.toLowerCase()];
   if (decimals === undefined) return null;
+  if (safeParseDecimal(units) === null) return null;
   try {
     return parseUnits(units, decimals);
   } catch {

--- a/features/earn/shared/api/mellow-points.test.ts
+++ b/features/earn/shared/api/mellow-points.test.ts
@@ -1,0 +1,80 @@
+import { getAddress, parseEther } from 'viem';
+
+import { getMellowClaimReward, getMellowUserPointsWei } from './mellow-points';
+
+const VAULT = '0x0000000000000000000000000000000000000d00';
+const OTHER = '0x0000000000000000000000000000000000000d01';
+
+const pointsResponse = (user_mellow_points: unknown) => [
+  { vault_address: OTHER, user_mellow_points: 'NaN' }, // other vaults may be broken
+  { vault_address: VAULT, user_mellow_points },
+];
+
+// DVV-DSP-01: malformed point values must fail in the queryFn, never in render
+describe('getMellowUserPointsWei', () => {
+  it('converts a decimal string to wei without a Number round trip', () => {
+    expect(getMellowUserPointsWei(pointsResponse('123.456789'), VAULT)).toBe(
+      parseEther('123.456789'),
+    );
+  });
+
+  it('accepts a numeric value', () => {
+    expect(getMellowUserPointsWei(pointsResponse(12.5), VAULT)).toBe(
+      parseEther('12.5'),
+    );
+  });
+
+  it('returns 0 for a new user without a record', () => {
+    expect(getMellowUserPointsWei([], VAULT)).toBe(0n);
+  });
+
+  it.each(['NaN', 'abc', '1e21', 1e21, '-1', null, undefined, {}])(
+    'rejects %p instead of producing an unparseable amount',
+    (value) => {
+      expect(() =>
+        getMellowUserPointsWei(pointsResponse(value), VAULT),
+      ).toThrow();
+    },
+  );
+
+  it('rejects a response that is not a list or has a bad address', () => {
+    expect(() => getMellowUserPointsWei({ vaults: [] }, VAULT)).toThrow();
+    expect(() =>
+      getMellowUserPointsWei(
+        [{ vault_address: '0x12', user_mellow_points: '1' }],
+        VAULT,
+      ),
+    ).toThrow();
+  });
+});
+
+describe('getMellowClaimReward', () => {
+  const reward = {
+    claimable_amount: '3000',
+    claimed_amount: '1000',
+    token: { address: OTHER, decimals: 18, price: 2.5, symbol: 'SSV' },
+    claim_url: 'https://example.com',
+  };
+
+  it('returns the validated reward with a checksummed token address, keeping extra fields', () => {
+    const data = { vaults: [{ vault: VAULT, rewards: [reward] }] };
+    expect(getMellowClaimReward(data, VAULT)).toMatchObject({
+      ...reward,
+      token: { ...reward.token, address: getAddress(OTHER) },
+    });
+  });
+
+  it('returns undefined when the vault has no rewards', () => {
+    const data = { vaults: [{ vault: VAULT, rewards: [] }] };
+    expect(getMellowClaimReward(data, VAULT)).toBeUndefined();
+  });
+
+  it('rejects non-integer amounts', () => {
+    const data = {
+      vaults: [
+        { vault: VAULT, rewards: [{ ...reward, claimable_amount: '1.5' }] },
+      ],
+    };
+    expect(() => getMellowClaimReward(data, VAULT)).toThrow();
+  });
+});

--- a/features/earn/shared/api/mellow-points.ts
+++ b/features/earn/shared/api/mellow-points.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod';
+import { isAddressEqual, type Address } from 'viem';
+
+import {
+  ADDRESS_SCHEMA,
+  BIGINT_STRING_SCHEMA,
+  TOKEN_DECIMALS_SCHEMA,
+  decimalToUnitsSchema,
+} from 'utils/zod';
+
+// Points arrive as decimal strings; converted to wei at 18 decimals right here
+const MELLOW_POINTS_SCHEMA = decimalToUnitsSchema(18);
+
+// Only the fields the widget reads are validated, the rest passes through
+const MELLOW_USER_POINTS_RESPONSE_SCHEMA = z.array(
+  z.looseObject({ vault_address: ADDRESS_SCHEMA }),
+);
+
+export const MELLOW_CLAIM_REWARD_SCHEMA = z.looseObject({
+  claimable_amount: BIGINT_STRING_SCHEMA,
+  claimed_amount: BIGINT_STRING_SCHEMA,
+  token: z.looseObject({
+    address: ADDRESS_SCHEMA,
+    decimals: TOKEN_DECIMALS_SCHEMA,
+    price: z.number().min(0),
+  }),
+});
+
+const MELLOW_CLAIM_RESPONSE_SCHEMA = z.object({
+  vaults: z.array(
+    z.looseObject({ vault: ADDRESS_SCHEMA, rewards: z.array(z.unknown()) }),
+  ),
+});
+
+export type MellowClaimReward = z.infer<typeof MELLOW_CLAIM_REWARD_SCHEMA>;
+
+/**
+ * Validated Mellow points of `vault` for the user, as wei at 18 decimals so
+ * components never parse them. A missing record means a new user with 0 points.
+ */
+export const getMellowUserPointsWei = (data: unknown, vault: Address) => {
+  const record = MELLOW_USER_POINTS_RESPONSE_SCHEMA.parse(data).find((item) =>
+    isAddressEqual(item.vault_address, vault),
+  );
+
+  return record ? MELLOW_POINTS_SCHEMA.parse(record.user_mellow_points) : 0n;
+};
+
+/** First validated claim reward of `vault`; undefined when the user has none. */
+export const getMellowClaimReward = (data: unknown, vault: Address) => {
+  const reward = MELLOW_CLAIM_RESPONSE_SCHEMA.parse(data).vaults.find((item) =>
+    isAddressEqual(item.vault, vault),
+  )?.rewards[0];
+
+  return reward === undefined
+    ? undefined
+    : MELLOW_CLAIM_REWARD_SCHEMA.parse(reward);
+};

--- a/features/earn/shared/hooks/use-vault-apy.ts
+++ b/features/earn/shared/hooks/use-vault-apy.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { STRATEGY_CONSTANT } from 'consts/react-query-strategies';
 
 const APY_STALE_THRESHOLD_MS = 2 * 24 * 60 * 60 * 1000; // 2 days
 
@@ -16,6 +17,7 @@ export const useVaultApy = ({
 }) => {
   const { data, isLoading } = useQuery({
     queryKey: [queryScope, 'apy'],
+    ...STRATEGY_CONSTANT,
     queryFn,
   });
 

--- a/features/earn/shared/v2/vault-allocation/hooks/use-metavault-allocation.ts
+++ b/features/earn/shared/v2/vault-allocation/hooks/use-metavault-allocation.ts
@@ -1,7 +1,7 @@
 import { Address } from 'viem';
 import { useQuery } from '@tanstack/react-query';
 
-import { STRATEGY_LAZY } from 'consts/react-query-strategies';
+import { STRATEGY_CONSTANT } from 'consts/react-query-strategies';
 
 import { fetchMetavaultsAllocationData } from '../apy-data/metavaults-allocation';
 
@@ -10,7 +10,7 @@ export const useMetavaultAllocation = (vaultAddress?: Address) => {
     queryKey: ['metavault-allocation', vaultAddress],
     queryFn: () => fetchMetavaultsAllocationData(vaultAddress),
     enabled: !!vaultAddress,
-    ...STRATEGY_LAZY,
+    ...STRATEGY_CONSTANT,
   });
 
   return { data, isLoading, isError };

--- a/features/earn/shared/v2/vault-chart/hooks/use-staking-chart-data.ts
+++ b/features/earn/shared/v2/vault-chart/hooks/use-staking-chart-data.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { STRATEGY_CONSTANT } from 'consts/react-query-strategies';
 
 import { fetchStakingApyData } from '../apy-data/staking-apy';
 import { STAKING_CHART_QUERY_SCOPE } from '../consts';
@@ -9,6 +10,7 @@ export const useStakingChartData = (
 ) => {
   const result = useQuery({
     queryKey: [STAKING_CHART_QUERY_SCOPE, 'chart-data', fromTimestamp],
+    ...STRATEGY_CONSTANT,
     queryFn: async () => {
       const data = await fetchStakingApyData(fromTimestamp);
       return data;

--- a/features/earn/shared/v2/vault-chart/hooks/use-treasury-chart-data.ts
+++ b/features/earn/shared/v2/vault-chart/hooks/use-treasury-chart-data.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { STRATEGY_CONSTANT } from 'consts/react-query-strategies';
 
 import { fetchTreasuryChartData } from '../apy-data/treasury-apy';
 import { TREASURY_CHART_QUERY_SCOPE } from '../consts';
@@ -9,6 +10,7 @@ export const useTreasuryChartData = (
 ) => {
   const result = useQuery({
     queryKey: [TREASURY_CHART_QUERY_SCOPE, 'chart-data', fromTimestamp],
+    ...STRATEGY_CONSTANT,
     queryFn: async () => {
       const data = await fetchTreasuryChartData(fromTimestamp);
       return data;

--- a/features/earn/shared/v2/vault-chart/hooks/use-vault-chart-data.ts
+++ b/features/earn/shared/v2/vault-chart/hooks/use-vault-chart-data.ts
@@ -5,7 +5,7 @@ import type { Address } from 'viem';
 
 import { unixTimestampToMs } from 'utils/unix-timestamp-to-ms';
 import { useEthUsd } from 'shared/hooks/use-eth-usd';
-import { STRATEGY_LAZY } from 'consts/react-query-strategies';
+import { STRATEGY_CONSTANT } from 'consts/react-query-strategies';
 import { useEthVaultStats } from 'features/earn/vault-eth/hooks/use-vault-stats';
 import { useUsdVaultStats } from 'features/earn/vault-usd/hooks/use-vault-stats';
 
@@ -44,7 +44,7 @@ export const useMetavaultChartData = ({
       vaultAddress,
       fromTimestamp,
     ],
-    ...STRATEGY_LAZY,
+    ...STRATEGY_CONSTANT,
     queryFn: async () => {
       if (!vaultAddress) return null;
 

--- a/features/earn/vault-dvv/components/dvv-position/dvv-position.tsx
+++ b/features/earn/vault-dvv/components/dvv-position/dvv-position.tsx
@@ -1,4 +1,3 @@
-import { parseEther } from 'viem';
 import { useDappStatus } from 'modules/web3';
 
 import { VaultPosition } from '../../../shared/vault-position';
@@ -79,8 +78,6 @@ export const DVVPosition = () => {
 
   if (!isDappActive || !address) return null;
 
-  // convert mellow points to the wei at 18 decimals for easier compatibility with components
-  const mellowPointsBalance = parseEther(data?.mellowPoints.toFixed(4) ?? '0');
   return (
     <VaultPosition
       position={{
@@ -128,7 +125,7 @@ export const DVVPosition = () => {
       points={[
         {
           symbol: MELLOW_POINT_SYMBOL,
-          balance: mellowPointsBalance,
+          balance: data?.mellowPoints,
           usdAmount: null,
           isLoading: isLoadingPoints,
           icon: <TokenMellowIcon />,

--- a/features/earn/vault-dvv/hooks/use-dvv-points.ts
+++ b/features/earn/vault-dvv/hooks/use-dvv-points.ts
@@ -1,51 +1,19 @@
 import invariant from 'tiny-invariant';
-import { isAddressEqual, type Address } from 'viem';
 import { useQuery } from '@tanstack/react-query';
 
 import { getContractAddress } from 'config/networks/contract-address';
 import { CHAINS } from 'consts/chains';
 import { useDappStatus } from 'modules/web3';
 import { bnAmountToNumber, maxBN } from 'utils/bn';
+import { standardFetcher } from 'utils/standardFetcher';
+import {
+  getMellowClaimReward,
+  getMellowUserPointsWei,
+  type MellowClaimReward,
+} from 'features/earn/shared/api/mellow-points';
 import { DVV_STATS_ORIGIN } from '../consts';
 
-type UserPointsResponse = {
-  user_address: Address;
-  user_referal_points: string;
-  user_vault_balance: number;
-  timestamp: number;
-  vault_address: Address;
-  user_mellow_points: string;
-  user_symbiotic_points: string;
-  user_merits_points: string;
-}[];
-
-type UserClaimPointsResponse = {
-  vaults: {
-    chain_id: number;
-    vault: Address;
-    rewards: [
-      {
-        chain_id: number;
-        token: {
-          chain_id: number;
-          symbol: string;
-          address: Address;
-          decimals: number;
-          price: number;
-        };
-        claimable_amount: string;
-        claimed_amount: string;
-        claim_contract_address: string;
-        claim_index: number;
-        claim_url: string;
-      },
-    ];
-  }[];
-};
-
-const transformPoints = (
-  reward?: UserClaimPointsResponse['vaults'][number]['rewards'][number],
-) => {
+const transformPoints = (reward?: MellowClaimReward) => {
   const claimable = maxBN(
     BigInt(reward?.claimable_amount ?? 0) - BigInt(reward?.claimed_amount ?? 0),
     0n,
@@ -78,31 +46,17 @@ export const useDVVPoints = () => {
       const ssvUrl = `${mellowBaseUrl}/${address}/ssv`;
 
       const [userPointsRes, obolRes, ssvRes] = await Promise.all([
-        fetch(userPointsUrl)
-          .then((res) => res.json() as Promise<UserPointsResponse>)
-          .then((data) =>
-            data.find((vault) => isAddressEqual(vault.vault_address, dvvVault)),
-          ),
-        fetch(obolUrl)
-          .then((res) => res.json() as Promise<UserClaimPointsResponse>)
-          .then(
-            (data) =>
-              data.vaults.find((vault) => isAddressEqual(vault.vault, dvvVault))
-                ?.rewards[0],
-          ),
-        fetch(ssvUrl)
-          .then((res) => res.json() as Promise<UserClaimPointsResponse>)
-          .then(
-            (data) =>
-              data.vaults.find((vault) => isAddressEqual(vault.vault, dvvVault))
-                ?.rewards[0],
-          ),
+        standardFetcher<unknown>(userPointsUrl),
+        standardFetcher<unknown>(obolUrl),
+        standardFetcher<unknown>(ssvUrl),
       ]);
 
+      // Validate here so a malformed response becomes a query error, not a
+      // render-time throw that takes the whole route down
       return {
-        mellowPoints: Number(userPointsRes?.user_mellow_points ?? 0),
-        obol: transformPoints(obolRes),
-        ssv: transformPoints(ssvRes),
+        mellowPoints: getMellowUserPointsWei(userPointsRes, dvvVault),
+        obol: transformPoints(getMellowClaimReward(obolRes, dvvVault)),
+        ssv: transformPoints(getMellowClaimReward(ssvRes, dvvVault)),
       };
     },
   });

--- a/features/earn/vault-dvv/hooks/use-dvv-stats.ts
+++ b/features/earn/vault-dvv/hooks/use-dvv-stats.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { type Address, getContract } from 'viem';
 import { useQuery } from '@tanstack/react-query';
+import { STRATEGY_CONSTANT } from 'consts/react-query-strategies';
 import { LidoSDKWrap } from '@lidofinance/lido-ethereum-sdk/wrap';
 
 import { CONTRACT_NAMES } from 'config/networks/networks-map';
@@ -19,6 +20,7 @@ const useDVVTvl = () => {
 
   return useQuery({
     queryKey: ['dvv', 'stats', 'tvl'],
+    ...STRATEGY_CONSTANT,
     queryFn: async () => {
       const vault = getDVVVaultContract(publicClientMainnet);
 
@@ -116,6 +118,7 @@ export type MellowAPIResponse = {
 export const useDVVApr = () => {
   return useQuery({
     queryKey: ['dvv', 'stats', 'apr'],
+    ...STRATEGY_CONSTANT,
     queryFn: async () => {
       return fetchDVVStatsAprBreakdown();
     },

--- a/features/earn/vault-eth/upgrade-assets/upgrade-assets.tsx
+++ b/features/earn/vault-eth/upgrade-assets/upgrade-assets.tsx
@@ -27,6 +27,7 @@ import {
   ETH_VAULT_QUERY_SCOPE,
 } from '../consts';
 import { useEthVaultDrawer } from '../drawer-context';
+import { useEthVaultAvailable } from '../hooks/use-vault-available';
 import { useEthVaultDeposit } from '../deposit/hooks';
 import { EthDepositTokenUpgradable } from '../types';
 
@@ -60,6 +61,7 @@ export const UpgradeAssetsBlock: FC = () => {
   const [isUpgrading, setIsUpgrading] = useState(false);
   const referral = useReferralQueryValue();
   const { isDepositGeoAvailable } = useEarnGeoGate();
+  const { isDepositEnabled } = useEthVaultAvailable();
   const { openDrawer: openDrawerRight } = useEthVaultDrawer();
 
   const { deposit } = useEthVaultDeposit();
@@ -110,7 +112,10 @@ export const UpgradeAssetsBlock: FC = () => {
     [deposit, queryClient, referral, refetchBalances],
   );
 
-  if (!isWalletConnected || !isDepositGeoAvailable) return null;
+  // An upgrade is a deposit: hide the block when deposits are paused, even if
+  // balances are still cached from before the pause
+  if (!isWalletConnected || !isDepositGeoAvailable || !isDepositEnabled)
+    return null;
 
   const tokensWithBalance = ETH_VAULT_DEPOSIT_TOKENS_UPGRADABLE.filter(
     (token) => {

--- a/features/earn/vault-ggv/allocation/hooks/use-ggv-allocation.ts
+++ b/features/earn/vault-ggv/allocation/hooks/use-ggv-allocation.ts
@@ -1,5 +1,6 @@
 import { type Address, getContract } from 'viem';
 import { useQuery } from '@tanstack/react-query';
+import { STRATEGY_CONSTANT } from 'consts/react-query-strategies';
 
 import { AggregatorAbi } from 'abi/aggregator-abi';
 import { CONTRACT_NAMES } from 'config/networks/networks-map';
@@ -18,6 +19,7 @@ export const useGGVAllocation = () => {
 
   const allocation = useQuery({
     queryKey: ['ggv', 'stats', 'allocation'],
+    ...STRATEGY_CONSTANT,
     queryFn: async () => {
       const vault = getGGVVaultContract(publicClientMainnet);
       const contract = getContract({

--- a/features/earn/vault-ggv/hooks/use-ggv-stats.ts
+++ b/features/earn/vault-ggv/hooks/use-ggv-stats.ts
@@ -9,6 +9,7 @@ import { useConfig } from 'config';
 import { useMainnetOnlyWagmi } from 'modules/web3';
 
 import { useQuery } from '@tanstack/react-query';
+import { STRATEGY_CONSTANT } from 'consts/react-query-strategies';
 import {
   getGGVAccountantContract,
   getGGVLensContract,
@@ -21,6 +22,7 @@ const useGGVTvl = () => {
 
   return useQuery({
     queryKey: ['ggv', 'stats', 'tvl'],
+    ...STRATEGY_CONSTANT,
     queryFn: async () => {
       const lens = getGGVLensContract(publicClientMainnet);
       const vault = getGGVVaultContract(publicClientMainnet);
@@ -65,6 +67,7 @@ export const useGGVApy = () => {
 
   return useQuery({
     queryKey: ['ggv', 'stats', 'apy', ggvAPYType],
+    ...STRATEGY_CONSTANT,
     queryFn: async () => {
       const lens = getGGVLensContract(publicClientMainnet);
       const vault = getGGVVaultContract(publicClientMainnet);

--- a/features/earn/vault-ggv/utils.ts
+++ b/features/earn/vault-ggv/utils.ts
@@ -1,23 +1,52 @@
 import { type Address } from 'viem';
 import { bnAmountToNumber } from 'utils/bn';
 import { GGV_INCENTIVES, GGV_START_DATE, GGV_STATS_ORIGIN } from './consts';
+import { z } from 'zod';
 import { standardFetcher } from 'utils/standardFetcher';
+import { DECIMAL_STRING_SCHEMA } from 'utils/zod';
 import { ManifestConfigVaultApyType } from 'config/external-config';
 
-export type SevenSeasAPIDailyResponseItem = {
-  block_number: number;
-  daily_apy: number;
-  price_usd: string;
-  share_price: number;
-  timestamp: string;
-  total_assets: string;
-  tvl: string;
-  unix_seconds: number;
-  vault_address: Address;
-};
-type SevenSeasAPIDailyResponse = {
-  Response: SevenSeasAPIDailyResponseItem[];
-};
+// Only the fields the widget reads are validated, the rest passes through
+const SEVEN_SEAS_DAILY_ITEM_SCHEMA = z.looseObject({
+  daily_apy: z.number(),
+  timestamp: z.string(),
+  unix_seconds: z.number(),
+  total_assets: DECIMAL_STRING_SCHEMA,
+});
+
+const SEVEN_SEAS_DAILY_RESPONSE_SCHEMA = z.object({
+  Response: z.array(SEVEN_SEAS_DAILY_ITEM_SCHEMA),
+});
+
+const SEVEN_SEAS_PERFORMANCE_RESPONSE_SCHEMA = z.object({
+  Response: z.looseObject({
+    apy: z.number(),
+    timestamp: z.string(),
+    real_apy_breakdown: z.array(
+      z.looseObject({
+        allocation: z.number(),
+        apy: z.number(),
+        chain: z.string(),
+        protocol: z.string(),
+      }),
+    ),
+  }),
+});
+
+export type SevenSeasAPIDailyResponseItem = z.infer<
+  typeof SEVEN_SEAS_DAILY_ITEM_SCHEMA
+>;
+export type SevenSeasAPIPerformanceResponse = z.infer<
+  typeof SEVEN_SEAS_PERFORMANCE_RESPONSE_SCHEMA
+>;
+
+const fetchDailyData = async (url: string) =>
+  SEVEN_SEAS_DAILY_RESPONSE_SCHEMA.parse(await standardFetcher<unknown>(url));
+
+const fetchPerformance = async (url: string) =>
+  SEVEN_SEAS_PERFORMANCE_RESPONSE_SCHEMA.parse(
+    await standardFetcher<unknown>(url),
+  );
 
 const WEEK_SECONDS = 7 * 24 * 60 * 60;
 
@@ -25,7 +54,7 @@ export const fetchDailyGGVApy = async (vault: Address) => {
   const weekAgo = Math.floor(new Date().getTime() / 1000 - WEEK_SECONDS);
   const url = `${GGV_STATS_ORIGIN}/dailyData/ethereum/${vault}/${weekAgo}/latest`;
 
-  const data = await standardFetcher<SevenSeasAPIDailyResponse>(url);
+  const data = await fetchDailyData(url);
   const latestApy = data.Response[0];
 
   if (!latestApy) {
@@ -40,30 +69,10 @@ export const fetchDailyGGVApy = async (vault: Address) => {
   return { daily: latestApy.daily_apy, average: averageApy };
 };
 
-export type SevenSeasAPIPerformanceResponse = {
-  Response: {
-    apy: number;
-    fees: number;
-    global_apy_breakdown: {
-      fee: number;
-      maturity_apy: number;
-      real_apy: number;
-    };
-    maturity_apy_breakdown: unknown[];
-    real_apy_breakdown: {
-      allocation: number;
-      apy: number;
-      chain: string;
-      protocol: string;
-    }[];
-    timestamp: string;
-  };
-};
-
 export const fetchWeeklyGGVApy = async (vault: Address) => {
   const url = `${GGV_STATS_ORIGIN}/performance/ethereum/${vault}?aggregation_period=7`;
 
-  const data = await standardFetcher<SevenSeasAPIPerformanceResponse>(url);
+  const data = await fetchPerformance(url);
 
   return data.Response.apy * 100;
 };
@@ -71,7 +80,7 @@ export const fetchWeeklyGGVApy = async (vault: Address) => {
 export const fetchGGVPerformance = async (vault: Address) => {
   const url = `${GGV_STATS_ORIGIN}/performance/ethereum/${vault}`;
 
-  const data = await standardFetcher<SevenSeasAPIPerformanceResponse>(url);
+  const data = await fetchPerformance(url);
 
   return data;
 };
@@ -80,7 +89,7 @@ export const fetchDailyGGVChainData = async (vault: Address) => {
   const last3DaysTimestamp = Math.floor(Date.now() / 1000) - 86400 * 3;
   const url = `${GGV_STATS_ORIGIN}/dailyData/all/${vault}/${last3DaysTimestamp}/latest`;
 
-  const data = await standardFetcher<SevenSeasAPIDailyResponse>(url);
+  const data = await fetchDailyData(url);
   const latestData = data.Response;
 
   return latestData;

--- a/features/earn/vault-ggv/withdraw/hooks/use-ggv-withdrawal-requests.ts
+++ b/features/earn/vault-ggv/withdraw/hooks/use-ggv-withdrawal-requests.ts
@@ -1,18 +1,13 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import {
-  Address,
-  encodeAbiParameters,
-  Hash,
-  isAddressEqual,
-  keccak256,
-} from 'viem';
+import { Address, encodeAbiParameters, isAddressEqual, keccak256 } from 'viem';
 import { useQuery } from '@tanstack/react-query';
 import { useDappStatus, useMainnetOnlyWagmi } from 'modules/web3';
 
 import { getGGVQueueContract, getGGVVaultContract } from '../../contracts';
 import { getTokenAddress } from 'config/networks/token-address';
 
-import type { WQApiResponse } from '../types';
+import { WQ_API_RESPONSE_SCHEMA, type WQApiResponse } from '../types';
+import { standardFetcher } from 'utils/standardFetcher';
 import { GGV_STATS_ORIGIN } from '../../consts';
 
 export type GGVWithdrawalRequestsResponse = ReturnType<
@@ -54,16 +49,16 @@ const transformAPIResponse = (response: WQApiResponse) => {
     ...request,
     amount: BigInt(request.amount),
     blockNumber: BigInt(request.blockNumber),
-    offerToken: request.offerToken as Address,
+    offerToken: request.offerToken,
     timestamp: BigInt(request.timestamp),
-    transaction_hash: request.transaction_hash as Hash,
-    user: request.user as Address,
-    wantToken: request.wantToken as Address,
+    transaction_hash: request.transaction_hash,
+    user: request.user,
+    wantToken: request.wantToken,
     wantTokenDecimals: BigInt(request.wantTokenDecimals),
     metadata: {
       nonce: BigInt(request.metadata.nonce),
-      user: request.metadata.user as Address,
-      assetOut: request.metadata.assetOut as Address,
+      user: request.metadata.user,
+      assetOut: request.metadata.assetOut,
       amountOfAssets: BigInt(request.metadata.amountOfAssets),
       amountOfShares: BigInt(request.metadata.amountOfShares),
       creationTime: Number(request.metadata.creationTime),
@@ -80,7 +75,7 @@ const transformAPIResponse = (response: WQApiResponse) => {
         fulfillment: {
           block_number: BigInt(Fulfillment.block_number),
           timestamp: BigInt(Fulfillment.timestamp),
-          transaction_hash: Fulfillment.transaction_hash as Hash,
+          transaction_hash: Fulfillment.transaction_hash,
         },
       }))
       .sort(
@@ -92,7 +87,7 @@ const transformAPIResponse = (response: WQApiResponse) => {
         cancellation: {
           block_number: BigInt(Cancellation.block_number),
           timestamp: BigInt(Cancellation.timestamp),
-          transaction_hash: Cancellation.transaction_hash as Hash,
+          transaction_hash: Cancellation.transaction_hash,
         },
         request: transformRequest(Request),
       }),
@@ -124,8 +119,8 @@ export const useGGVWithdrawalRequests = () => {
 
       const url = `${GGV_STATS_ORIGIN}/boringQueue/ethereum/${vault.address}/${address}?string_values=true`;
 
-      const response: WQApiResponse = await fetch(url).then((res) =>
-        res.json(),
+      const response = WQ_API_RESPONSE_SCHEMA.parse(
+        await standardFetcher<unknown>(url),
       );
 
       const requests = transformAPIResponse(response);

--- a/features/earn/vault-ggv/withdraw/types.ts
+++ b/features/earn/vault-ggv/withdraw/types.ts
@@ -1,60 +1,56 @@
+import { z } from 'zod';
 import type { GGVWithdrawalRequestsResponse } from './hooks/use-ggv-withdrawal-requests';
+import { ADDRESS_SCHEMA, BIGINT_STRING_SCHEMA, HASH_SCHEMA } from 'utils/zod';
 
 export type { GGVWithdrawalRequestsResponse } from './hooks/use-ggv-withdrawal-requests';
 
 export type GGVWithdrawalRequest =
   GGVWithdrawalRequestsResponse['openRequests'][number];
 
-type Cancellation = {
-  block_number: string;
-  timestamp: string;
-  transaction_hash: string;
-};
+// SevenSeas boring queue API. Numeric strings go through BigInt/Number in the
+// hook, addresses through isAddressEqual — validate them before they get there
+const QUEUE_EVENT_SCHEMA = z.object({
+  block_number: BIGINT_STRING_SCHEMA,
+  timestamp: BIGINT_STRING_SCHEMA,
+  transaction_hash: HASH_SCHEMA,
+});
 
-type Fulfillment = {
-  block_number: string;
-  timestamp: string;
-  transaction_hash: string;
-};
+const REQUEST_SCHEMA = z.looseObject({
+  amount: BIGINT_STRING_SCHEMA,
+  blockNumber: BIGINT_STRING_SCHEMA,
+  offerToken: ADDRESS_SCHEMA,
+  timestamp: BIGINT_STRING_SCHEMA,
+  transaction_hash: HASH_SCHEMA,
+  user: ADDRESS_SCHEMA,
+  wantToken: ADDRESS_SCHEMA,
+  wantTokenDecimals: BIGINT_STRING_SCHEMA,
+  wantTokenSymbol: z.string(),
+  metadata: z.looseObject({
+    amountOfAssets: BIGINT_STRING_SCHEMA,
+    amountOfShares: BIGINT_STRING_SCHEMA,
+    assetOut: ADDRESS_SCHEMA,
+    creationTime: BIGINT_STRING_SCHEMA,
+    nonce: BIGINT_STRING_SCHEMA,
+    secondsToDeadline: BIGINT_STRING_SCHEMA,
+    secondsToMaturity: BIGINT_STRING_SCHEMA,
+    user: ADDRESS_SCHEMA,
+  }),
+});
 
-type RequestMetadata = {
-  amountOfAssets: string;
-  amountOfShares: string;
-  assetOut: string;
-  creationTime: string;
-  nonce: string;
-  secondsToDeadline: string;
-  secondsToMaturity: string;
-  user: string;
-};
+export const WQ_API_RESPONSE_SCHEMA = z.object({
+  Response: z.object({
+    cancelled_requests: z.array(
+      z.object({ Cancellation: QUEUE_EVENT_SCHEMA, Request: REQUEST_SCHEMA }),
+    ),
+    expired_requests: z.array(REQUEST_SCHEMA),
+    fulfilled_requests: z.array(
+      z.object({ Fulfillment: QUEUE_EVENT_SCHEMA, Request: REQUEST_SCHEMA }),
+    ),
+    open_requests: z.array(REQUEST_SCHEMA),
+  }),
+});
 
-type Request = {
-  amount: string;
-  blockNumber: string;
-  metadata: RequestMetadata;
-  offerToken: string;
-  timestamp: string;
-  transaction_hash: string;
-  user: string;
-  wantToken: string;
-  wantTokenDecimals: string;
-  wantTokenSymbol: string;
-};
-
-export type WQApiResponse = {
-  Response: {
-    cancelled_requests: {
-      Cancellation: Cancellation;
-      Request: Request;
-    }[];
-    expired_requests: Request[];
-    fulfilled_requests: {
-      Fulfillment: Fulfillment;
-      Request: Request;
-    }[];
-    open_requests: Request[];
-  };
-};
+export type WQApiResponse = z.infer<typeof WQ_API_RESPONSE_SCHEMA>;
 
 export type GGVWithdrawalFormValues = {
   amount: bigint | null;

--- a/features/earn/vault-stg/components/stg-position/stg-position.tsx
+++ b/features/earn/vault-stg/components/stg-position/stg-position.tsx
@@ -1,4 +1,3 @@
-import { parseEther } from 'viem';
 import { TokenStrethIcon, TokenMellowIcon } from 'assets/earn';
 import { VaultPosition } from 'features/earn/shared/vault-position';
 import { STG_TOKEN_SYMBOL, MELLOW_POINT_SYMBOL } from '../../consts';
@@ -23,15 +22,6 @@ export const STGPosition = () => {
     usdQuery: { isLoading: isLoadingUsd } = { isLoading: false },
   } = useSTGPosition();
 
-  // convert mellow points to the wei at 18 decimals for easier compatibility with components
-  const mellowPointsBalance =
-    mellowPoints && Number.isFinite(mellowPoints)
-      ? parseEther(mellowPoints.toFixed(4))
-      : // temp solution for the problem that the new users will get undefined points balance from API
-        // TODO: find solution how to distinguish between new users and broken data from API
-        // set this to undefined after fixing the issue
-        0n;
-
   return (
     <VaultPosition
       position={{
@@ -45,7 +35,7 @@ export const STGPosition = () => {
       points={[
         {
           symbol: MELLOW_POINT_SYMBOL,
-          balance: mellowPointsBalance,
+          balance: mellowPoints,
           usdAmount: null,
           isLoading: isLoading,
           icon: <TokenMellowIcon />,

--- a/features/earn/vault-stg/hooks/use-stg-apy.ts
+++ b/features/earn/vault-stg/hooks/use-stg-apy.ts
@@ -1,9 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
+import { STRATEGY_CONSTANT } from 'consts/react-query-strategies';
 import { fetchSTGStatsApr } from '../utils';
 
 export const useSTGApy = () => {
   const { data, isLoading } = useQuery({
     queryKey: ['stg', 'apy'],
+    ...STRATEGY_CONSTANT,
     queryFn: fetchSTGStatsApr,
   });
 

--- a/features/earn/vault-stg/hooks/use-stg-position.ts
+++ b/features/earn/vault-stg/hooks/use-stg-position.ts
@@ -1,4 +1,3 @@
-import { isAddressEqual, type Address } from 'viem';
 import { useQuery } from '@tanstack/react-query';
 import invariant from 'tiny-invariant';
 
@@ -9,18 +8,8 @@ import { standardFetcher } from 'utils/standardFetcher';
 import { getSTGShareManagerSTRETH } from '../contracts';
 import { getWithdrawalParams } from '../withdraw/utils';
 import { useWstethUsd } from 'shared/hooks/use-wsteth-usd';
+import { getMellowUserPointsWei } from 'features/earn/shared/api/mellow-points';
 import { STG_STATS_ORIGIN } from '../consts';
-
-type UserPointsResponse = {
-  user_address: Address;
-  user_referal_points: string;
-  user_vault_balance: number;
-  timestamp: number;
-  vault_address: Address;
-  user_mellow_points: string;
-  user_symbiotic_points: string;
-  user_merits_points: string;
-}[];
 
 export const useSTGPosition = () => {
   const { address, isDappActive } = useDappStatus();
@@ -54,17 +43,12 @@ export const useSTGPosition = () => {
     queryKey: ['stg', 'mellow-points', { address }] as const,
     enabled: isEnabled,
     queryFn: async () => {
-      // TODO: add zod validation
-      const mellowBaseUrl = `${STG_STATS_ORIGIN}/v1/chain/1/users`;
-      const userPointsUrl = `${mellowBaseUrl}/${address}`;
-
-      const userPointsData =
-        await standardFetcher<UserPointsResponse>(userPointsUrl);
-      const pointsForVault = userPointsData.find((vault) =>
-        isAddressEqual(vault.vault_address, stgVaultAddress),
+      const userPointsUrl = `${STG_STATS_ORIGIN}/v1/chain/1/users/${address}`;
+      // validated and converted to wei here, so components never parse it
+      return getMellowUserPointsWei(
+        await standardFetcher<unknown>(userPointsUrl),
+        stgVaultAddress,
       );
-
-      return pointsForVault ?? null;
     },
   });
 
@@ -89,9 +73,7 @@ export const useSTGPosition = () => {
 
   const data = isEnabled ? strethBalanceQuery.data : undefined;
   const wsteth = strethToWstethQuery.data;
-  const mellowPoints = mellowPointsBalanceQuery.data?.user_mellow_points
-    ? Number(mellowPointsBalanceQuery.data.user_mellow_points)
-    : undefined;
+  const mellowPoints = mellowPointsBalanceQuery.data;
 
   const { usdAmount, ...usdQuery } = useWstethUsd(
     wsteth,

--- a/features/earn/vault-stg/hooks/use-stg-stats.ts
+++ b/features/earn/vault-stg/hooks/use-stg-stats.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { STRATEGY_CONSTANT } from 'consts/react-query-strategies';
 import { useEthUsd } from 'shared/hooks/use-eth-usd';
 import { UNIX_TIMESTAMP_SCHEMA } from 'utils/zod';
 import { useSTGCollect } from './use-stg-collect';
@@ -16,6 +17,7 @@ type STGStatsData = {
 export const useSTGStats = () => {
   const { data, isLoading } = useQuery<STGStatsData>({
     queryKey: ['stg', 'stats'],
+    ...STRATEGY_CONSTANT,
     queryFn: async () => {
       const fetchedData = await fetchSTGStats();
       const allocations = ALLOCATION_SCHEMA.parse(fetchedData.allocations);

--- a/features/rewards/fetchers/backend.test.ts
+++ b/features/rewards/fetchers/backend.test.ts
@@ -1,0 +1,58 @@
+import { BACKEND_SCHEMA } from './backend';
+
+const validResponse = {
+  events: [
+    {
+      type: 'reward',
+      change: '1000',
+      balance: '2000',
+      blockTime: '1700000000',
+      transactionHash: '0xabc',
+      apr: '3.1',
+    },
+  ],
+  totals: { ethRewards: '123456789', currencyRewards: '12.34' },
+  averageApr: '3.1',
+  ethToStEthRatio: 1,
+  stETHCurrencyPrice: { eth: 1, usd: 3000 },
+  totalItems: 1,
+};
+
+// The deployed /api/rewards contract (test/consts.ts) serializes both totals
+// as strings; rejecting them would break the dashboard and the CSV export
+describe('BACKEND_SCHEMA', () => {
+  it('accepts string totals and converts them to numbers', () => {
+    const parsed = BACKEND_SCHEMA.parse(validResponse);
+    expect(parsed.totals).toEqual({
+      ethRewards: 123456789,
+      currencyRewards: 12.34,
+    });
+  });
+
+  it('still accepts numeric totals', () => {
+    const parsed = BACKEND_SCHEMA.parse({
+      ...validResponse,
+      totals: { ethRewards: 5, currencyRewards: 0 },
+    });
+    expect(parsed.totals).toEqual({ ethRewards: 5, currencyRewards: 0 });
+  });
+
+  it('keeps extra event fields', () => {
+    const parsed = BACKEND_SCHEMA.parse(validResponse);
+    expect(parsed.events[0]).toMatchObject({ apr: '3.1' });
+  });
+
+  it('rejects non-numeric totals', () => {
+    expect(() =>
+      BACKEND_SCHEMA.parse({
+        ...validResponse,
+        totals: { ethRewards: 'abc', currencyRewards: '1' },
+      }),
+    ).toThrow();
+  });
+
+  it('rejects a response with missing totals', () => {
+    const { totals: _, ...noTotals } = validResponse;
+    expect(() => BACKEND_SCHEMA.parse(noTotals)).toThrow();
+  });
+});

--- a/features/rewards/fetchers/backend.ts
+++ b/features/rewards/fetchers/backend.ts
@@ -1,4 +1,6 @@
 import { config } from 'config';
+import { z } from 'zod';
+import type { Backend } from 'features/rewards/types';
 
 export type BackendQuery = {
   address: string;
@@ -8,6 +10,25 @@ export type BackendQuery = {
   archiveRate?: boolean;
   onlyRewards?: boolean;
 };
+
+// Validates the shape the table relies on; event rows carry many optional
+// fields that pass through untouched
+export const BACKEND_SCHEMA = z.object({
+  events: z.array(
+    z.looseObject({
+      type: z.string(),
+      change: z.string(),
+      balance: z.string(),
+      blockTime: z.string(),
+      transactionHash: z.string(),
+    }),
+  ),
+  totals: z.object({ ethRewards: z.number(), currencyRewards: z.number() }),
+  averageApr: z.string(),
+  ethToStEthRatio: z.number(),
+  stETHCurrencyPrice: z.record(z.string(), z.number()),
+  totalItems: z.number(),
+});
 
 export const backendRequest = async (query: BackendQuery) => {
   const params = new URLSearchParams();
@@ -28,5 +49,5 @@ export const backendRequest = async (query: BackendQuery) => {
     throw new Error(responded?.message ?? requested.statusText);
   }
 
-  return await requested.json();
+  return BACKEND_SCHEMA.parse(await requested.json()) as Backend;
 };

--- a/features/rewards/fetchers/backend.ts
+++ b/features/rewards/fetchers/backend.ts
@@ -1,6 +1,7 @@
 import { config } from 'config';
 import { z } from 'zod';
 import type { Backend } from 'features/rewards/types';
+import { NUMERIC_SCHEMA } from 'utils/zod';
 
 export type BackendQuery = {
   address: string;
@@ -23,7 +24,11 @@ export const BACKEND_SCHEMA = z.object({
       transactionHash: z.string(),
     }),
   ),
-  totals: z.object({ ethRewards: z.number(), currencyRewards: z.number() }),
+  // The backend serializes both totals as numeric strings
+  totals: z.object({
+    ethRewards: NUMERIC_SCHEMA,
+    currencyRewards: NUMERIC_SCHEMA,
+  }),
   averageApr: z.string(),
   ethToStEthRatio: z.number(),
   stETHCurrencyPrice: z.record(z.string(), z.number()),

--- a/features/rewards/hooks/useRewardsDataLoad.ts
+++ b/features/rewards/hooks/useRewardsDataLoad.ts
@@ -4,6 +4,7 @@ import { STRATEGY_LAZY } from 'consts/react-query-strategies';
 import { Backend } from 'features/rewards/types';
 
 import { standardFetcher } from 'utils/standardFetcher';
+import { BACKEND_SCHEMA } from 'features/rewards/fetchers/backend';
 import { useLaggyDataWrapper } from './use-laggy-data-wrapper';
 
 type UseRewardsDataLoad = (props: {
@@ -58,11 +59,13 @@ export const useRewardsDataLoad: UseRewardsDataLoad = (props) => {
     queryKey: ['rewards-data', address, apiRewardsUrl],
     enabled: !!address && !featureFlags.rewardsMaintenance,
     ...STRATEGY_LAZY,
-    queryFn: ({ signal }) =>
+    queryFn: async ({ signal }) =>
       // The 'react-query' has AbortController support built in,
       // and it automatically cancels requests when
       // the component is unmounted or the queryKey changes.
-      standardFetcher(apiRewardsUrl, { signal }),
+      BACKEND_SCHEMA.parse(
+        await standardFetcher<unknown>(apiRewardsUrl, { signal }),
+      ) as Backend,
   });
 
   const { isLagging, dataOrLaggyData } = useLaggyDataWrapper(data);

--- a/features/settings/settings-form/settings-form.tsx
+++ b/features/settings/settings-form/settings-form.tsx
@@ -1,13 +1,17 @@
 import { useCallback } from 'react';
 import { useForm } from 'react-hook-form';
 
-import { LIDO_CONTRACT_NAMES } from '@lidofinance/lido-ethereum-sdk/common';
 import { Button, ToastSuccess, Block, Input } from '@lidofinance/lido-ui';
 
+import type { CHAINS } from 'consts/chains';
 import { useUserConfig } from 'config/user-config';
+import { wagmiChainMap } from 'modules/web3/consts/chains';
 import { LinkArrow } from 'shared/components/link-arrow/link-arrow';
-import { useContractAddress } from 'modules/web3';
-import { RPCErrorType, checkRpcUrl } from 'utils/check-rpc-url';
+import {
+  RPCErrorType,
+  checkRpcUrl,
+  getRpcCheckAddress,
+} from 'utils/check-rpc-url';
 
 import {
   Actions,
@@ -15,59 +19,53 @@ import {
   DescriptionTitle,
   SettingsFormWrap,
 } from './styles';
-import { useDappStatus } from 'modules/web3';
 
 type FormValues = {
   rpcUrl: string;
 };
 
-export const SettingsForm = () => {
-  const { savedUserConfig, setSavedUserConfig } = useUserConfig();
-  const { chainId } = useDappStatus();
+// One form per chain: every supported chain keeps its own custom RPC, and a
+// user on an L2 can replace the L2 endpoint the wrap form actually uses
+const RpcUrlForm = ({ chainId }: { chainId: CHAINS }) => {
+  const { savedUserConfig, setRpcUrl } = useUserConfig();
+  const chainName = wagmiChainMap[chainId]?.name ?? `chain ${chainId}`;
 
   const formMethods = useForm<FormValues>({
     mode: 'onChange',
     reValidateMode: 'onChange',
-    defaultValues: {
-      rpcUrl: (savedUserConfig.rpcUrls as Record<typeof chainId, string>)[
-        chainId
-      ],
-    },
+    defaultValues: { rpcUrl: savedUserConfig.rpcUrls[chainId] ?? '' },
   });
-
-  const { data: stethAddress } = useContractAddress(LIDO_CONTRACT_NAMES.lido);
 
   const {
     formState,
     setValue,
-    getValues,
     formState: { errors },
     clearErrors,
   } = formMethods;
 
-  const saveSettings = useCallback(
-    (formValues: FormValues) => {
-      setSavedUserConfig({
-        rpcUrls: {
-          [chainId]: formValues.rpcUrl,
-        },
-      });
+  const handleSubmit = useCallback(
+    ({ rpcUrl }: FormValues) => {
+      setRpcUrl(chainId, rpcUrl);
+      ToastSuccess(`${chainName} RPC has been saved`);
     },
-    [chainId, setSavedUserConfig],
+    [chainId, chainName, setRpcUrl],
   );
 
-  const handleSubmit = useCallback(
-    (formValues: FormValues) => {
-      saveSettings(formValues);
-      ToastSuccess('Settings have been saved');
-    },
-    [saveSettings],
-  );
+  const handleReset = useCallback(() => {
+    setValue('rpcUrl', '');
+    clearErrors();
+    setRpcUrl(chainId);
+    ToastSuccess(`${chainName} RPC has been reset`);
+  }, [chainId, chainName, clearErrors, setRpcUrl, setValue]);
 
   const validateRpcUrl = useCallback(
     async (rpcUrl: string) => {
       if (!rpcUrl) return true;
-      const rpcCheckResult = await checkRpcUrl(rpcUrl, chainId, stethAddress);
+      const rpcCheckResult = await checkRpcUrl(
+        rpcUrl,
+        chainId,
+        getRpcCheckAddress(chainId),
+      );
       switch (rpcCheckResult) {
         case true:
           return true;
@@ -79,45 +77,48 @@ export const SettingsForm = () => {
           return 'Url is working, but network does not match';
       }
     },
-    [chainId, stethAddress],
+    [chainId],
   );
 
-  const handleReset = useCallback(() => {
-    setValue('rpcUrl', '');
-    saveSettings(getValues());
-    clearErrors();
-    ToastSuccess('Settings have been reset');
-  }, [clearErrors, setValue, saveSettings, getValues]);
+  return (
+    <Block>
+      <form onSubmit={formMethods.handleSubmit(handleSubmit)}>
+        <Input
+          fullwidth
+          label={`${chainName} RPC URL`}
+          error={errors?.rpcUrl?.message}
+          {...formMethods.register('rpcUrl', {
+            required: true,
+            validate: validateRpcUrl,
+          })}
+        />
+        <Actions>
+          <Button fullwidth variant="translucent" onClick={handleReset}>
+            Reset to defaults
+          </Button>
+          <Button
+            type="submit"
+            fullwidth
+            color="primary"
+            loading={formState.isValidating}
+            disabled={!formState.isValid || formState.isValidating}
+          >
+            Save
+          </Button>
+        </Actions>
+      </form>
+    </Block>
+  );
+};
+
+export const SettingsForm = () => {
+  const { supportedChainIds } = useUserConfig();
 
   return (
     <SettingsFormWrap>
-      <Block>
-        <form onSubmit={formMethods.handleSubmit(handleSubmit)}>
-          <Input
-            fullwidth
-            label="RPC URL"
-            error={errors?.rpcUrl?.message}
-            {...formMethods.register('rpcUrl', {
-              required: true,
-              validate: validateRpcUrl,
-            })}
-          />
-          <Actions>
-            <Button fullwidth variant="translucent" onClick={handleReset}>
-              Reset to defaults
-            </Button>
-            <Button
-              type="submit"
-              fullwidth
-              color="primary"
-              loading={formState.isValidating}
-              disabled={!formState.isValid || formState.isValidating}
-            >
-              Save
-            </Button>
-          </Actions>
-        </form>
-      </Block>
+      {supportedChainIds.map((chainId) => (
+        <RpcUrlForm key={chainId} chainId={chainId} />
+      ))}
 
       <br />
 

--- a/features/withdrawals/hooks/contract/useRequest.ts
+++ b/features/withdrawals/hooks/contract/useRequest.ts
@@ -107,8 +107,13 @@ export const useWithdrawalRequest = ({
             onReceipt: async ({ payload }) => {
               return txModalStages.pending(amount, token, payload);
             },
-            // NOOP, handled in catch
-            onFailure: () => {},
+            onFailure: ({ error }) =>
+              txModalStages.failed(
+                error,
+                onRetry,
+                isSigningPermit,
+                onTryAllowance,
+              ),
             onSuccess: async ({ txHash }) => {
               void onConfirm?.();
               txModalStages.success(amount, token, txHash);
@@ -173,8 +178,13 @@ export const useWithdrawalRequest = ({
                 }
               }
             },
-            // NOOP, handled in catch
-            onFailure: () => {},
+            onFailure: ({ error }) =>
+              txModalStages.failed(
+                error,
+                onRetry,
+                isSigningPermit,
+                onTryAllowance,
+              ),
             onMultisigDone: () => {
               txModalStages.successMultisig();
             },

--- a/features/withdrawals/hooks/useNftDataByTxHash.ts
+++ b/features/withdrawals/hooks/useNftDataByTxHash.ts
@@ -4,7 +4,7 @@ import { usePublicClient } from 'wagmi';
 import { WithdrawalQueueAbi } from '@lidofinance/lido-ethereum-sdk/withdraw';
 import { useQuery } from '@tanstack/react-query';
 
-import { STRATEGY_CONSTANT } from 'consts/react-query-strategies';
+import { STRATEGY_IMMUTABLE } from 'consts/react-query-strategies';
 import { useDappStatus, useLidoSDK } from 'modules/web3';
 import { standardFetcher } from 'utils/standardFetcher';
 
@@ -24,7 +24,7 @@ export const useNftDataByTxHash = (txHash?: Hash) => {
   return useQuery<NFTApiData[] | null>({
     queryKey: ['nft-data-by-tx-hash', txHash, address],
     enabled: !!(txHash && address && publicClient),
-    ...STRATEGY_CONSTANT,
+    ...STRATEGY_IMMUTABLE,
     queryFn: async () => {
       if (!txHash || !address || !publicClient) return null;
 

--- a/features/withdrawals/hooks/useNftDataByTxHash.ts
+++ b/features/withdrawals/hooks/useNftDataByTxHash.ts
@@ -3,6 +3,7 @@ import { decodeEventLog, getEventSelector } from 'viem';
 import { usePublicClient } from 'wagmi';
 import { WithdrawalQueueAbi } from '@lidofinance/lido-ethereum-sdk/withdraw';
 import { useQuery } from '@tanstack/react-query';
+import { z } from 'zod';
 
 import { STRATEGY_IMMUTABLE } from 'consts/react-query-strategies';
 import { useDappStatus, useLidoSDK } from 'modules/web3';
@@ -10,11 +11,10 @@ import { standardFetcher } from 'utils/standardFetcher';
 
 const EVENT_NAME = 'WithdrawalRequested';
 
-type NFTApiData = {
-  description: string;
-  image: string;
-  name: string;
-};
+// only `image` is rendered
+const NFT_API_DATA_SCHEMA = z.looseObject({ image: z.string() });
+
+type NFTApiData = z.infer<typeof NFT_API_DATA_SCHEMA>;
 
 export const useNftDataByTxHash = (txHash?: Hash) => {
   const { address, chainId } = useDappStatus();
@@ -54,8 +54,9 @@ export const useNftDataByTxHash = (txHash?: Hash) => {
           const tokenURI = await contractWithdrawalQueue.read.tokenURI([
             e.args.requestId,
           ]);
-          const nftData = await standardFetcher<NFTApiData>(tokenURI);
-          return nftData;
+          return NFT_API_DATA_SCHEMA.parse(
+            await standardFetcher<unknown>(tokenURI),
+          );
         };
 
         return fetch();

--- a/features/wsteth/wrap/wrap-form-context/wrap-form-context.tsx
+++ b/features/wsteth/wrap/wrap-form-context/wrap-form-context.tsx
@@ -6,6 +6,7 @@ import {
   createContext,
   useContext,
   useCallback,
+  useEffect,
 } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 
@@ -77,6 +78,15 @@ export const WrapFormProvider: FC<PropsWithChildren> = ({ children }) => {
   } = formObject;
   useQueryParamsReferralForm<WrapFormInputType>({ setValue });
   const [token, amount] = watch(['token', 'amount']);
+
+  // L2 only wraps stETH. The selector is hidden there, so a token picked before
+  // connecting (or before switching chains) must be normalized here, not just
+  // in the connection-change reset which skips the initial connect
+  useEffect(() => {
+    if (isL2 && token !== TOKENS_TO_WRAP.stETH) {
+      setValue('token', TOKENS_TO_WRAP.stETH, { shouldValidate: true });
+    }
+  }, [isL2, token, setValue]);
   const { retryEvent, retryFire } = useFormControllerRetry();
 
   const approvalDataOnL1 = useWrapTxOnL1Approve({
@@ -128,14 +138,11 @@ export const WrapFormProvider: FC<PropsWithChildren> = ({ children }) => {
     (): FormControllerContextValueType<WrapFormInputType> => ({
       onSubmit,
       onReset: ({ token }: WrapFormInputType) => {
-        reset({
-          ...defaultValues,
-          token: isL2 ? TOKENS_TO_WRAP.stETH : token,
-        });
+        reset({ ...defaultValues, token });
       },
       retryEvent,
     }),
-    [onSubmit, retryEvent, reset, defaultValues, isL2],
+    [onSubmit, retryEvent, reset, defaultValues],
   );
 
   return (

--- a/modules/mellow-meta-vaults/hooks/use-withdraw.ts
+++ b/modules/mellow-meta-vaults/hooks/use-withdraw.ts
@@ -70,20 +70,22 @@ export const useWithdraw = ({
         // Eager return to save rpc calls, duplicates predicate from meetsSyncRedeemRequirements
         if (amount > remainingDailyLimit) return false;
 
-        const [{ assets }, actualLiquidAssets] = await Promise.all([
-          collector.read.getWithdrawalParams([
-            amount,
-            syncQueue.address,
-            COLLECTOR_CONFIG,
-          ]) as Promise<{ assets: bigint }>,
-          syncQueue.read.getLiquidAssets(),
-        ]);
+        const [{ assets, isWithdrawalPossible }, actualLiquidAssets] =
+          await Promise.all([
+            collector.read.getWithdrawalParams([
+              amount,
+              syncQueue.address,
+              COLLECTOR_CONFIG,
+            ]) as Promise<{ assets: bigint; isWithdrawalPossible: boolean }>,
+            syncQueue.read.getLiquidAssets(),
+          ]);
         const liquidAssets = overrideWithQAMockBigInt(
           actualLiquidAssets,
           QA_LIQUID_ASSETS_KEY,
         );
 
         return meetsSyncRedeemRequirements({
+          isWithdrawalPossible,
           requestedShares: amount,
           requestedAssets: assets,
           remainingDailyLimit,

--- a/modules/mellow-meta-vaults/utils/sync-redeem-requirements.test.ts
+++ b/modules/mellow-meta-vaults/utils/sync-redeem-requirements.test.ts
@@ -6,6 +6,7 @@ describe('meetsSyncRedeemRequirements', () => {
   it('uses the sync queue when both limits cover the request', () => {
     expect(
       meetsSyncRedeemRequirements({
+        isWithdrawalPossible: true,
         requestedShares: 10n,
         requestedAssets: 10n,
         remainingDailyLimit: 11n,
@@ -17,6 +18,7 @@ describe('meetsSyncRedeemRequirements', () => {
   it('allows a request equal to both limits', () => {
     expect(
       meetsSyncRedeemRequirements({
+        isWithdrawalPossible: true,
         requestedShares: 10n,
         requestedAssets: 10n,
         remainingDailyLimit: 10n,
@@ -28,6 +30,7 @@ describe('meetsSyncRedeemRequirements', () => {
   it('uses the async queue when the daily limit is insufficient', () => {
     expect(
       meetsSyncRedeemRequirements({
+        isWithdrawalPossible: true,
         requestedShares: 10n,
         requestedAssets: 10n,
         remainingDailyLimit: 9n,
@@ -39,6 +42,7 @@ describe('meetsSyncRedeemRequirements', () => {
   it('uses the async queue when liquid assets are insufficient', () => {
     expect(
       meetsSyncRedeemRequirements({
+        isWithdrawalPossible: true,
         requestedShares: 10n,
         requestedAssets: 10n,
         remainingDailyLimit: 20n,
@@ -47,9 +51,36 @@ describe('meetsSyncRedeemRequirements', () => {
     ).toBe(false);
   });
 
+  // ETHV-WD-ROUTE-01: a paused sync queue quotes zero assets, which must not
+  // read as "enough liquidity"
+  it('uses the async queue when the Collector says the sync withdrawal is impossible', () => {
+    expect(
+      meetsSyncRedeemRequirements({
+        isWithdrawalPossible: false,
+        requestedShares: 10n,
+        requestedAssets: 0n,
+        remainingDailyLimit: 20n,
+        liquidAssets: 20n,
+      }),
+    ).toBe(false);
+  });
+
+  it('uses the async queue when the quote returns zero assets for a positive request', () => {
+    expect(
+      meetsSyncRedeemRequirements({
+        isWithdrawalPossible: true,
+        requestedShares: 10n,
+        requestedAssets: 0n,
+        remainingDailyLimit: 20n,
+        liquidAssets: 20n,
+      }),
+    ).toBe(false);
+  });
+
   it('compares share and asset limits in their respective token units', () => {
     expect(
       meetsSyncRedeemRequirements({
+        isWithdrawalPossible: true,
         requestedShares: 1_000_000_000_000_000_000n,
         requestedAssets: 1_021_236n,
         remainingDailyLimit: 12_000_000_000_000_000_000_000n,

--- a/modules/mellow-meta-vaults/utils/sync-redeem-requirements.ts
+++ b/modules/mellow-meta-vaults/utils/sync-redeem-requirements.ts
@@ -6,15 +6,25 @@
  * can be used only when the requested shares do not exceed the remaining daily
  * limit and the corresponding requested assets do not exceed the available
  * liquid assets. Otherwise, the redemption must use the async queue.
+ *
+ * The Collector's own verdict comes first: a paused sync queue quotes
+ * `isWithdrawalPossible=false` with zero assets, which would otherwise pass
+ * the asset comparison trivially.
  */
 export const meetsSyncRedeemRequirements = ({
+  isWithdrawalPossible,
   requestedShares,
   requestedAssets,
   remainingDailyLimit,
   liquidAssets,
 }: {
+  isWithdrawalPossible: boolean;
   requestedShares: bigint;
   requestedAssets: bigint;
   remainingDailyLimit: bigint;
   liquidAssets: bigint;
-}) => requestedShares <= remainingDailyLimit && requestedAssets <= liquidAssets;
+}) =>
+  isWithdrawalPossible &&
+  requestedAssets > 0n &&
+  requestedShares <= remainingDailyLimit &&
+  requestedAssets <= liquidAssets;

--- a/modules/web3/hooks/tx-flow/run-tx-flow.test.ts
+++ b/modules/web3/hooks/tx-flow/run-tx-flow.test.ts
@@ -6,8 +6,9 @@ import {
 
 import { TransactionRevertedError } from '../../utils/transaction-reverted-error';
 import { TxSettledError } from '../../utils/tx-settled-error';
-import { runTxFlow, type TxFlowDeps } from './run-tx-flow';
-import type { AACall, TxCallbackProps, TxFlowArgs } from './types';
+import { TxStaleError } from '../../utils/tx-stale-error';
+import { runTxFlow } from './run-tx-flow';
+import type { AACall, TxCallbackProps, TxFlowArgs, TxFlowDeps } from './types';
 
 const ADDRESS: Address = '0x0000000000000000000000000000000000000001';
 const TX_HASH =
@@ -401,6 +402,60 @@ describe('runTxFlow', () => {
         { isAA: true, sendAACalls, isCurrent: () => current },
       );
       expect(sendAACalls).not.toHaveBeenCalled();
+    });
+
+    it('aborts a legacy transaction that went stale before signing', async () => {
+      let current = true;
+      const send = vi.fn();
+      const cb = createCallbacks();
+      await expect(
+        run(
+          {
+            ...cb,
+            sendTransaction: legacySdk(
+              { stage: TransactionCallbackStage.GAS_LIMIT },
+              () => {
+                current = false;
+              },
+              { stage: TransactionCallbackStage.SIGN },
+              send,
+            ),
+          },
+          { isCurrent: () => current },
+        ),
+      ).rejects.toBeInstanceOf(TxStaleError);
+      expect(send).not.toHaveBeenCalled();
+      expect(cb.onSign).not.toHaveBeenCalled();
+      expect(cb.onFailure).not.toHaveBeenCalled();
+    });
+
+    it('aborts an AA transaction that went stale before signing', async () => {
+      let current = true;
+      const send = vi.fn();
+      const cb = createCallbacks();
+      // mirrors useSendAACalls: SIGN is awaited before sendCalls, errors are
+      // reported as ERROR and rethrown
+      const sendAACalls = async (
+        _calls: unknown,
+        callback: (props: TxCallbackProps) => Promise<void>,
+      ) => {
+        current = false;
+        try {
+          await callback({ stage: TransactionCallbackStage.SIGN });
+          send();
+        } catch (error) {
+          await callback({ stage: TransactionCallbackStage.ERROR, error });
+          throw error;
+        }
+      };
+      await expect(
+        run(
+          { ...cb, callsFn: async () => [] },
+          { isAA: true, sendAACalls, isCurrent: () => current },
+        ),
+      ).rejects.toBeInstanceOf(TxStaleError);
+      expect(send).not.toHaveBeenCalled();
+      expect(cb.onFailure).not.toHaveBeenCalled();
     });
 
     it('ignores stages reported after the flow went stale', async () => {

--- a/modules/web3/hooks/tx-flow/run-tx-flow.test.ts
+++ b/modules/web3/hooks/tx-flow/run-tx-flow.test.ts
@@ -1,0 +1,435 @@
+import type { Address, Hash, TransactionReceipt } from 'viem';
+import {
+  TransactionCallbackStage,
+  type TransactionCallback,
+} from '@lidofinance/lido-ethereum-sdk/core';
+
+import { TransactionRevertedError } from '../../utils/transaction-reverted-error';
+import { TxSettledError } from '../../utils/tx-settled-error';
+import { runTxFlow, type TxFlowDeps } from './run-tx-flow';
+import type { AACall, TxCallbackProps, TxFlowArgs } from './types';
+
+const ADDRESS: Address = '0x0000000000000000000000000000000000000001';
+const TX_HASH =
+  '0x1111111111111111111111111111111111111111111111111111111111111111';
+const TX_HASH_2 =
+  '0x2222222222222222222222222222222222222222222222222222222222222222';
+const CALL_ID = '0xcall';
+
+const receipt = (status: 'success' | 'reverted' = 'success') =>
+  ({ status, transactionHash: TX_HASH }) as unknown as TransactionReceipt;
+
+type Stage = TxCallbackProps | (() => Promise<void> | void);
+
+// Mirrors the SDK's `performTransaction`: stages are awaited in order, a
+// throwing stage callback aborts the sequence and rejects the call, and no
+// ERROR stage is ever emitted
+const legacySdk =
+  (...stages: Stage[]) =>
+  async (callback: TransactionCallback) => {
+    for (const stage of stages) {
+      if (typeof stage === 'function') await stage();
+      else await callback(stage as Parameters<TransactionCallback>[0]);
+    }
+  };
+
+// Mirrors `useSendAACalls`: SIGN, RECEIPT (callId), DONE (txHash); any error,
+// including one thrown by a stage callback, is reported as an ERROR stage and
+// then rethrown
+const aaSdk =
+  (options: { failWith?: unknown; txHash?: Hash } = {}) =>
+  async (
+    _calls: unknown,
+    callback: (props: TxCallbackProps) => Promise<void>,
+  ) => {
+    try {
+      await callback({ stage: TransactionCallbackStage.SIGN });
+      await callback({
+        stage: TransactionCallbackStage.RECEIPT,
+        callId: CALL_ID,
+      });
+      if (options.failWith) throw options.failWith;
+      await callback({
+        stage: TransactionCallbackStage.DONE,
+        txHash: options.txHash ?? TX_HASH,
+      });
+    } catch (error) {
+      await callback({ stage: TransactionCallbackStage.ERROR, error });
+      throw error;
+    }
+  };
+
+const createCallbacks = () => ({
+  onSign: vi.fn(),
+  onReceipt: vi.fn(),
+  onConfirmation: vi.fn(),
+  onSuccess: vi.fn(),
+  onFailure: vi.fn(),
+});
+
+const createDeps = (overrides: Partial<TxFlowDeps> = {}): TxFlowDeps => ({
+  isAA: false,
+  address: ADDRESS,
+  validateAddress: vi.fn(async () => true),
+  sendAACalls: vi.fn(aaSdk()),
+  isCurrent: () => true,
+  txHash: { current: undefined },
+  ...overrides,
+});
+
+const run = (args: Partial<TxFlowArgs>, deps: Partial<TxFlowDeps> = {}) =>
+  runTxFlow({ sendTransaction: legacySdk(), ...args }, createDeps(deps));
+
+const reportedError = (onFailure: ReturnType<typeof vi.fn>) =>
+  onFailure.mock.calls[0]?.[0]?.error;
+
+describe('runTxFlow', () => {
+  describe('legacy transactions', () => {
+    it('drives the stages and forwards the tx hash', async () => {
+      const cb = createCallbacks();
+      const txHash = { current: undefined };
+      await run(
+        {
+          ...cb,
+          sendTransaction: legacySdk(
+            { stage: TransactionCallbackStage.SIGN },
+            { stage: TransactionCallbackStage.RECEIPT, payload: TX_HASH },
+            {
+              stage: TransactionCallbackStage.CONFIRMATION,
+              payload: receipt(),
+            },
+            { stage: TransactionCallbackStage.DONE },
+          ),
+        },
+        { txHash },
+      );
+
+      expect(cb.onSign).toHaveBeenCalledWith(
+        expect.objectContaining({ isAA: false }),
+      );
+      expect(cb.onReceipt).toHaveBeenCalledWith(
+        expect.objectContaining({ txHashOrCallId: TX_HASH }),
+      );
+      expect(cb.onConfirmation).toHaveBeenCalledTimes(1);
+      expect(cb.onSuccess).toHaveBeenCalledWith(
+        expect.objectContaining({ txHash: TX_HASH }),
+      );
+      expect(cb.onFailure).not.toHaveBeenCalled();
+      expect(txHash.current).toBeUndefined();
+    });
+
+    it('rejects a failure before settlement without dressing it up', async () => {
+      const cb = createCallbacks();
+      const rejected = new Error('User rejected the request');
+      await expect(
+        run({
+          ...cb,
+          sendTransaction: legacySdk(
+            { stage: TransactionCallbackStage.SIGN },
+            () => {
+              throw rejected;
+            },
+          ),
+        }),
+      ).rejects.toBe(rejected);
+
+      // The SDK emits no ERROR stage for legacy transactions and the flow
+      // must not invent one before settlement: the caller handles rejection
+      expect(cb.onFailure).not.toHaveBeenCalled();
+      expect(cb.onSuccess).not.toHaveBeenCalled();
+    });
+
+    it('reports a failure after confirmation as settled and resolves', async () => {
+      const cb = createCallbacks();
+      const readError = new Error('balance read timeout');
+      await expect(
+        run({
+          ...cb,
+          sendTransaction: legacySdk(
+            { stage: TransactionCallbackStage.RECEIPT, payload: TX_HASH },
+            {
+              stage: TransactionCallbackStage.CONFIRMATION,
+              payload: receipt(),
+            },
+            () => {
+              throw readError;
+            },
+          ),
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(cb.onFailure).toHaveBeenCalledTimes(1);
+      const error = reportedError(cb.onFailure);
+      expect(error).toBeInstanceOf(TxSettledError);
+      expect(error.cause).toBe(readError);
+      expect(error.txHash).toBe(TX_HASH);
+      expect(cb.onSuccess).not.toHaveBeenCalled();
+    });
+
+    it('reports a failing onConfirmation as settled', async () => {
+      const cb = createCallbacks();
+      cb.onConfirmation.mockRejectedValue(new Error('confirmations read'));
+      await expect(
+        run({
+          ...cb,
+          sendTransaction: legacySdk(
+            { stage: TransactionCallbackStage.RECEIPT, payload: TX_HASH },
+            {
+              stage: TransactionCallbackStage.CONFIRMATION,
+              payload: receipt(),
+            },
+            { stage: TransactionCallbackStage.DONE },
+          ),
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(cb.onFailure).toHaveBeenCalledTimes(1);
+      expect(reportedError(cb.onFailure)).toBeInstanceOf(TxSettledError);
+      expect(cb.onSuccess).not.toHaveBeenCalled();
+    });
+
+    it('reports a failing onSuccess once as settled and resolves', async () => {
+      const cb = createCallbacks();
+      cb.onSuccess.mockRejectedValue(new Error('balance refresh'));
+      await expect(
+        run({
+          ...cb,
+          sendTransaction: legacySdk(
+            { stage: TransactionCallbackStage.RECEIPT, payload: TX_HASH },
+            {
+              stage: TransactionCallbackStage.CONFIRMATION,
+              payload: receipt(),
+            },
+            { stage: TransactionCallbackStage.DONE },
+          ),
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(cb.onFailure).toHaveBeenCalledTimes(1);
+      const error = reportedError(cb.onFailure);
+      expect(error).toBeInstanceOf(TxSettledError);
+      expect(error.txHash).toBe(TX_HASH);
+    });
+
+    it('surfaces a reverted receipt as a failure and skips success', async () => {
+      const cb = createCallbacks();
+      await expect(
+        run({
+          ...cb,
+          sendTransaction: legacySdk(
+            { stage: TransactionCallbackStage.RECEIPT, payload: TX_HASH },
+            {
+              stage: TransactionCallbackStage.CONFIRMATION,
+              payload: receipt('reverted'),
+            },
+            { stage: TransactionCallbackStage.DONE },
+          ),
+        }),
+      ).rejects.toBeInstanceOf(TransactionRevertedError);
+
+      expect(cb.onConfirmation).not.toHaveBeenCalled();
+      expect(cb.onSuccess).not.toHaveBeenCalled();
+      // Not settled: the revert is a real failure, never a TxSettledError
+      expect(cb.onFailure).not.toHaveBeenCalled();
+    });
+
+    it('does not let a settled approval mask a failing chained deposit', async () => {
+      const cb = createCallbacks();
+      const depositRejected = new Error('User rejected the request');
+      await expect(
+        run({
+          ...cb,
+          sendTransaction: legacySdk(
+            // approve
+            { stage: TransactionCallbackStage.RECEIPT, payload: TX_HASH },
+            {
+              stage: TransactionCallbackStage.CONFIRMATION,
+              payload: receipt(),
+            },
+            { stage: TransactionCallbackStage.DONE },
+            // deposit
+            { stage: TransactionCallbackStage.SIGN },
+            () => {
+              throw depositRejected;
+            },
+          ),
+        }),
+      ).rejects.toBe(depositRejected);
+
+      expect(cb.onSuccess).toHaveBeenCalledTimes(1);
+      expect(cb.onFailure).not.toHaveBeenCalled();
+    });
+
+    it('tracks the hash of each chained transaction separately', async () => {
+      const cb = createCallbacks();
+      const txHash = { current: undefined };
+      await run(
+        {
+          ...cb,
+          sendTransaction: legacySdk(
+            { stage: TransactionCallbackStage.RECEIPT, payload: TX_HASH },
+            {
+              stage: TransactionCallbackStage.CONFIRMATION,
+              payload: receipt(),
+            },
+            { stage: TransactionCallbackStage.DONE },
+            { stage: TransactionCallbackStage.RECEIPT, payload: TX_HASH_2 },
+            {
+              stage: TransactionCallbackStage.CONFIRMATION,
+              payload: receipt(),
+            },
+            { stage: TransactionCallbackStage.DONE },
+          ),
+        },
+        { txHash },
+      );
+
+      expect(cb.onSuccess.mock.calls.map(([args]) => args.txHash)).toEqual([
+        TX_HASH,
+        TX_HASH_2,
+      ]);
+      expect(txHash.current).toBeUndefined();
+    });
+
+    it('falls back to sendTransaction for AA wallets without callsFn', async () => {
+      const sendTransaction = vi.fn(legacySdk());
+      const sendAACalls = vi.fn(aaSdk());
+      await run({ sendTransaction }, { isAA: true, sendAACalls });
+
+      expect(sendTransaction).toHaveBeenCalledTimes(1);
+      expect(sendAACalls).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('AA transactions', () => {
+    it('builds the calls, drives the stages and forwards the tx hash', async () => {
+      const cb = createCallbacks();
+      const calls: AACall[] = [{ to: ADDRESS }];
+      const callsFn = vi.fn(async () => calls);
+      const sendAACalls = vi.fn(aaSdk());
+      const sendTransaction = vi.fn(legacySdk());
+      await run(
+        { ...cb, callsFn, sendTransaction },
+        { isAA: true, sendAACalls },
+      );
+
+      expect(sendAACalls).toHaveBeenCalledWith(calls, expect.any(Function));
+      expect(sendTransaction).not.toHaveBeenCalled();
+      expect(cb.onSign).toHaveBeenCalledWith(
+        expect.objectContaining({ isAA: true }),
+      );
+      expect(cb.onReceipt).toHaveBeenCalledWith(
+        expect.objectContaining({ txHashOrCallId: CALL_ID }),
+      );
+      expect(cb.onSuccess).toHaveBeenCalledWith(
+        expect.objectContaining({ txHash: TX_HASH, isAA: true }),
+      );
+      expect(cb.onFailure).not.toHaveBeenCalled();
+    });
+
+    it('reports a failure before settlement once, as is, and rejects', async () => {
+      const cb = createCallbacks();
+      const failed = new Error('Transaction failed');
+      await expect(
+        run(
+          { ...cb, callsFn: async () => [] },
+          { isAA: true, sendAACalls: aaSdk({ failWith: failed }) },
+        ),
+      ).rejects.toBe(failed);
+
+      expect(cb.onFailure).toHaveBeenCalledTimes(1);
+      expect(reportedError(cb.onFailure)).toBe(failed);
+      expect(cb.onSuccess).not.toHaveBeenCalled();
+    });
+
+    it('reports a failing onSuccess once as settled and resolves', async () => {
+      const cb = createCallbacks();
+      const refreshError = new Error('balance refresh');
+      cb.onSuccess.mockRejectedValue(refreshError);
+      await expect(
+        run(
+          { ...cb, callsFn: async () => [] },
+          { isAA: true, sendAACalls: aaSdk() },
+        ),
+      ).resolves.toBeUndefined();
+
+      // DONE reports the failure itself; the ERROR stage the AA sender emits
+      // afterwards for the same error must not report it a second time
+      expect(cb.onFailure).toHaveBeenCalledTimes(1);
+      const error = reportedError(cb.onFailure);
+      expect(error).toBeInstanceOf(TxSettledError);
+      expect(error.cause).toBe(refreshError);
+    });
+  });
+
+  describe('stale operations', () => {
+    it('does nothing for an invalid address', async () => {
+      const sendTransaction = vi.fn(legacySdk());
+      await run(
+        { sendTransaction },
+        { validateAddress: vi.fn(async () => false) },
+      );
+      expect(sendTransaction).not.toHaveBeenCalled();
+    });
+
+    it('does not send if the flow went stale during address validation', async () => {
+      let current = true;
+      const sendTransaction = vi.fn(legacySdk());
+      await run(
+        { sendTransaction },
+        {
+          isCurrent: () => current,
+          validateAddress: async () => {
+            current = false;
+            return true;
+          },
+        },
+      );
+      expect(sendTransaction).not.toHaveBeenCalled();
+    });
+
+    it('does not reach the wallet if the flow went stale while building calls', async () => {
+      let current = true;
+      const sendAACalls = vi.fn(aaSdk());
+      await run(
+        {
+          callsFn: async () => {
+            current = false;
+            return [];
+          },
+        },
+        { isAA: true, sendAACalls, isCurrent: () => current },
+      );
+      expect(sendAACalls).not.toHaveBeenCalled();
+    });
+
+    it('ignores stages reported after the flow went stale', async () => {
+      let current = true;
+      const cb = createCallbacks();
+      await run(
+        {
+          ...cb,
+          sendTransaction: legacySdk(
+            { stage: TransactionCallbackStage.SIGN },
+            () => {
+              current = false;
+            },
+            { stage: TransactionCallbackStage.RECEIPT, payload: TX_HASH },
+            {
+              stage: TransactionCallbackStage.CONFIRMATION,
+              payload: receipt(),
+            },
+            { stage: TransactionCallbackStage.DONE },
+          ),
+        },
+        { isCurrent: () => current },
+      );
+
+      expect(cb.onSign).toHaveBeenCalledTimes(1);
+      expect(cb.onReceipt).not.toHaveBeenCalled();
+      expect(cb.onConfirmation).not.toHaveBeenCalled();
+      expect(cb.onSuccess).not.toHaveBeenCalled();
+      expect(cb.onFailure).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/modules/web3/hooks/tx-flow/run-tx-flow.ts
+++ b/modules/web3/hooks/tx-flow/run-tx-flow.ts
@@ -3,7 +3,16 @@ import { TransactionCallbackStage } from '@lidofinance/lido-ethereum-sdk/core';
 
 import { TransactionRevertedError } from '../../utils/transaction-reverted-error';
 import { TxSettledError } from '../../utils/tx-settled-error';
+import { TxStaleError } from '../../utils/tx-stale-error';
 import type { TxCallbackProps, TxFlowArgs, TxFlowDeps } from './types';
+
+// Stages the SDK awaits before it reaches the wallet: throwing from them
+// aborts the request. Later stages only report on a transaction already sent.
+const PRE_SEND_STAGES = new Set<TxCallbackProps['stage']>([
+  TransactionCallbackStage.GAS_LIMIT,
+  TransactionCallbackStage.PERMIT,
+  TransactionCallbackStage.SIGN,
+]);
 
 /**
  * The transaction state machine behind {@link useTxFlow}, kept free of React
@@ -39,6 +48,8 @@ export const runTxFlow = async (
   // approval settling must not mask a failure of the deposit that follows
   let isSettled = false;
   let isFailureReported = false;
+  // Kept because the SDK rewraps thrown errors and loses the instance
+  let staleError: TxStaleError | undefined;
   const toFlowError = (error: unknown) =>
     isSettled ? new TxSettledError(error, txHash.current) : error;
 
@@ -49,7 +60,11 @@ export const runTxFlow = async (
    * @param args - The arguments for the current stage of the transaction.
    */
   const txStagesCallback = async (txArgs: TxCallbackProps) => {
-    if (!isCurrent()) return;
+    if (!isCurrent()) {
+      if (PRE_SEND_STAGES.has(txArgs.stage))
+        throw (staleError = new TxStaleError());
+      return;
+    }
     const args = { ...txArgs, isAA };
     switch (args.stage) {
       case TransactionCallbackStage.SIGN:
@@ -136,6 +151,7 @@ export const runTxFlow = async (
       await sendTransaction(txStagesCallback);
     }
   } catch (error) {
+    if (staleError) throw staleError;
     if (!isSettled) throw error;
     // The SDK emits no ERROR stage for legacy transactions, so report the
     // settled failure here; swallowing it lets the caller finish as a

--- a/modules/web3/hooks/tx-flow/run-tx-flow.ts
+++ b/modules/web3/hooks/tx-flow/run-tx-flow.ts
@@ -1,0 +1,151 @@
+import type { Hash } from 'viem';
+import { TransactionCallbackStage } from '@lidofinance/lido-ethereum-sdk/core';
+
+import { TransactionRevertedError } from '../../utils/transaction-reverted-error';
+import { TxSettledError } from '../../utils/tx-settled-error';
+import type { TxCallbackProps, TxFlowArgs, TxFlowDeps } from './types';
+
+/**
+ * The transaction state machine behind {@link useTxFlow}, kept free of React
+ * so it can be driven directly in tests.
+ */
+export const runTxFlow = async (
+  {
+    callsFn,
+    sendTransaction,
+    onPermit,
+    onSign,
+    onGasLimit,
+    onReceipt,
+    onConfirmation,
+    onSuccess,
+    onFailure,
+    onMultisigDone,
+  }: TxFlowArgs,
+  {
+    isAA,
+    address,
+    validateAddress,
+    sendAACalls,
+    isCurrent,
+    txHash,
+  }: TxFlowDeps,
+) => {
+  // Set once a successful receipt is known and cleared when its DONE stage
+  // completes. In between, the transaction is done: a failing confirmations
+  // read or balance refresh must not be presented as a failed transaction,
+  // and never with a Retry. Clearing matters for flows that chain several
+  // transactions (approve, then deposit) through one stage callback: the
+  // approval settling must not mask a failure of the deposit that follows
+  let isSettled = false;
+  let isFailureReported = false;
+  const toFlowError = (error: unknown) =>
+    isSettled ? new TxSettledError(error, txHash.current) : error;
+
+  /**
+   * Callback function to handle different stages of the transaction flow.
+   * It calls the appropriate callback based on the stage of the transaction.
+   *
+   * @param args - The arguments for the current stage of the transaction.
+   */
+  const txStagesCallback = async (txArgs: TxCallbackProps) => {
+    if (!isCurrent()) return;
+    const args = { ...txArgs, isAA };
+    switch (args.stage) {
+      case TransactionCallbackStage.SIGN:
+        return onSign?.(args);
+      case TransactionCallbackStage.RECEIPT:
+        // In case of AA sendCalls, the callId is used to track the transaction.
+        // But in case of legacy sendTransaction, the payload is the transaction hash.
+        // Memoize the txHash for using it in subsequent calls.
+        txHash.current = args.payload;
+        await onReceipt?.({
+          ...args,
+          txHashOrCallId:
+            'callId' in args ? (args.callId as Hash) : args.payload,
+        });
+        break;
+      case TransactionCallbackStage.DONE:
+        isSettled = true;
+        try {
+          await onSuccess?.({
+            ...args,
+            txHash: 'txHash' in args ? args.txHash : txHash.current,
+          });
+        } catch (error) {
+          // Report here rather than relying on the SDK rejecting: the L2
+          // wrap path fires the SDK call without awaiting it
+          isFailureReported = true;
+          await onFailure?.({
+            ...args,
+            stage: TransactionCallbackStage.ERROR,
+            error: toFlowError(error),
+          });
+          throw error;
+        }
+        isSettled = false;
+        txHash.current = undefined; // Reset txHash after success
+        break;
+      case TransactionCallbackStage.MULTISIG_DONE:
+        await onMultisigDone?.(args);
+        break;
+      case TransactionCallbackStage.ERROR:
+        if (isFailureReported) break;
+        isFailureReported = true;
+        await onFailure?.({
+          ...args,
+          error: toFlowError('error' in args ? args.error : args.payload),
+        });
+        break;
+      case TransactionCallbackStage.PERMIT:
+        await onPermit?.(args);
+        break;
+      case TransactionCallbackStage.GAS_LIMIT:
+        await onGasLimit?.(args);
+        break;
+      case TransactionCallbackStage.CONFIRMATION:
+        // The SDK reports CONFIRMATION and then DONE regardless of the
+        // receipt status, so a reverted transaction would be presented as a
+        // success. Throwing here skips DONE and surfaces it as a failure.
+        if (args.payload?.status === 'reverted') {
+          throw new TransactionRevertedError(args.payload);
+        }
+        isSettled = true;
+        await onConfirmation?.(args);
+        break;
+      default:
+        break;
+    }
+  };
+
+  const result = await validateAddress(address);
+  // if address is not valid, or the operation went stale while validating,
+  // don't send the transaction
+  if (!result || !isCurrent()) return;
+
+  try {
+    // callsFn must be defined for AA transactions. If it's not defined, the transaction will be sent to yourself instead of the smart account.
+    if (isAA && callsFn) {
+      const calls = await callsFn();
+      // building calls can take a while, check again before reaching the wallet
+      if (!isCurrent()) return;
+      await sendAACalls(calls, async (props) => {
+        await txStagesCallback(props);
+      });
+    } else {
+      await sendTransaction(txStagesCallback);
+    }
+  } catch (error) {
+    if (!isSettled) throw error;
+    // The SDK emits no ERROR stage for legacy transactions, so report the
+    // settled failure here; swallowing it lets the caller finish as a
+    // success (reset form, track completion) since the tx did complete
+    if (!isFailureReported) {
+      await onFailure?.({
+        stage: TransactionCallbackStage.ERROR,
+        error: toFlowError(error),
+        isAA,
+      });
+    }
+  }
+};

--- a/modules/web3/hooks/tx-flow/types.ts
+++ b/modules/web3/hooks/tx-flow/types.ts
@@ -59,8 +59,7 @@ export type sendCallsCallbackProps =
   | onFailureCallbackProps;
 
 export type TxCallbackProps =
-  | sendTransactionCallbackProps
-  | sendCallsCallbackProps;
+  sendTransactionCallbackProps | sendCallsCallbackProps;
 
 export type StageCallback<TArgs, TReturn = void> = (
   args: TArgs & CommonCallbackProps,
@@ -100,3 +99,18 @@ export type TxFlowArgs = {
   callsFn?: () => Promise<(AACall | null | undefined | false)[]>;
   sendTransaction: (txStagesCallback: TransactionCallback) => Promise<void>;
 } & StageCallbacks;
+
+export type TxFlowDeps = {
+  isAA: boolean;
+  address?: Address;
+  validateAddress: (address?: Address) => Promise<boolean>;
+  sendAACalls: (
+    calls: (AACall | null | undefined | false)[],
+    callback: (props: TxCallbackProps) => Promise<void>,
+  ) => Promise<unknown>;
+  // False once the owning UI unmounted or a newer flow started; a stale flow
+  // must neither reach the wallet nor report stages
+  isCurrent: () => boolean;
+  // Memoized txHash shared across stages (and across flows by the hook)
+  txHash: { current: Hash | undefined };
+};

--- a/modules/web3/hooks/tx-flow/use-tx-flow.ts
+++ b/modules/web3/hooks/tx-flow/use-tx-flow.ts
@@ -7,6 +7,7 @@ import { useDappStatus } from 'modules/web3';
 import { useAA } from '../use-aa';
 import { useSendAACalls } from './use-send-aa-calls';
 import { TransactionRevertedError } from '../../utils/transaction-reverted-error';
+import { TxSettledError } from '../../utils/tx-settled-error';
 import { TxCallbackProps, TxFlowArgs } from './types';
 
 export type TxStagesCallback = (args: TxCallbackProps) => Promise<void>;
@@ -53,6 +54,17 @@ export const useTxFlow = () => {
       const operation = ++operationRef.current;
       const isCurrent = () => operationRef.current === operation;
 
+      // Set once a successful receipt is known and cleared when its DONE stage
+      // completes. In between, the transaction is done: a failing confirmations
+      // read or balance refresh must not be presented as a failed transaction,
+      // and never with a Retry. Clearing matters for flows that chain several
+      // transactions (approve, then deposit) through one stage callback: the
+      // approval settling must not mask a failure of the deposit that follows
+      let isSettled = false;
+      let isFailureReported = false;
+      const toFlowError = (error: unknown) =>
+        isSettled ? new TxSettledError(error, txHash.current) : error;
+
       /**
        * Callback function to handle different stages of the transaction flow.
        * It calls the appropriate callback based on the stage of the transaction.
@@ -77,19 +89,35 @@ export const useTxFlow = () => {
             });
             break;
           case TransactionCallbackStage.DONE:
-            await onSuccess?.({
-              ...args,
-              txHash: 'txHash' in args ? args.txHash : txHash.current,
-            });
+            isSettled = true;
+            try {
+              await onSuccess?.({
+                ...args,
+                txHash: 'txHash' in args ? args.txHash : txHash.current,
+              });
+            } catch (error) {
+              // Report here rather than relying on the SDK rejecting: the L2
+              // wrap path fires the SDK call without awaiting it
+              isFailureReported = true;
+              await onFailure?.({
+                ...args,
+                stage: TransactionCallbackStage.ERROR,
+                error: toFlowError(error),
+              });
+              throw error;
+            }
+            isSettled = false;
             txHash.current = undefined; // Reset txHash after success
             break;
           case TransactionCallbackStage.MULTISIG_DONE:
             await onMultisigDone?.(args);
             break;
           case TransactionCallbackStage.ERROR:
+            if (isFailureReported) break;
+            isFailureReported = true;
             await onFailure?.({
               ...args,
-              error: 'error' in args ? args.error : args.payload,
+              error: toFlowError('error' in args ? args.error : args.payload),
             });
             break;
           case TransactionCallbackStage.PERMIT:
@@ -105,6 +133,7 @@ export const useTxFlow = () => {
             if (args.payload?.status === 'reverted') {
               throw new TransactionRevertedError(args.payload);
             }
+            isSettled = true;
             await onConfirmation?.(args);
             break;
           default:
@@ -117,16 +146,30 @@ export const useTxFlow = () => {
       // don't send the transaction
       if (!result || !isCurrent()) return;
 
-      // callsFn must be defined for AA transactions. If it's not defined, the transaction will be sent to yourself instead of the smart account.
-      if (isAA && callsFn) {
-        const calls = await callsFn();
-        // building calls can take a while, check again before reaching the wallet
-        if (!isCurrent()) return;
-        await sendAACalls(calls, async (props) => {
-          await txStagesCallback(props);
-        });
-      } else {
-        await sendTransaction(txStagesCallback);
+      try {
+        // callsFn must be defined for AA transactions. If it's not defined, the transaction will be sent to yourself instead of the smart account.
+        if (isAA && callsFn) {
+          const calls = await callsFn();
+          // building calls can take a while, check again before reaching the wallet
+          if (!isCurrent()) return;
+          await sendAACalls(calls, async (props) => {
+            await txStagesCallback(props);
+          });
+        } else {
+          await sendTransaction(txStagesCallback);
+        }
+      } catch (error) {
+        if (!isSettled) throw error;
+        // The SDK emits no ERROR stage for legacy transactions, so report the
+        // settled failure here; swallowing it lets the caller finish as a
+        // success (reset form, track completion) since the tx did complete
+        if (!isFailureReported) {
+          await onFailure?.({
+            stage: TransactionCallbackStage.ERROR,
+            error: toFlowError(error),
+            isAA,
+          });
+        }
       }
     },
     [isAA, sendAACalls, validateAddress, address],

--- a/modules/web3/hooks/tx-flow/use-tx-flow.ts
+++ b/modules/web3/hooks/tx-flow/use-tx-flow.ts
@@ -1,13 +1,11 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { Hash } from 'viem';
-import { TransactionCallbackStage } from '@lidofinance/lido-ethereum-sdk/core';
 import { useAddressValidation } from 'providers/address-validation-provider';
 import { useDappStatus } from 'modules/web3';
 
 import { useAA } from '../use-aa';
 import { useSendAACalls } from './use-send-aa-calls';
-import { TransactionRevertedError } from '../../utils/transaction-reverted-error';
-import { TxSettledError } from '../../utils/tx-settled-error';
+import { runTxFlow } from './run-tx-flow';
 import { TxCallbackProps, TxFlowArgs } from './types';
 
 export type TxStagesCallback = (args: TxCallbackProps) => Promise<void>;
@@ -15,6 +13,7 @@ export type TxStagesCallback = (args: TxCallbackProps) => Promise<void>;
 /**
  * Hook to handle the transaction flow for both Account Abstraction (AA) and standard transactions.
  * It manages transaction lifecycle callbacks for various stages.
+ * The state machine itself lives in {@link runTxFlow}.
  *
  * @returns A function that initiates the transaction flow with the provided arguments and stage callbacks.
  *
@@ -39,138 +38,16 @@ export const useTxFlow = () => {
   }, []);
 
   return useCallback(
-    async ({
-      callsFn,
-      sendTransaction,
-      onPermit,
-      onSign,
-      onGasLimit,
-      onReceipt,
-      onConfirmation,
-      onSuccess,
-      onFailure,
-      onMultisigDone,
-    }: TxFlowArgs) => {
+    (args: TxFlowArgs) => {
       const operation = ++operationRef.current;
-      const isCurrent = () => operationRef.current === operation;
-
-      // Set once a successful receipt is known and cleared when its DONE stage
-      // completes. In between, the transaction is done: a failing confirmations
-      // read or balance refresh must not be presented as a failed transaction,
-      // and never with a Retry. Clearing matters for flows that chain several
-      // transactions (approve, then deposit) through one stage callback: the
-      // approval settling must not mask a failure of the deposit that follows
-      let isSettled = false;
-      let isFailureReported = false;
-      const toFlowError = (error: unknown) =>
-        isSettled ? new TxSettledError(error, txHash.current) : error;
-
-      /**
-       * Callback function to handle different stages of the transaction flow.
-       * It calls the appropriate callback based on the stage of the transaction.
-       *
-       * @param args - The arguments for the current stage of the transaction.
-       */
-      const txStagesCallback = async (txArgs: TxCallbackProps) => {
-        if (!isCurrent()) return;
-        const args = { ...txArgs, isAA };
-        switch (args.stage) {
-          case TransactionCallbackStage.SIGN:
-            return onSign?.(args);
-          case TransactionCallbackStage.RECEIPT:
-            // In case of AA sendCalls, the callId is used to track the transaction.
-            // But in case of legacy sendTransaction, the payload is the transaction hash.
-            // Memoize the txHash for using it in subsequent calls.
-            txHash.current = args.payload;
-            await onReceipt?.({
-              ...args,
-              txHashOrCallId:
-                'callId' in args ? (args.callId as Hash) : args.payload,
-            });
-            break;
-          case TransactionCallbackStage.DONE:
-            isSettled = true;
-            try {
-              await onSuccess?.({
-                ...args,
-                txHash: 'txHash' in args ? args.txHash : txHash.current,
-              });
-            } catch (error) {
-              // Report here rather than relying on the SDK rejecting: the L2
-              // wrap path fires the SDK call without awaiting it
-              isFailureReported = true;
-              await onFailure?.({
-                ...args,
-                stage: TransactionCallbackStage.ERROR,
-                error: toFlowError(error),
-              });
-              throw error;
-            }
-            isSettled = false;
-            txHash.current = undefined; // Reset txHash after success
-            break;
-          case TransactionCallbackStage.MULTISIG_DONE:
-            await onMultisigDone?.(args);
-            break;
-          case TransactionCallbackStage.ERROR:
-            if (isFailureReported) break;
-            isFailureReported = true;
-            await onFailure?.({
-              ...args,
-              error: toFlowError('error' in args ? args.error : args.payload),
-            });
-            break;
-          case TransactionCallbackStage.PERMIT:
-            await onPermit?.(args);
-            break;
-          case TransactionCallbackStage.GAS_LIMIT:
-            await onGasLimit?.(args);
-            break;
-          case TransactionCallbackStage.CONFIRMATION:
-            // The SDK reports CONFIRMATION and then DONE regardless of the
-            // receipt status, so a reverted transaction would be presented as a
-            // success. Throwing here skips DONE and surfaces it as a failure.
-            if (args.payload?.status === 'reverted') {
-              throw new TransactionRevertedError(args.payload);
-            }
-            isSettled = true;
-            await onConfirmation?.(args);
-            break;
-          default:
-            break;
-        }
-      };
-
-      const result = await validateAddress(address);
-      // if address is not valid, or the operation went stale while validating,
-      // don't send the transaction
-      if (!result || !isCurrent()) return;
-
-      try {
-        // callsFn must be defined for AA transactions. If it's not defined, the transaction will be sent to yourself instead of the smart account.
-        if (isAA && callsFn) {
-          const calls = await callsFn();
-          // building calls can take a while, check again before reaching the wallet
-          if (!isCurrent()) return;
-          await sendAACalls(calls, async (props) => {
-            await txStagesCallback(props);
-          });
-        } else {
-          await sendTransaction(txStagesCallback);
-        }
-      } catch (error) {
-        if (!isSettled) throw error;
-        // The SDK emits no ERROR stage for legacy transactions, so report the
-        // settled failure here; swallowing it lets the caller finish as a
-        // success (reset form, track completion) since the tx did complete
-        if (!isFailureReported) {
-          await onFailure?.({
-            stage: TransactionCallbackStage.ERROR,
-            error: toFlowError(error),
-            isAA,
-          });
-        }
-      }
+      return runTxFlow(args, {
+        isAA,
+        address,
+        validateAddress,
+        sendAACalls,
+        txHash,
+        isCurrent: () => operationRef.current === operation,
+      });
     },
     [isAA, sendAACalls, validateAddress, address],
   );

--- a/modules/web3/hooks/tx-flow/use-tx-flow.ts
+++ b/modules/web3/hooks/tx-flow/use-tx-flow.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { Hash } from 'viem';
 import { TransactionCallbackStage } from '@lidofinance/lido-ethereum-sdk/core';
 import { useAddressValidation } from 'providers/address-validation-provider';
@@ -27,6 +27,16 @@ export const useTxFlow = () => {
   // Is used to memoize txHash to keep track of it across stages.
   const txHash = useRef<Hash | undefined>(undefined);
 
+  // Increase counter when operation ended by UI unmount
+  // this invalidates any ongoing operation
+  const operationRef = useRef(0);
+  useEffect(() => {
+    return () => {
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      operationRef.current++;
+    };
+  }, []);
+
   return useCallback(
     async ({
       callsFn,
@@ -40,6 +50,9 @@ export const useTxFlow = () => {
       onFailure,
       onMultisigDone,
     }: TxFlowArgs) => {
+      const operation = ++operationRef.current;
+      const isCurrent = () => operationRef.current === operation;
+
       /**
        * Callback function to handle different stages of the transaction flow.
        * It calls the appropriate callback based on the stage of the transaction.
@@ -47,6 +60,7 @@ export const useTxFlow = () => {
        * @param args - The arguments for the current stage of the transaction.
        */
       const txStagesCallback = async (txArgs: TxCallbackProps) => {
+        if (!isCurrent()) return;
         const args = { ...txArgs, isAA };
         switch (args.stage) {
           case TransactionCallbackStage.SIGN:
@@ -99,12 +113,15 @@ export const useTxFlow = () => {
       };
 
       const result = await validateAddress(address);
-      // if address is not valid, don't send the transaction
-      if (!result) return;
+      // if address is not valid, or the operation went stale while validating,
+      // don't send the transaction
+      if (!result || !isCurrent()) return;
 
       // callsFn must be defined for AA transactions. If it's not defined, the transaction will be sent to yourself instead of the smart account.
       if (isAA && callsFn) {
         const calls = await callsFn();
+        // building calls can take a while, check again before reaching the wallet
+        if (!isCurrent()) return;
         await sendAACalls(calls, async (props) => {
           await txStagesCallback(props);
         });

--- a/modules/web3/hooks/use-contract-address.ts
+++ b/modules/web3/hooks/use-contract-address.ts
@@ -6,7 +6,7 @@ import type {
 } from '@lidofinance/lido-ethereum-sdk/common';
 import { LIDO_L2_CONTRACT_ADDRESSES } from '@lidofinance/lido-ethereum-sdk/common';
 
-import { STRATEGY_CONSTANT } from 'consts/react-query-strategies';
+import { STRATEGY_IMMUTABLE } from 'consts/react-query-strategies';
 import { useLidoSDK, useLidoSDKL2 } from 'modules/web3';
 
 export const useContractAddress = (
@@ -18,7 +18,7 @@ export const useContractAddress = (
   return useQuery<Address | null>({
     queryKey: ['use-contract-address', core.chainId, isL2, contractName],
     enabled: !!core && !!core.chainId,
-    ...STRATEGY_CONSTANT,
+    ...STRATEGY_IMMUTABLE,
     queryFn: () => {
       if (isL2) {
         // LIDO_L2_CONTRACT_ADDRESSES[core.chainId] have only 'wsteth' and 'steth' contract names

--- a/modules/web3/hooks/use-steth-contract-address.ts
+++ b/modules/web3/hooks/use-steth-contract-address.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { STRATEGY_IMMUTABLE } from 'consts/react-query-strategies';
 import { useLidoSDK, useLidoSDKL2 } from 'modules/web3';
 
 export const useStETHContractAddress = () => {
@@ -8,7 +9,7 @@ export const useStETHContractAddress = () => {
   return useQuery({
     queryKey: ['use-steth-contract-address', isL2, l2.steth, stETH],
     enabled: !!(isL2 ? l2.steth : stETH),
-    staleTime: Infinity,
+    ...STRATEGY_IMMUTABLE,
     queryFn: () =>
       isL2 ? l2.steth.contractAddress() : stETH.contractAddress(),
   });

--- a/modules/web3/hooks/use-wsteth-contract-address.ts
+++ b/modules/web3/hooks/use-wsteth-contract-address.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { STRATEGY_IMMUTABLE } from 'consts/react-query-strategies';
 import { useLidoSDK, useLidoSDKL2 } from 'modules/web3';
 
 export const useWstETHContractAddress = () => {
@@ -8,7 +9,7 @@ export const useWstETHContractAddress = () => {
   return useQuery({
     queryKey: ['use-wsteth-contract-address', isL2, l2.wsteth, wstETH],
     enabled: !!(isL2 ? l2.wsteth : wstETH),
-    staleTime: Infinity,
+    ...STRATEGY_IMMUTABLE,
     queryFn: () =>
       isL2 ? l2.wsteth.contractAddress() : wstETH.contractAddress(),
   });

--- a/modules/web3/utils/tx-settled-error.ts
+++ b/modules/web3/utils/tx-settled-error.ts
@@ -1,0 +1,19 @@
+import type { Hash } from 'viem';
+
+/**
+ * Thrown by the tx flow when something fails *after* the transaction settled
+ * on-chain (confirmations read, balance refresh). The transaction itself is
+ * done, so this must never be presented as a failed transaction with a Retry.
+ * Resolved to ErrorMessage.TX_SETTLED_DATA_UNAVAILABLE by `getErrorMessage`.
+ */
+export class TxSettledError extends Error {
+  cause: unknown;
+  txHash?: Hash;
+
+  constructor(cause: unknown, txHash?: Hash) {
+    super('Transaction settled on-chain but a follow-up read failed');
+    this.name = 'TxSettledError';
+    this.cause = cause;
+    this.txHash = txHash;
+  }
+}

--- a/modules/web3/utils/tx-stale-error.ts
+++ b/modules/web3/utils/tx-stale-error.ts
@@ -1,0 +1,10 @@
+/**
+ * Thrown by the tx flow when the UI that started it is gone before the wallet
+ * was reached. Aborts the SDK before it sends the request; never shown.
+ */
+export class TxStaleError extends Error {
+  constructor() {
+    super('Transaction flow abandoned before signing');
+    this.name = 'TxStaleError';
+  }
+}

--- a/providers/external-forbidden-route.tsx
+++ b/providers/external-forbidden-route.tsx
@@ -3,10 +3,7 @@ import { useRouter } from 'next/router';
 
 import { useRouterPath } from 'shared/hooks/use-router-path';
 import { useConfig } from 'config';
-import {
-  ManifestConfigPage,
-  ManifestConfigPages,
-} from 'config/external-config';
+import { isDisabledPath } from 'config/external-config';
 import { HOME_PATH } from 'consts/urls';
 
 import { LayoutEffectSsrDelayed } from 'shared/components/layout-effect-ssr-delayed';
@@ -22,28 +19,18 @@ export const ExternalForbiddenRouteProvider = ({
   const { pages } = useConfig().externalConfig;
 
   const checkPathEffect = useCallback(() => {
-    if (pages) {
-      const paths = Object.keys(pages) as ManifestConfigPage[];
-      const forbiddenPath = paths.find((pathKey) => path.includes(pathKey));
-      if (
-        forbiddenPath &&
-        forbiddenPath !== ManifestConfigPages.Stake &&
-        pages[forbiddenPath]?.shouldDisable
-      ) {
-        setShowContent(false);
-        // Extract dynamic path segment names (e.g. [vault], [action]) to exclude them from query
-        const dynamicParams = new Set(
-          router.pathname.match(/\[(\w+)\]/g)?.map((p) => p.slice(1, -1)) ?? [],
-        );
-        const query = Object.fromEntries(
-          Object.entries(router.query).filter(
-            ([key]) => !dynamicParams.has(key),
-          ),
-        );
-        void router
-          .push({ pathname: HOME_PATH, query })
-          .finally(() => setShowContent(true));
-      }
+    if (pages && isDisabledPath(path, pages)) {
+      setShowContent(false);
+      // Extract dynamic path segment names (e.g. [vault], [action]) to exclude them from query
+      const dynamicParams = new Set(
+        router.pathname.match(/\[(\w+)\]/g)?.map((p) => p.slice(1, -1)) ?? [],
+      );
+      const query = Object.fromEntries(
+        Object.entries(router.query).filter(([key]) => !dynamicParams.has(key)),
+      );
+      void router
+        .push({ pathname: HOME_PATH, query })
+        .finally(() => setShowContent(true));
     }
   }, [pages, path, router]);
 

--- a/providers/modal-provider.tsx
+++ b/providers/modal-provider.tsx
@@ -110,10 +110,14 @@ const ModalProviderRaw = ({ children }: ModalProviderRaw) => {
   );
 
   const closeModal: ModalContextValue['closeModal'] = useCallback((modal) => {
+    // Bind the close to the session that is current now: a modal opened before
+    // the timer fires must not be closed by an action meant for its predecessor
+    const modalSession = modalSessionRef.current;
     // setTimeout helps to get rid of this error:
     // "Can't perform a react state update on an unmounted component"
     // after WalletConnect connection
     setTimeout(() => {
+      if (modalSessionRef.current !== modalSession) return;
       setModalState((prevState) => {
         if (modal && modal !== prevState?.modal) return prevState;
         return null;

--- a/shared/hooks/use-api-address-validation.ts
+++ b/shared/hooks/use-api-address-validation.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { Address } from 'viem';
 import { useQueryClient } from '@tanstack/react-query';
+import { z } from 'zod';
 
 import { API_ROUTES } from 'consts/api';
 import { config } from 'config';
@@ -20,6 +21,8 @@ const getApiUrl = (route: string, params?: Record<string, string>) => {
   return url;
 };
 
+const VALIDATION_RESPONSE_SCHEMA = z.object({ isValid: z.boolean() });
+
 export const useApiAddressValidation = () => {
   const queryClient = useQueryClient();
 
@@ -36,9 +39,10 @@ export const useApiAddressValidation = () => {
             const url = getApiUrl(API_ROUTES.VALIDATION, {
               address: addressToValidate,
             });
-            return await standardFetcher(url, {
-              method: 'GET',
-            });
+            // a malformed response is treated like a failed request (null)
+            return VALIDATION_RESPONSE_SCHEMA.parse(
+              await standardFetcher<unknown>(url, { method: 'GET' }),
+            );
           } catch (error) {
             return null;
           }

--- a/shared/hooks/use-earn-vaults-apr.ts
+++ b/shared/hooks/use-earn-vaults-apr.ts
@@ -1,18 +1,33 @@
 import { useQuery } from '@tanstack/react-query';
+import { z } from 'zod';
 import { STRATEGY_CONSTANT } from 'consts/react-query-strategies';
 import { standardFetcher } from 'utils/standardFetcher';
-import { VaultsAprResponse } from 'pages/api/earn/vaults-apr';
 import { API_ROUTES } from 'consts/api';
+
+// mirrors VaultsAprResponse served by pages/api/earn/vaults-apr
+const VAULTS_APR_RESPONSE_SCHEMA = z.object({
+  data: z.object({ maxValue: z.number() }).catchall(
+    z.union([
+      z.number(),
+      z.object({
+        apr: z.number().optional(),
+        timestamp: z.number().optional(),
+      }),
+    ]),
+  ),
+  meta: z.object({ resTimestamp: z.number() }),
+});
+
+export type VaultsAprResponse = z.infer<typeof VAULTS_APR_RESPONSE_SCHEMA>;
 
 export const useEarnVaultsApr = () => {
   const { data, isLoading } = useQuery<VaultsAprResponse>({
     queryKey: ['earn', 'vaults-apr'],
     ...STRATEGY_CONSTANT,
-    queryFn: async () => {
-      return await standardFetcher<VaultsAprResponse>(
-        API_ROUTES.EARN_VAULTS_APR,
-      );
-    },
+    queryFn: async () =>
+      VAULTS_APR_RESPONSE_SCHEMA.parse(
+        await standardFetcher<unknown>(API_ROUTES.EARN_VAULTS_APR),
+      ),
   });
 
   return {

--- a/shared/hooks/use-earn-vaults-apr.ts
+++ b/shared/hooks/use-earn-vaults-apr.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { STRATEGY_CONSTANT } from 'consts/react-query-strategies';
 import { standardFetcher } from 'utils/standardFetcher';
 import { VaultsAprResponse } from 'pages/api/earn/vaults-apr';
 import { API_ROUTES } from 'consts/api';
@@ -6,6 +7,7 @@ import { API_ROUTES } from 'consts/api';
 export const useEarnVaultsApr = () => {
   const { data, isLoading } = useQuery<VaultsAprResponse>({
     queryKey: ['earn', 'vaults-apr'],
+    ...STRATEGY_CONSTANT,
     queryFn: async () => {
       return await standardFetcher<VaultsAprResponse>(
         API_ROUTES.EARN_VAULTS_APR,

--- a/shared/hooks/use-earn-vaults-tvl.ts
+++ b/shared/hooks/use-earn-vaults-tvl.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { STRATEGY_CONSTANT } from 'consts/react-query-strategies';
 import { standardFetcher } from 'utils/standardFetcher';
 import { VaultsTvlResponse } from 'pages/api/earn/vaults-tvl';
 import { API_ROUTES } from 'consts/api';
@@ -6,6 +7,7 @@ import { API_ROUTES } from 'consts/api';
 export const useEarnVaultsTvl = () => {
   const { data, isLoading } = useQuery<VaultsTvlResponse>({
     queryKey: ['earn', 'vaults-tvl'],
+    ...STRATEGY_CONSTANT,
     queryFn: async () => {
       return await standardFetcher<VaultsTvlResponse>(
         API_ROUTES.EARN_VAULTS_TVL,

--- a/shared/hooks/use-earn-vaults-tvl.ts
+++ b/shared/hooks/use-earn-vaults-tvl.ts
@@ -1,18 +1,25 @@
 import { useQuery } from '@tanstack/react-query';
+import { z } from 'zod';
 import { STRATEGY_CONSTANT } from 'consts/react-query-strategies';
 import { standardFetcher } from 'utils/standardFetcher';
-import { VaultsTvlResponse } from 'pages/api/earn/vaults-tvl';
 import { API_ROUTES } from 'consts/api';
+
+// mirrors VaultsTvlResponse served by pages/api/earn/vaults-tvl
+const VAULTS_TVL_RESPONSE_SCHEMA = z.object({
+  data: z.record(z.string(), z.any()),
+  meta: z.object({ resTimestamp: z.number() }),
+});
+
+export type VaultsTvlResponse = z.infer<typeof VAULTS_TVL_RESPONSE_SCHEMA>;
 
 export const useEarnVaultsTvl = () => {
   const { data, isLoading } = useQuery<VaultsTvlResponse>({
     queryKey: ['earn', 'vaults-tvl'],
     ...STRATEGY_CONSTANT,
-    queryFn: async () => {
-      return await standardFetcher<VaultsTvlResponse>(
-        API_ROUTES.EARN_VAULTS_TVL,
-      );
-    },
+    queryFn: async () =>
+      VAULTS_TVL_RESPONSE_SCHEMA.parse(
+        await standardFetcher<unknown>(API_ROUTES.EARN_VAULTS_TVL),
+      ),
   });
 
   return {

--- a/shared/hooks/use-geo-availability.ts
+++ b/shared/hooks/use-geo-availability.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { z } from 'zod';
 
 import { config, useConfig } from 'config';
 import { API_ROUTES, getApiPath } from 'consts/api';
@@ -11,6 +12,11 @@ import { standardFetcher } from 'utils/standardFetcher';
 // and with no region to trust, the fail-closed default applies: that build
 // renders the limited experience for everyone.
 const CAN_RESOLVE_REGION = !config.ipfsMode;
+
+const GEO_RESPONSE_SCHEMA = z.object({
+  country: z.string().nullable(),
+  availability: z.enum([GEO_AVAILABILITY.full, GEO_AVAILABILITY.limited]),
+});
 
 const QA_COUNTRY_KEY = 'mock-qa-helpers-geo-country';
 
@@ -90,7 +96,9 @@ export const useGeoAvailability = (): UseGeoAvailabilityResult => {
         return { country: null, availability: GEO_AVAILABILITY.limited };
       }
 
-      return standardFetcher<GeoResponse>(getApiPath(API_ROUTES.GEO));
+      return GEO_RESPONSE_SCHEMA.parse(
+        await standardFetcher<unknown>(getApiPath(API_ROUTES.GEO)),
+      );
     },
   });
 

--- a/shared/hooks/use-token-address.ts
+++ b/shared/hooks/use-token-address.ts
@@ -9,7 +9,7 @@ import {
 import { LidoSDKCore } from '@lidofinance/lido-ethereum-sdk/core';
 import { useQuery } from '@tanstack/react-query';
 
-import { STRATEGY_CONSTANT } from 'consts/react-query-strategies';
+import { STRATEGY_IMMUTABLE } from 'consts/react-query-strategies';
 import { useDappStatus, useLidoSDK, useLidoSDKL2 } from 'modules/web3';
 
 const fetchTokenAddress = async (
@@ -42,7 +42,7 @@ export const useTokenAddress = (token: string): Address | undefined => {
   const { data: address } = useQuery({
     queryKey: ['tokenAddress', token, core, chainId, isL2],
     enabled: !!token,
-    ...STRATEGY_CONSTANT,
+    ...STRATEGY_IMMUTABLE,
     queryFn: () => fetchTokenAddress(token, core, chainId, isL2),
   });
 

--- a/shared/hooks/useDVstEthApr.ts
+++ b/shared/hooks/useDVstEthApr.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import invariant from 'tiny-invariant';
-import { STRATEGY_LAZY } from 'consts/react-query-strategies';
+import { STRATEGY_CONSTANT } from 'consts/react-query-strategies';
 import { standardFetcher } from 'utils/standardFetcher';
 
 type VaultDataPartial = {
@@ -14,7 +14,7 @@ const API_ENDPOINT = 'https://api.mellow.finance/v1/vaults';
 export const useDVstEthApr = () => {
   const result = useQuery<RequestResponseData, Error, string>({
     queryKey: ['dvsteth-apr'],
-    ...STRATEGY_LAZY,
+    ...STRATEGY_CONSTANT,
     queryFn: async () => {
       return await standardFetcher<RequestResponseData>(API_ENDPOINT);
     },

--- a/shared/hooks/useDVstEthApr.ts
+++ b/shared/hooks/useDVstEthApr.ts
@@ -1,30 +1,27 @@
 import { useQuery } from '@tanstack/react-query';
 import invariant from 'tiny-invariant';
+import { z } from 'zod';
 import { STRATEGY_CONSTANT } from 'consts/react-query-strategies';
 import { standardFetcher } from 'utils/standardFetcher';
+import { APY_SCHEMA } from 'utils/zod';
 
-type VaultDataPartial = {
-  id: string;
-  apr: number;
-};
-type RequestResponseData = Array<VaultDataPartial>;
+// Only the vault we read is validated: other vaults in the list may be broken
+const MELLOW_VAULTS_SCHEMA = z.array(z.looseObject({ id: z.string() }));
 
 const API_ENDPOINT = 'https://api.mellow.finance/v1/vaults';
 
 export const useDVstEthApr = () => {
-  const result = useQuery<RequestResponseData, Error, string>({
+  const result = useQuery({
     queryKey: ['dvsteth-apr'],
     ...STRATEGY_CONSTANT,
     queryFn: async () => {
-      return await standardFetcher<RequestResponseData>(API_ENDPOINT);
-    },
-    select: (data) => {
-      invariant(data, '[useDVstEthApr] Failed to fetch API');
-
-      const vaultData = data.find((vault) => vault.id === 'ethereum-dvsteth');
+      const vaults = MELLOW_VAULTS_SCHEMA.parse(
+        await standardFetcher<unknown>(API_ENDPOINT),
+      );
+      const vaultData = vaults.find((vault) => vault.id === 'ethereum-dvsteth');
       invariant(vaultData, '[useDVstEthApr] invalid API response');
 
-      return vaultData.apr.toFixed(1);
+      return APY_SCHEMA.parse(vaultData.apr).toFixed(1);
     },
   });
 

--- a/shared/hooks/useLidoApr.ts
+++ b/shared/hooks/useLidoApr.ts
@@ -1,6 +1,6 @@
 import invariant from 'tiny-invariant';
+import { z } from 'zod';
 
-import { CHAINS } from '@lidofinance/lido-ethereum-sdk/common';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
 import { ETH_API_ROUTES, getEthApiPath } from 'consts/api';
@@ -8,19 +8,17 @@ import { STRATEGY_CONSTANT } from 'consts/react-query-strategies';
 import { standardFetcher } from 'utils/standardFetcher';
 import { useLidoSDK } from 'modules/web3';
 
-type APR_RECORD = { timeUnix: number; apr: number };
+const SMA_APR_RESPONSE_SCHEMA = z.object({
+  data: z.object({
+    smaApr: z.number(),
+    aprs: z
+      .array(z.object({ timeUnix: z.number(), apr: z.number() }))
+      .optional(),
+  }),
+  meta: z.looseObject({}).optional(),
+});
 
-type SMA_APR_RESPONSE = {
-  data: {
-    smaApr: number;
-    aprs?: APR_RECORD[];
-  };
-  meta?: {
-    symbol: 'stETH';
-    address: string;
-    chainId: CHAINS;
-  };
-};
+type SMA_APR_RESPONSE = z.infer<typeof SMA_APR_RESPONSE_SCHEMA>;
 
 type UseLidoAprResult = UseQueryResult<SMA_APR_RESPONSE> & {
   apr?: string;
@@ -36,7 +34,10 @@ export const useLidoApr = (): UseLidoAprResult => {
     queryFn: async () => {
       try {
         invariant(url, 'Missing URL for fetching the SMA APR');
-        return await standardFetcher<SMA_APR_RESPONSE>(url);
+        // a malformed response falls through to the SDK like a failed request
+        return SMA_APR_RESPONSE_SCHEMA.parse(
+          await standardFetcher<unknown>(url),
+        );
       } catch (error) {
         // Fallback from SDK
         const lastApr = await statistics.apr.getSmaApr({ days: 7 });

--- a/shared/hooks/useLidoApr.ts
+++ b/shared/hooks/useLidoApr.ts
@@ -4,7 +4,7 @@ import { CHAINS } from '@lidofinance/lido-ethereum-sdk/common';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
 import { ETH_API_ROUTES, getEthApiPath } from 'consts/api';
-import { STRATEGY_LAZY } from 'consts/react-query-strategies';
+import { STRATEGY_CONSTANT } from 'consts/react-query-strategies';
 import { standardFetcher } from 'utils/standardFetcher';
 import { useLidoSDK } from 'modules/web3';
 
@@ -32,7 +32,7 @@ export const useLidoApr = (): UseLidoAprResult => {
 
   const result = useQuery<SMA_APR_RESPONSE>({
     queryKey: ['lido-apr', url],
-    ...STRATEGY_LAZY,
+    ...STRATEGY_CONSTANT,
     queryFn: async () => {
       try {
         invariant(url, 'Missing URL for fetching the SMA APR');

--- a/shared/hooks/useLidoStats.ts
+++ b/shared/hooks/useLidoStats.ts
@@ -4,7 +4,7 @@ import { LOCALE } from 'config/groups/locale';
 
 import { ETH_API_ROUTES, getEthApiPath } from 'consts/api';
 import { DATA_UNAVAILABLE } from 'consts/text';
-import { STRATEGY_LAZY } from 'consts/react-query-strategies';
+import { STRATEGY_CONSTANT } from 'consts/react-query-strategies';
 import { standardFetcher } from 'utils/standardFetcher';
 
 type RequestResponseData = {
@@ -48,6 +48,6 @@ export const useLidoStats = (): {
           : DATA_UNAVAILABLE,
       };
     },
-    ...STRATEGY_LAZY,
+    ...STRATEGY_CONSTANT,
   });
 };

--- a/shared/hooks/useLidoStats.ts
+++ b/shared/hooks/useLidoStats.ts
@@ -1,4 +1,5 @@
 import invariant from 'tiny-invariant';
+import { z } from 'zod';
 import { useQuery } from '@tanstack/react-query';
 import { LOCALE } from 'config/groups/locale';
 
@@ -7,12 +8,14 @@ import { DATA_UNAVAILABLE } from 'consts/text';
 import { STRATEGY_CONSTANT } from 'consts/react-query-strategies';
 import { standardFetcher } from 'utils/standardFetcher';
 
-type RequestResponseData = {
-  uniqueAnytimeHolders: string;
-  uniqueHolders: string;
-  totalStaked: string;
-  marketCap: number;
-};
+// fields are optional: `select` shows DATA_UNAVAILABLE for whatever is missing
+const LIDO_STATS_SCHEMA = z.object({
+  uniqueAnytimeHolders: z.string().optional(),
+  totalStaked: z.string().optional(),
+  marketCap: z.number().optional(),
+});
+
+type RequestResponseData = z.infer<typeof LIDO_STATS_SCHEMA>;
 
 type QueryResponseData = {
   totalStaked: string;
@@ -29,9 +32,9 @@ export const useLidoStats = (): {
   return useQuery<RequestResponseData, Error, QueryResponseData>({
     queryKey: ['lido-stats', url],
     enabled: !!url,
-    queryFn: () => {
+    queryFn: async () => {
       invariant(url, 'Missing URL for LidoStats request');
-      return standardFetcher<RequestResponseData>(url);
+      return LIDO_STATS_SCHEMA.parse(await standardFetcher<unknown>(url));
     },
     select: (rawData) => {
       invariant(rawData, 'Failed to fetch LidoStats');

--- a/shared/transaction-modal/hooks/use-transaction-modal-stage.tsx
+++ b/shared/transaction-modal/hooks/use-transaction-modal-stage.tsx
@@ -16,6 +16,9 @@ export const useTransactionModalStage = <S extends Record<string, Function>>(
   const { openModal } = useTransactionModal();
   const { closeModal } = useModalActions();
   const isMountedRef = useRef(true);
+  // Close handle of the session this hook opened last, so the flow's modal
+  // goes away together with the UI part that started the flow
+  const closeSessionRef = useRef<(() => void) | null>(null);
 
   const txModalStages = useMemo(() => {
     const transitStage: TransactionModalTransitStage = (
@@ -23,10 +26,10 @@ export const useTransactionModalStage = <S extends Record<string, Function>>(
       modalProps = {},
     ) => {
       if (!isMountedRef.current) return;
-      openModal({
+      closeSessionRef.current = openModal({
         children: TxStageEl,
         ...modalProps,
-      });
+      }).closeModal;
     };
 
     return getStages(transitStage);
@@ -35,6 +38,7 @@ export const useTransactionModalStage = <S extends Record<string, Function>>(
   useEffect(() => {
     return () => {
       isMountedRef.current = false;
+      closeSessionRef.current?.();
     };
   }, []);
 

--- a/shared/transaction-modal/transaction-modal-content.tsx
+++ b/shared/transaction-modal/transaction-modal-content.tsx
@@ -14,6 +14,7 @@ export const Wrap = styled.div`
 
 export const Title = styled(Text).attrs({
   size: 'sm',
+  forwardedAs: 'div',
 })`
   margin-top: ${({ theme }) => theme.spaceMap.xxl}px;
   font-weight: 800;

--- a/shared/transaction-modal/tx-stages-basic/tx-stage-fail.tsx
+++ b/shared/transaction-modal/tx-stages-basic/tx-stage-fail.tsx
@@ -3,7 +3,7 @@ import { ErrorMessage } from 'utils';
 
 import { Loader } from '@lidofinance/lido-ui';
 import { TransactionModalContent } from 'shared/transaction-modal/transaction-modal-content';
-import { StageIconFail } from './icons';
+import { StageIconFail, StageIconSuccess } from './icons';
 import { ModalFooterButton, LoaderWrapper } from './styles';
 
 type TxStageFailProps = {
@@ -25,13 +25,20 @@ export const TxStageFail = ({
     },
     [onRetry],
   );
+  // The transaction itself went through, only a follow-up read failed:
+  // retrying would submit it again
+  const isSettled = failedText === ErrorMessage.TX_SETTLED_DATA_UNAVAILABLE;
+
   return (
     <TransactionModalContent
-      title="Transaction Failed"
-      icon={<StageIconFail showLedger={false} />}
+      title={isSettled ? 'Transaction completed' : 'Transaction Failed'}
+      icon={
+        isSettled ? <StageIconSuccess /> : <StageIconFail showLedger={false} />
+      }
       description={failedText ?? 'Something went wrong'}
       footer={footer}
       footerHint={
+        !isSettled &&
         failedText !== ErrorMessage.NOT_ENOUGH_ETHER &&
         onRetry &&
         (!isLoading ? (

--- a/shared/transaction-modal/tx-stages-composed/tx-stage-operation-succeed-balance-shown.tsx
+++ b/shared/transaction-modal/tx-stages-composed/tx-stage-operation-succeed-balance-shown.tsx
@@ -18,7 +18,7 @@ export const SkeletonBalance = styled(InlineLoader).attrs({
   width: 100px;
 `;
 
-export const BalanceContainer = styled('div')`
+export const BalanceContainer = styled.span`
   display: inline-block;
   white-space: nowrap;
 `;

--- a/utils/__tests__/tx-settled-error.test.ts
+++ b/utils/__tests__/tx-settled-error.test.ts
@@ -1,0 +1,19 @@
+import { ErrorMessage, getErrorMessage } from 'utils/getErrorMessage';
+import { TxSettledError } from 'modules/web3/utils/tx-settled-error';
+
+// Post-settlement failures: the wrapped RPC error must not leak its own
+// classification (e.g. a provider code) through to the user
+describe('TxSettledError', () => {
+  it('always resolves to the settled message, whatever the cause', () => {
+    const causes = [
+      new Error('timeout'),
+      { code: -32603, message: 'Internal JSON-RPC error' },
+      { code: 4001, message: 'User rejected the request' },
+    ];
+    for (const cause of causes) {
+      expect(getErrorMessage(new TxSettledError(cause, '0xabc'))).toBe(
+        ErrorMessage.TX_SETTLED_DATA_UNAVAILABLE,
+      );
+    }
+  });
+});

--- a/utils/check-rpc-url.ts
+++ b/utils/check-rpc-url.ts
@@ -6,7 +6,12 @@ import {
   decodeFunctionResult,
 } from 'viem';
 import type { Address } from 'viem';
-import { CHAINS } from '@lidofinance/lido-ethereum-sdk/common';
+import {
+  CHAINS,
+  LIDO_L2_CONTRACT_ADDRESSES,
+  LIDO_L2_CONTRACT_NAMES,
+} from '@lidofinance/lido-ethereum-sdk/common';
+import { getContractAddress } from 'config/networks/contract-address';
 
 import { isUrl } from './is-url';
 
@@ -28,6 +33,11 @@ const abi = [
     type: 'function',
   },
 ];
+
+/** stETH address on the chain: the contract `checkRpcUrl` reads to prove the RPC serves it */
+export const getRpcCheckAddress = (chainId: CHAINS) =>
+  getContractAddress(chainId, 'lido') ??
+  LIDO_L2_CONTRACT_ADDRESSES[chainId]?.[LIDO_L2_CONTRACT_NAMES.steth];
 
 export const checkRpcUrl = async (
   rpcUrl: string,

--- a/utils/get-one-inch-rate.ts
+++ b/utils/get-one-inch-rate.ts
@@ -1,9 +1,16 @@
 import invariant from 'tiny-invariant';
+import { z } from 'zod';
 
 import { ETH_API_ROUTES, getEthApiPath } from 'consts/api';
 import { LIDO_TOKENS_VALUES } from 'consts/tokens';
 
 import { standardFetcher } from './standardFetcher';
+import { BIGINT_STRING_SCHEMA } from './zod';
+
+const ONE_INCH_RATE_SCHEMA = z.object({
+  rate: z.number(),
+  toReceive: BIGINT_STRING_SCHEMA,
+});
 
 type GetOneInchRateParams = {
   token: LIDO_TOKENS_VALUES;
@@ -19,11 +26,7 @@ export const getOneInchRate = async (params: GetOneInchRateParams) => {
 
   invariant(url, 'Missing URL for OneInch rate request');
 
-  const data = await standardFetcher<{
-    rate: number;
-    toReceive: string;
-    fromAmount: string;
-  }>(url);
+  const data = ONE_INCH_RATE_SCHEMA.parse(await standardFetcher<unknown>(url));
 
   return {
     rate: data.rate,

--- a/utils/get-open-ocean-rate.ts
+++ b/utils/get-open-ocean-rate.ts
@@ -1,41 +1,28 @@
 import { formatEther } from 'viem';
+import { z } from 'zod';
 import { CHAINS } from '@lidofinance/lido-ethereum-sdk/common';
 
 import { getTokenAddress } from 'config/networks/token-address';
 import { standardFetcher } from './standardFetcher';
+import { BIGINT_STRING_SCHEMA } from './zod';
 import {
   calculateRateReceive,
   RateCalculationResult,
 } from './calculate-rate-to-receive';
 import { type Token, type TokenSymbol } from 'consts/tokens';
 
-type OpenOceanGetGasPartial = {
-  without_decimals: {
-    standard: {
-      maxFeePerGas: string;
-      legacyGasPrice: string;
-    };
-  };
-};
+const OPEN_OCEAN_GAS_SCHEMA = z.object({
+  without_decimals: z.object({
+    standard: z.object({ maxFeePerGas: z.string() }),
+  }),
+});
 
-type OpenOceanGetQuotePartial = {
-  data: {
-    inToken: {
-      symbol: string;
-      name: string;
-      address: string;
-      decimals: number;
-    };
-    outToken: {
-      symbol: string;
-      name: string;
-      address: string;
-      decimals: number;
-    };
-    inAmount: string;
-    outAmount: string;
-  };
-};
+const OPEN_OCEAN_QUOTE_SCHEMA = z.object({
+  data: z.object({
+    inAmount: BIGINT_STRING_SCHEMA,
+    outAmount: BIGINT_STRING_SCHEMA,
+  }),
+});
 
 export const getOpenOceanRate = async (
   amount: bigint,
@@ -43,8 +30,8 @@ export const getOpenOceanRate = async (
   toToken: Token | TokenSymbol,
 ): Promise<RateCalculationResult> => {
   const basePath = 'https://open-api.openocean.finance/v3/1';
-  const gasData = await standardFetcher<OpenOceanGetGasPartial>(
-    `${basePath}/gasPrice`,
+  const gasData = OPEN_OCEAN_GAS_SCHEMA.parse(
+    await standardFetcher<unknown>(`${basePath}/gasPrice`),
   );
 
   const params = new URLSearchParams({
@@ -54,8 +41,8 @@ export const getOpenOceanRate = async (
     amount: formatEther(amount),
   });
 
-  const quote = await standardFetcher<OpenOceanGetQuotePartial>(
-    `${basePath}/quote?${params.toString()}`,
+  const quote = OPEN_OCEAN_QUOTE_SCHEMA.parse(
+    await standardFetcher<unknown>(`${basePath}/quote?${params.toString()}`),
   );
 
   return calculateRateReceive(

--- a/utils/getErrorMessage.ts
+++ b/utils/getErrorMessage.ts
@@ -1,4 +1,5 @@
 import { SendCallsError } from 'modules/web3';
+import { TxSettledError } from 'modules/web3/utils/tx-settled-error';
 import { UnknownBundleIdError, UserRejectedRequestError } from 'viem';
 import { trackMatomoEvent } from 'utils/track-matomo-event';
 import debounce from 'lodash/debounce';
@@ -20,6 +21,7 @@ export enum ErrorMessage {
   SITE_BLOCKED = 'Your wallet has temporarily blocked requests from this site.\nUnblock this site in your wallet or try again later.',
   PROVIDER_DISCONNECTED = 'Your wallet is disconnected.\nReconnect your wallet and try again.',
   CHAIN_DISCONNECTED = 'Your wallet is not connected to the selected network.\nSwitch to the selected network in your wallet and try again.',
+  TX_SETTLED_DATA_UNAVAILABLE = 'Your transaction was completed, but the updated data could not be loaded. Refresh the page to see the latest state.',
 }
 
 export const getError = (error: unknown): ErrorMessage | string => {
@@ -181,6 +183,10 @@ const describeCauseChain = (
 
 // extracts message from Errors made by us
 const extractHumaneMessage = (error: unknown) => {
+  // Checked first: the wrapped cause may carry a provider code of its own
+  if (error instanceof TxSettledError) {
+    return ErrorMessage.TX_SETTLED_DATA_UNAVAILABLE;
+  }
   if (error instanceof SendCallsError) {
     return error.message;
   }
@@ -326,6 +332,8 @@ const ERROR_TO_MATOMO_MAP: Record<ErrorMessage, MATOMO_ERROR_EVENTS_TYPES> = {
     MATOMO_ERROR_EVENTS_TYPES.PROVIDER_DISCONNECTED,
   [ErrorMessage.CHAIN_DISCONNECTED]:
     MATOMO_ERROR_EVENTS_TYPES.CHAIN_DISCONNECTED,
+  [ErrorMessage.TX_SETTLED_DATA_UNAVAILABLE]:
+    MATOMO_ERROR_EVENTS_TYPES.TX_SETTLED_DATA_UNAVAILABLE,
 };
 
 const trackErrorDebounced = debounce((errorMessage: string) => {

--- a/utils/getErrorMessage.ts
+++ b/utils/getErrorMessage.ts
@@ -1,5 +1,6 @@
 import { SendCallsError } from 'modules/web3';
 import { TxSettledError } from 'modules/web3/utils/tx-settled-error';
+import { TxStaleError } from 'modules/web3/utils/tx-stale-error';
 import { UnknownBundleIdError, UserRejectedRequestError } from 'viem';
 import { trackMatomoEvent } from 'utils/track-matomo-event';
 import debounce from 'lodash/debounce';
@@ -76,6 +77,8 @@ export const getError = (error: unknown): ErrorMessage | string => {
 };
 
 export const getErrorMessage = (error: unknown): ErrorMessage | string => {
+  // the UI that would show this is gone; nothing to log or track
+  if (error instanceof TxStaleError) return ErrorMessage.SOMETHING_WRONG;
   try {
     console.error('TX_ERROR:', {
       error,

--- a/utils/zod.test.ts
+++ b/utils/zod.test.ts
@@ -1,0 +1,46 @@
+import { getAddress } from 'viem';
+
+import {
+  ADDRESS_SCHEMA,
+  BIGINT_STRING_SCHEMA,
+  DECIMAL_STRING_SCHEMA,
+  decimalToUnitsSchema,
+} from './zod';
+
+const LOWER = '0xae7ab96520de3a18e5e111b5eaab095312d7fe84';
+
+describe('ADDRESS_SCHEMA', () => {
+  it('accepts any valid casing and returns the checksummed address', () => {
+    expect(ADDRESS_SCHEMA.parse(LOWER)).toBe(getAddress(LOWER));
+  });
+  it.each(['0x12', 'not-an-address', 42])('rejects %p', (value) => {
+    expect(ADDRESS_SCHEMA.safeParse(value).success).toBe(false);
+  });
+});
+
+describe('BIGINT_STRING_SCHEMA', () => {
+  it.each(['0', '1000000000000000000000000'])('accepts %p', (value) => {
+    expect(BIGINT_STRING_SCHEMA.safeParse(value).success).toBe(true);
+  });
+  it.each(['-1', '1.5', '1e21', 'abc', ''])('rejects %p', (value) => {
+    expect(BIGINT_STRING_SCHEMA.safeParse(value).success).toBe(false);
+  });
+});
+
+describe('decimal schemas', () => {
+  it.each(['0', '1', '123.456789', '999999999999999999999.999'])(
+    'accept %p',
+    (value) => {
+      expect(DECIMAL_STRING_SCHEMA.safeParse(value).success).toBe(true);
+      expect(decimalToUnitsSchema(18).safeParse(value).success).toBe(true);
+    },
+  );
+  it.each(['NaN', '1e21', '-1', 'abc', 'Infinity'])('reject %p', (value) => {
+    expect(DECIMAL_STRING_SCHEMA.safeParse(value).success).toBe(false);
+    expect(decimalToUnitsSchema(18).safeParse(value).success).toBe(false);
+  });
+  it('converts to base units at the given decimals', () => {
+    expect(decimalToUnitsSchema(6).parse('1.5')).toBe(1_500_000n);
+    expect(decimalToUnitsSchema(6).parse(2)).toBe(2_000_000n);
+  });
+});

--- a/utils/zod.ts
+++ b/utils/zod.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { getAddress, isAddress, parseUnits } from 'viem';
+import { getAddress, isAddress, isHash, parseUnits, type Hash } from 'viem';
 
 // Unix timestamp validator (seconds, valid until year 2286)
 export const UNIX_TIMESTAMP_SCHEMA = z.coerce
@@ -30,6 +30,12 @@ export const ADDRESS_SCHEMA = z
     message: 'Invalid Ethereum address',
   })
   .transform((value) => getAddress(value));
+
+// 32-byte hash, e.g. a transaction hash
+export const HASH_SCHEMA = z
+  .string()
+  .refine((value) => isHash(value), { message: 'Invalid hash' })
+  .transform((value) => value as Hash);
 
 // Unsigned integer string, e.g. a token amount in base units. Kept as string.
 // Digits only: `BigInt()` would also accept '', whitespace and hex

--- a/utils/zod.ts
+++ b/utils/zod.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { getAddress, isAddress, parseUnits } from 'viem';
 
 // Unix timestamp validator (seconds, valid until year 2286)
 export const UNIX_TIMESTAMP_SCHEMA = z.coerce
@@ -16,3 +17,61 @@ export const APY_SCHEMA = NUMERIC_SCHEMA;
 
 // Percentage validator (0 to 100), not suitable for APY which can be <0 and >100
 export const PERCENT_SCHEMA = z.number().min(0).max(100);
+
+// ---------------------------------------------------------------------------
+// Ethereum primitives, validated with viem so API strings can be trusted by
+// the same code that later feeds them to viem
+// ---------------------------------------------------------------------------
+
+// Ethereum address, checksummed on output
+export const ADDRESS_SCHEMA = z
+  .string()
+  .refine((value) => isAddress(value, { strict: false }), {
+    message: 'Invalid Ethereum address',
+  })
+  .transform((value) => getAddress(value));
+
+// Unsigned integer string, e.g. a token amount in base units. Kept as string.
+// Digits only: `BigInt()` would also accept '', whitespace and hex
+export const BIGINT_STRING_SCHEMA = z
+  .string()
+  .regex(/^\d+$/u, { message: 'Expected an unsigned integer string' });
+
+// ERC-20 decimals
+export const TOKEN_DECIMALS_SCHEMA = z.number().int().min(0).max(255);
+
+const toUnits = (value: string, decimals: number) => {
+  try {
+    const units = parseUnits(value, decimals);
+    return units >= 0n ? units : null;
+  } catch {
+    return null;
+  }
+};
+
+// Non-negative decimal string that `parseUnits` accepts: rejects NaN, exponent
+// notation and negatives. Kept as string for callers that parse it themselves
+export const DECIMAL_STRING_SCHEMA = z
+  .string()
+  .refine((value) => toUnits(value, 18) !== null, {
+    message: 'Expected a non-negative decimal string',
+  });
+
+// Same input, converted to base units so no `Number` round trip is needed.
+// Numbers are accepted and stringified first; 1e21+ turns into exponent
+// notation and is rejected like any other unparseable value
+export const decimalToUnitsSchema = (decimals: number) =>
+  z
+    .union([z.string(), z.number()])
+    .pipe(z.coerce.string())
+    .transform((value, ctx) => {
+      const units = toUnits(value, decimals);
+      if (units === null) {
+        ctx.addIssue({
+          code: 'custom',
+          message: 'Expected a non-negative decimal value',
+        });
+        return z.NEVER;
+      }
+      return units;
+    });

--- a/utilsApi/__tests__/collect-request-address-metric-known-contract.test.ts
+++ b/utilsApi/__tests__/collect-request-address-metric-known-contract.test.ts
@@ -1,0 +1,87 @@
+import { CHAINS } from '@lidofinance/lido-ethereum-sdk/common';
+import { toFunctionSelector } from 'viem';
+
+// One recognized contract with a one-function ABI. Mocked so the test does not
+// pull in `config/` through the real metrics map.
+const KNOWN_TO = '0x0000000000000000000000000000000000000002';
+const ABI = [
+  {
+    type: 'function',
+    name: 'balanceOf',
+    stateMutability: 'view',
+    inputs: [{ name: 'account', type: 'address' }],
+    outputs: [{ name: '', type: 'uint256' }],
+  },
+] as const;
+
+vi.mock('../contractAddressesMetricsMap', () => ({
+  METRIC_CONTRACT_ADDRESSES: {
+    [1]: { '0x0000000000000000000000000000000000000002': 'testContract' },
+  },
+  getMetricContractAbi: () => ABI,
+}));
+
+import { collectRequestAddressMetric } from '../collect-request-address-metric';
+
+const makeEthCall = (data: string) => ({
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'eth_call',
+  params: [{ to: KNOWN_TO, data }, 'latest'],
+});
+
+const makeCounterMock = () => {
+  const recorded: Record<string, string>[] = [];
+  const counter: any = {
+    labels: (labels: Record<string, string>) => ({
+      inc: () => recorded.push(labels),
+    }),
+  };
+  return { counter, recorded };
+};
+
+// RPC-METRIC-ATTRIBUTION-01: a recognized address must not let arbitrary
+// selectors create unbounded label series
+describe('collectRequestAddressMetric on a recognized contract', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('keeps the raw selector when it decodes against the ABI', async () => {
+    const selector = toFunctionSelector(ABI[0]);
+    const { counter, recorded } = makeCounterMock();
+    await collectRequestAddressMetric({
+      calls: [makeEthCall(selector)],
+      chainId: CHAINS.Mainnet,
+      metrics: counter,
+    });
+    expect(recorded[0]).toMatchObject({
+      address: KNOWN_TO,
+      contractName: 'testContract',
+      methodEncoded: selector,
+      methodDecoded: 'balanceOf',
+    });
+  });
+
+  it('collapses every unknown selector into a single series', async () => {
+    const { counter, recorded } = makeCounterMock();
+    const calls = Array.from({ length: 1000 }, (_, i) =>
+      makeEthCall(`0x${i.toString(16).padStart(8, '0')}`),
+    );
+    await collectRequestAddressMetric({
+      calls,
+      chainId: CHAINS.Mainnet,
+      metrics: counter,
+    });
+    const series = new Set(recorded.map((labels) => JSON.stringify(labels)));
+    expect(recorded.length).toBe(1000);
+    expect(series.size).toBe(1);
+    expect(recorded[0]).toMatchObject({
+      address: KNOWN_TO,
+      contractName: 'testContract',
+      methodEncoded: 'unknown',
+      methodDecoded: 'unknown',
+    });
+  });
+});

--- a/utilsApi/collect-request-address-metric.ts
+++ b/utilsApi/collect-request-address-metric.ts
@@ -24,9 +24,10 @@ const shortError = (error: unknown) => {
 
 /**
  * Increments the eth_call Counter per batch entry. Labels bounded:
- * `address` / `methodEncoded` are kept raw only for allow-listed contracts;
- * for unknown contracts both collapse to `UNKNOWN_LABEL` so prom-client's
- * in-memory label store stays bounded regardless of incoming traffic shape.
+ * `address` is kept raw only for allow-listed contracts and `methodEncoded`
+ * only for selectors found in that contract's ABI; everything else collapses
+ * to `UNKNOWN_LABEL` so prom-client's in-memory label store stays bounded
+ * regardless of incoming traffic shape.
  *
  * Per-call try/catch isolates each entry: a malformed call cannot drop
  * metrics for siblings in the same batch.
@@ -74,14 +75,17 @@ export const collectRequestAddressMetric = async ({
         }
       }
 
+      // Keep the raw selector only when it decoded against the ABI. Any other
+      // selector collapses to `unknown`, otherwise arbitrary 4-byte values sent
+      // to a known contract would each allocate a new label series forever
+      const isKnownMethod = methodDecoded !== UNKNOWN_LABEL;
+
       metrics
         .labels({
           address: contractName ? address : UNKNOWN_LABEL,
           contractName: contractName || UNKNOWN_LABEL,
-          methodEncoded: contractName
-            ? methodEncoded || UNKNOWN_LABEL
-            : UNKNOWN_LABEL,
-          methodDecoded: methodDecoded || UNKNOWN_LABEL,
+          methodEncoded: isKnownMethod ? methodEncoded : UNKNOWN_LABEL,
+          methodDecoded,
         })
         .inc(1);
     } catch (error) {


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

A batch of bug fixes across the widget.

**Transaction flow**

- A transaction that settled on-chain but hit a failed follow-up read (confirmations, balance refresh) was shown as "Transaction Failed" with a Retry button. It now shows as completed with a note that data could not be refreshed, and never offers a retry that would resubmit.
- Closing or navigating away from a form while a transaction was being prepared could still hand the call to the wallet. The flow now cancels when its UI unmounts.
- Withdrawal request errors were only handled in one branch; the failed stage is now reported consistently for both the permit and approve paths.
- A transaction modal opened after an earlier one's close timer fired could be closed by mistake. Close actions are now bound to the modal session they belong to.

**Earn**

- Instant withdrawal routing checked only daily limit and liquidity. It now also honors the Collector's own verdict and rejects zero-asset quotes, so a paused sync queue can no longer be selected.
- The asset upgrade block is hidden while deposits are paused, matching the deposit form.

**DEX withdrawals**

- The CoW Swap trade guard now blocks orders whose minimum receive amount falls below the allowed slippage relative to the quoted buy amount.

**Data freshness and config**

- Default query staleness reduced from 5 to 2 minutes with periodic refetch, and the remote manifest now polls so page or vault disables reach open tabs without a reload.
- Page-disable checks no longer special-case the stake path; disable logic is shared and unit-tested.
- Custom RPC URL saves are chain-scoped, so saving two chains quickly no longer overwrites one with the other.
- The RPC health check reads the stETH contract for the selected chain, including L2s.

**Third-party APIs**

- Responses from 1inch, OpenOcean, Mellow points, GGV withdrawals, rewards backend, NFT metadata, and address validation are now validated with zod before use. Shared schemas for addresses, hashes, and integer strings were added.
- Wrap form: L2 now normalizes the token to stETH on initial connect, not only on connection change.
- Metrics: unknown 4-byte selectors sent to known contracts no longer create unbounded label series.

### Demo

<!--- If thee are visual changes, attach a link to a specific section on preview stand / add screenshots / record a [loom](https://www.loom.com/). -->

### Code review notes

<!--- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

<!--- List all possible edge cases and how to test them. -->

### Checklist:

- [ ] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
